### PR TITLE
Make the enum value accessors private.

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.cs
+++ b/SwiftReflector/Importing/TypeAggregator.cs
@@ -264,8 +264,11 @@ namespace SwiftReflector.Importing {
 		{
 			var types = new HashSet<TypeDefinition> ();
 			var notExcluded = Excludes.Excluding (typeList, typeDefinition => typeDefinition.FullName);
-			foreach (var type in notExcluded)
+			foreach (var type in notExcluded) {
+				if (type.IsAbstract)
+					continue;
 				types.Add (type);
+			}
 			var reallyInclude = Includes.Including (typeList, typeDefinition => typeDefinition.FullName);
 			foreach (var type in reallyInclude)
 				types.Add (type);

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -1073,7 +1073,7 @@ namespace SwiftReflector {
 			var localUsedNames = new List<string> { csFuncImplName };
 
 			var payloadFunc = TLFCompiler.CompileMethod (payloadDecl, use, "", "", csFuncImplName, false, true, false);
-			payloadFunc.Parameters.Clear ();
+			payloadFunc = new CSMethod (CSVisibility.None, payloadFunc.Kind, payloadFunc.Type, payloadFunc.Name, new CSParameterList (), new CSCodeBlock ());
 
 			var throwCall = new CSCodeBlock ();
 			throwCall.Add (CSThrow.ThrowLine (new ArgumentOutOfRangeException (), $"Expected Case to be {csCaseName}."));

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -767,6 +767,23 @@ case nothing
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Something\n");
 		}
 
+		[Test]
+		public void EnumPrivateAccessor ()
+		{
+			var swiftCode = @"
+public enum PrivAccess {
+case iVal(x: Int)
+case fVal(y: Float)
+}
+";
+			var miID = new CSIdentifier ("mi");
+			var miDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, miID, new CSFunctionCall ("typeof(PrivAccess).GetMethod", false, CSConstant.Val ("__GetValueIVal"),
+				new CSIdentifier ("System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance")));
+			var printer = CSFunctionCall.ConsoleWriteLine (miID.Dot (new CSIdentifier ("IsPublic")));
+			var callingCode = new CodeElementCollection<ICodeElement> () { miDecl, printer };
+			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n");
+		}
+
 
 		[Test]
 		public void TopLevelTuple ()


### PR DESCRIPTION
Made private payload accessors for enums really private fixing issue [19](https://github.com/xamarin/binding-tools-for-swift/issues/19)

Note that in `TypeAggregator.cs` I added a check for `IsAbstract` because I was getting name conflicts on a metal shader class that had the same name as the underlying swift protocol.