### PR TITLE
Generic mapping from generic SwiftMetatype now works

### DIFF
--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftNominalTypeDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftNominalTypeDescriptor.cs
@@ -177,7 +177,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			// returns the offset to generic arguments in the SwiftMetatype object
 			switch (GetKind ()) {
 			case NominalTypeDescriptorKind.Class:
-				return GetClassGenericOffset ();
+				return GetClassGenericOffsetInWords () * IntPtr.Size;
 			case NominalTypeDescriptorKind.Enum:
 			case NominalTypeDescriptorKind.Struct:
 				return SwiftMetatype.ValueBaseSize;
@@ -208,6 +208,14 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return (GenericHeader)Marshal.PtrToStructure (headerPtr, typeof (GenericHeader));
 		}
 
+		public int GetParameterCount ()
+		{
+			if (!IsGeneric ())
+				return 0;
+			var header = GetGenericHeader ();
+			return header.ParameterCount;
+		}
+
 		public int GetTotalGenericArgumentCount ()
 		{
 			if (!IsGeneric ())
@@ -232,11 +240,11 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return header.ExtraArgumentCount;
 		}
 
-		int GetClassGenericOffset ()
+		int GetClassGenericOffsetInWords () // returns in machine words
 		{
 			if (!HasResilientSuperClass ())
-				return NonResilientImmediateMembersOffset ();
-			return ResilientImmediateMembersOffset ();
+				return NonResilientImmediateMembersOffsetInWords ();
+			return ResilientImmediateMembersOffsetInWords ();
 		}
 
 		int MetadataNegativeSizeInWords {
@@ -268,7 +276,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			}
 		}
 
-		int NonResilientImmediateMembersOffset ()
+		int NonResilientImmediateMembersOffsetInWords ()
 		{
 			return ImmediateMembersAreNegative () ?
 				-MetadataNegativeSizeInWords :
@@ -303,7 +311,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return bounds;
 		}
 
-		int ResilientImmediateMembersOffset ()
+		int ResilientImmediateMembersOffsetInWords ()
 		{
 			var storedBoundsPtr = ResilientMetadataBounds;
 			var bounds = (long)Marshal.ReadIntPtr (storedBoundsPtr);

--- a/SwiftRuntimeLibrary/SwiftMetatype.cs
+++ b/SwiftRuntimeLibrary/SwiftMetatype.cs
@@ -146,7 +146,7 @@ namespace SwiftRuntimeLibrary {
 				ThrowOnInvalid ();
 				var kind = Kind;
 				return kind == MetatypeKind.Enum || kind == MetatypeKind.Struct ||
-					(kind == MetatypeKind.Class && IsSwiftClassMetaType ());
+					kind == MetatypeKind.Class;
 			}
 		}
 
@@ -168,7 +168,8 @@ namespace SwiftRuntimeLibrary {
 				var typeDesc = GetNominalTypeDescriptor ();
 				if (!typeDesc.IsGeneric ())
 					return 0;
-				return typeDesc.GetTotalGenericArgumentCount ();
+
+				return typeDesc.GetParameterCount ();
 			}
 		}
 

