### PR TITLE
Added more info to the SwiftProtocolTypeAttribute

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -1731,7 +1731,7 @@ namespace SwiftReflector {
 			string swiftProxyClassName = OverrideBuilder.ProxyClassName (protocolDecl);
 
 			use.AddIfNotPresent (typeof (SwiftProtocolTypeAttribute));
-			MakeProtocolTypeAttribute (className).AttachBefore (iface);
+			MakeProtocolTypeAttribute (className, PInvokeName (swiftLibraryPath), protocolContents.TypeDescriptor.MangledName.Substring (1)).AttachBefore (iface);
 
 			proxyClass = new CSClass (CSVisibility.Public, className);
 			picl = new CSClass (CSVisibility.Internal, PIClassName (swiftClassName));
@@ -5940,10 +5940,12 @@ namespace SwiftReflector {
 			return CSAttribute.FromAttr (typeof (SwiftEnumTypeAttribute), al, true);
 		}
 
-		static CSAttribute MakeProtocolTypeAttribute (string proxyNameClassName)
+		static CSAttribute MakeProtocolTypeAttribute (string proxyNameClassName, string library, string protocolDesc)
 		{
 			var al = new CSArgumentList ();
 			al.Add (new CSSimpleType (proxyNameClassName).Typeof ());
+			al.Add (CSConstant.Val (library));
+			al.Add (CSConstant.Val (protocolDesc));
 			return CSAttribute.FromAttr (typeof (SwiftProtocolTypeAttribute), al, true);
 		}
 

--- a/SwiftRuntimeLibrary/ICustomStringConvertible.cs
+++ b/SwiftRuntimeLibrary/ICustomStringConvertible.cs
@@ -11,7 +11,7 @@ using Xamarin.iOS;
 
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.CustomStringConvertible")]
-	[SwiftProtocolType (typeof (CustomStringConvertibleXamProxy))]
+	[SwiftProtocolType (typeof (CustomStringConvertibleXamProxy), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ICustomStringConvertible_ProtocolDescriptor)]
 	public interface ICustomStringConvertible {
 		SwiftString Description { get; }
 	}

--- a/SwiftRuntimeLibrary/ISwiftComparable.cs
+++ b/SwiftRuntimeLibrary/ISwiftComparable.cs
@@ -6,7 +6,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Comparable")]
-	[SwiftProtocolType (typeof (SwiftComparableProxy), true)]
+	[SwiftProtocolType (typeof (SwiftComparableProxy), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftComparable_ProtocolDescriptor, true)]
 	[SwiftExternalProtocolDefinition (typeof (SwiftString), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftComparable_SwiftString)]
 	[SwiftExternalProtocolDefinition (typeof (IntPtr), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftComparable_IntPtr)]
 

--- a/SwiftRuntimeLibrary/ISwiftEquatable.cs
+++ b/SwiftRuntimeLibrary/ISwiftEquatable.cs
@@ -6,7 +6,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Equatable")]
-	[SwiftProtocolType (typeof (SwiftEquatableProxy), true)]
+	[SwiftProtocolType (typeof (SwiftEquatableProxy), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftEquatable_ProtocolDescriptor, true)]
 	[SwiftExternalProtocolDefinition (typeof (SwiftString), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftEquatable_SwiftString)]
 	[SwiftExternalProtocolDefinition (typeof (IntPtr), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftEquatable_IntPtr)]
 	[SwiftExternalProtocolDefinition (typeof (bool), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftEquatable_bool)]

--- a/SwiftRuntimeLibrary/ISwiftHashable.cs
+++ b/SwiftRuntimeLibrary/ISwiftHashable.cs
@@ -6,7 +6,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Hashable")]
-	[SwiftProtocolType (typeof (SwiftHashableProxy), true)]
+	[SwiftProtocolType (typeof (SwiftHashableProxy), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftHashable_ProtocolDescriptor, true)]
 	[SwiftExternalProtocolDefinition (typeof (SwiftString), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftHashable_SwiftString)]
 	[SwiftExternalProtocolDefinition (typeof (IntPtr), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftHashable_IntPtr)]
 	[SwiftExternalProtocolDefinition (typeof (bool), SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.ISwiftHashable_bool)]

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -591,6 +591,21 @@ public class FilmStrip<T: Interpolatable> where T.ValueType == T {
 			TestRunning.TestAndExecute (swiftCode, callingCode, "No smoke\n", expectedErrorCount: 1, platform:PlatformName.macOS);
 		}
 
-
+		[Test]
+		public void TestProtocolTypeAttribute ()
+		{
+			var swiftCode = @"
+public protocol Useless {
+	func doNothing ()
+}
+";
+			// this will throw on fail
+			// SwiftProtocolTypeAttribute.DescriptorForType (typeof (Useless));
+			var getter = CSFunctionCall.FunctionCallLine ("SwiftProtocolTypeAttribute.DescriptorForType", false,
+				new CSSimpleType ("IUseless").Typeof ());
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (getter, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
In order to be existential container metadata, we're going to need the type descriptor for protocols.
This adds that information in in our static types as well as in the code generation.

Test as per usual.