--- a/tests/tom-swifty-test/SwiftReflector/SwiftTypeRegistryTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftTypeRegistryTests.cs
@@ -184,5 +184,116 @@ public func closureFuncTestDoesNothing () {
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Func`2\n2\nBoolean\nTrue\n");
 		}
 
+		[Test]
+		public void TestOptional ()
+		{
+			var swiftCode = @"
+public func optionalTestDoesNothing () {
+}";
+
+			// var ocsty = typeof (SwiftOptional<bool>);
+			// var mt = StructMarshal.Marshaler.Metatypeof (ocsty);
+			// Type csty;
+			// SwiftTypeRegistry.Registry.TryGetValue (mt, out csty);
+			// Console.WriteLine (csty.Name);
+			// Console.WriteLine (genargs.Length);
+			// Console.WriteLine (genargs[1].Name);
+			// Console.WriteLine (csty == ocsty);
+			var ocsTypeID = new CSIdentifier ("ocsty");
+			var csTypeID = new CSIdentifier ("csty");
+			var mtID = new CSIdentifier ("mt");
+
+			var ocstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, ocsTypeID, new CSSimpleType ("SwiftOptional", false, CSSimpleType.Bool).Typeof ());
+			var mtDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, mtID,
+				new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, ocsTypeID));
+			var cstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Type, csTypeID);
+			var tryGetLine = CSFunctionCall.FunctionCallLine ("SwiftTypeRegistry.Registry.TryGetValue", false,
+				mtID, new CSUnaryExpression (CSUnaryOperator.Out, csTypeID));
+			var print1 = CSFunctionCall.ConsoleWriteLine (ocsTypeID.Dot (new CSIdentifier ("Name")));
+			var genargsID = new CSIdentifier ("genargs");
+			var genArgsDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, genargsID, new CSFunctionCall ($"{csTypeID.Name}.GetGenericArguments", false));
+			var print2 = CSFunctionCall.ConsoleWriteLine (genargsID.Dot (new CSIdentifier ("Length")));
+			var print3 = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{genargsID.Name} [0].Name"));
+			var print4 = CSFunctionCall.ConsoleWriteLine (csTypeID == ocsTypeID);
+			var callingCode = CSCodeBlock.Create (ocstyDecl, mtDecl, cstyDecl, tryGetLine, print1, genArgsDecl, print2, print3, print4);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "SwiftOptional`1\n1\nBoolean\nTrue\n");
+		}
+
+		[Test]
+		public void TestDictionary ()
+		{
+			var swiftCode = @"
+public func dictionaryTestDoesNothing () {
+}";
+
+			// var ocsty = typeof (SwiftOptional<bool>);
+			// var mt = StructMarshal.Marshaler.Metatypeof (ocsty);
+			// Type csty;
+			// SwiftTypeRegistry.Registry.TryGetValue (mt, out csty);
+			// Console.WriteLine (csty.Name);
+			// Console.WriteLine (genargs.Length);
+			// Console.WriteLine (genargs[1].Name);
+			// Console.WriteLine (csty == ocsty);
+			var ocsTypeID = new CSIdentifier ("ocsty");
+			var csTypeID = new CSIdentifier ("csty");
+			var mtID = new CSIdentifier ("mt");
+
+			var ocstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, ocsTypeID, new CSSimpleType ("SwiftDictionary", false, CSSimpleType.Bool, CSSimpleType.Int).Typeof ());
+			var mtDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, mtID,
+				new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, ocsTypeID));
+			var cstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Type, csTypeID);
+			var tryGetLine = CSFunctionCall.FunctionCallLine ("SwiftTypeRegistry.Registry.TryGetValue", false,
+				mtID, new CSUnaryExpression (CSUnaryOperator.Out, csTypeID));
+			var print1 = CSFunctionCall.ConsoleWriteLine (ocsTypeID.Dot (new CSIdentifier ("Name")));
+			var genargsID = new CSIdentifier ("genargs");
+			var genArgsDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, genargsID, new CSFunctionCall ($"{csTypeID.Name}.GetGenericArguments", false));
+			var print2 = CSFunctionCall.ConsoleWriteLine (genargsID.Dot (new CSIdentifier ("Length")));
+			var print3 = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{genargsID.Name} [0].Name"));
+			var print4 = CSFunctionCall.ConsoleWriteLine (csTypeID == ocsTypeID);
+			var callingCode = CSCodeBlock.Create (ocstyDecl, mtDecl, cstyDecl, tryGetLine, print1, genArgsDecl, print2, print3, print4);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "SwiftDictionary`2\n2\nBoolean\nTrue\n");
+		}
+
+		[Test]
+		public void TestGenericClass ()
+		{
+			var swiftCode = @"
+public class GenClass<T> {
+	public var x: T
+	public init (a:T) {
+		x = a
+	}
+}
+";
+			// var ocsty = typeof (GenClass<bool>);
+			// var mt = StructMarshal.Marshaler.Metatypeof (ocsty);
+			// Type csty;
+			// SwiftTypeRegistry.Registry.TryGetValue (mt, out csty);
+			// Console.WriteLine (csty.Name);
+			// Console.WriteLine (genargs.Length);
+			// Console.WriteLine (genargs[1].Name);
+			// Console.WriteLine (csty == ocsty);
+			var ocsTypeID = new CSIdentifier ("ocsty");
+			var csTypeID = new CSIdentifier ("csty");
+			var mtID = new CSIdentifier ("mt");
+
+			var ocstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, ocsTypeID, new CSSimpleType ("GenClass", false, CSSimpleType.Bool).Typeof ());
+			var mtDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, mtID,
+				new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, ocsTypeID));
+			var cstyDecl = CSVariableDeclaration.VarLine (CSSimpleType.Type, csTypeID);
+			var tryGetLine = CSFunctionCall.FunctionCallLine ("SwiftTypeRegistry.Registry.TryGetValue", false,
+				mtID, new CSUnaryExpression (CSUnaryOperator.Out, csTypeID));
+			var print1 = CSFunctionCall.ConsoleWriteLine (ocsTypeID.Dot (new CSIdentifier ("Name")));
+			var genargsID = new CSIdentifier ("genargs");
+			var genArgsDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, genargsID, new CSFunctionCall ($"{csTypeID.Name}.GetGenericArguments", false));
+			var print2 = CSFunctionCall.ConsoleWriteLine (genargsID.Dot (new CSIdentifier ("Length")));
+			var print3 = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{genargsID.Name} [0].Name"));
+			var print4 = CSFunctionCall.ConsoleWriteLine (csTypeID == ocsTypeID);
+			var callingCode = CSCodeBlock.Create (ocstyDecl, mtDecl, cstyDecl, tryGetLine, print1, genArgsDecl, print2, print3, print4);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "GenClass`1\n1\nBoolean\nTrue\n");
+		}
 	}
 }


### PR DESCRIPTION
Fixed issue in handling retrieving bound generic types in `SwiftMetatype` fixing issue [16](https://github.com/xamarin/binding-tools-for-swift/issues/16)

Some of the tools to root around the nominal type descriptor were returning offsets in machine words but consuming code was assuming it was in bytes. Fixed.

Added tests for optional, generic structs, and generic classes. Also discovered that `GetTotalGenericArgumentCount` which is modeled off the code in the swift runtime code uses a number that is different from the number of generic parameters. This is because types generic types could be different in terms of the name, number of generic parameters, and number of constraints. This number and distinction is used in a runtime hash of the type.