### PR TITLE
Artisinal binding of IteratorProtocol

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSArray1D.cs
+++ b/Dynamo/Dynamo.CSLang/CSArray1D.cs
@@ -73,5 +73,43 @@ namespace Dynamo.CSLang
 		}
 
 	}
+
+	public class CSListInitialized : CSBaseExpression {
+		public CSListInitialized (CSType type, CommaListElementCollection<CSBaseExpression> initializers)
+		{
+			Type = Exceptions.ThrowOnNull (type, "type");
+			Parameters = Exceptions.ThrowOnNull (initializers, "initializers");
+		}
+
+		public CSListInitialized (CSType type, params CSBaseExpression [] parameters)
+			: this (type, new CommaListElementCollection<CSBaseExpression> (parameters))
+		{
+		}
+
+		public CSListInitialized (string typeName, params CSBaseExpression [] parameters)
+			: this (new CSSimpleType (typeName), new CommaListElementCollection<CSBaseExpression> (parameters))
+		{
+		}
+
+		public CSListInitialized (string typeName, IEnumerable<CSBaseExpression> parameters)
+			: this (new CSSimpleType (typeName), new CommaListElementCollection<CSBaseExpression> (parameters))
+		{
+		}
+
+		public CSType Type { get; private set; }
+		public CommaListElementCollection<CSBaseExpression> Parameters { get; private set; }
+		protected override void LLWrite (ICodeWriter writer, object o)
+		{
+			writer.Write ("new List<", true);
+			Type.WriteAll (writer);
+			writer.Write (">", true);
+			writer.Write ("(", false);
+			writer.Write (") ", true);
+			writer.Write ("{ ", true);
+			Parameters.WriteAll (writer);
+			writer.Write ("}", false);
+		}
+
+	}
 }
 

--- a/Dynamo/Dynamo.CSLang/CSFieldDeclaration.cs
+++ b/Dynamo/Dynamo.CSLang/CSFieldDeclaration.cs
@@ -40,6 +40,16 @@ namespace Dynamo.CSLang {
 		{
 			return new CSLine (new CSVariableDeclaration (type, name, value));
 		}
+
+		public static CSLine VarLine (string name, ICSExpression value)
+		{
+			return new CSLine (new CSVariableDeclaration (CSSimpleType.Var, name, value));
+		}
+
+		public static CSLine VarLine (CSIdentifier name, ICSExpression value)
+		{
+			return new CSLine (new CSVariableDeclaration (CSSimpleType.Var, name, value));
+		}
 	}
 
 	public class CSFieldDeclaration : CSVariableDeclaration {

--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -262,6 +262,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftTypeRegistry.cs">
       <Link>SwiftTypeRegistry.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftIteratorProtocol.cs">
+      <Link>SwiftIteratorProtocol.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -267,6 +267,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftTypeRegistry.cs">
       <Link>SwiftTypeRegistry.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftIteratorProtocol.cs">
+      <Link>SwiftIteratorProtocol.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="mkdir -p GeneratedCode" />

--- a/SwiftRuntimeLibrary/SwiftCore.cs
+++ b/SwiftRuntimeLibrary/SwiftCore.cs
@@ -351,6 +351,15 @@ namespace SwiftRuntimeLibrary {
 			}
 		}
 
+		[DllImport (SwiftCoreConstants.LibSwiftCore)]
+		static extern IntPtr swift_conformsToProtocol (SwiftMetatype metadata, SwiftNominalTypeDescriptor protocolDescriptor);
+
+		public static IntPtr ConformsToSwiftProtocol (SwiftMetatype metadata, SwiftNominalTypeDescriptor protocolDescriptor)
+		{
+			return swift_conformsToProtocol (metadata, protocolDescriptor);
+		}
+
+
 
 		#region ClosureAdapters
 

--- a/SwiftRuntimeLibrary/SwiftIteratorProtocol.cs
+++ b/SwiftRuntimeLibrary/SwiftIteratorProtocol.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using SwiftRuntimeLibrary.SwiftMarshal;
+
+namespace SwiftRuntimeLibrary {
+	// this code is preliminary and is likely to change
+	// do not depend on this
+
+	[SwiftProtocolType (typeof (SwiftIteratorProtocolProxy<>), SwiftCoreConstants.LibSwiftCore, "$sStMp", true)]
+	public interface ISwiftIterator<T> {
+		SwiftOptional<T> Next ();
+	}
+
+	delegate void NextFunc (IntPtr returnVal, IntPtr self);
+
+	struct SwiftIteratorProtocolVtable {
+		[MarshalAs (UnmanagedType.FunctionPtr)]
+		public NextFunc func0;
+	}
+
+
+	public class SwiftIteratorProtocolProxy<T> : ISwiftObject, ISwiftIterator<T> {
+#if __IOS__
+		[MonoNativeFunctionWrapper]
+#endif
+		static SwiftIteratorProtocolProxy ()
+		{
+			SetVTable ();
+		}
+
+		static void SetVTable ()
+		{
+			var vt = new SwiftIteratorProtocolVtable ();
+			vt.func0 = NextFuncReceiver;
+			IteratorProtocolPinvokes.SetVtable (ref vt, StructMarshal.Marshaler.Metatypeof (typeof (T)));
+		}
+
+		static void NextFuncReceiver(IntPtr returnVal, IntPtr self)
+		{
+			var instance = SwiftObjectRegistry.Registry.CSObjectForSwiftObject<SwiftIteratorProtocolProxy<T>> (self);
+			var result = instance.Next ();
+			StructMarshal.Marshaler.ToSwift (result, returnVal);
+		}
+
+		ISwiftIterator<T> proxiedType;
+
+		public SwiftIteratorProtocolProxy (ISwiftIterator<T> proxiedType)
+		{
+			this.proxiedType = proxiedType;
+			SwiftObject = IteratorProtocolPinvokes.NewIteratorProtocol (StructMarshal.Marshaler.Metatypeof (typeof (T)));
+			SwiftCore.Retain (SwiftObject);
+			SwiftObjectRegistry.Registry.Add (this);
+		}
+
+		SwiftIteratorProtocolProxy (IntPtr ptr)
+			: this (ptr, SwiftObjectRegistry.Registry)
+		{
+		}
+
+		SwiftIteratorProtocolProxy (IntPtr ptr, SwiftObjectRegistry registry)
+		{
+			SwiftObject = ptr;
+			SwiftCore.Retain (ptr);
+			registry.Add (this);
+		}
+
+		#region IDisposable implementation
+
+		bool disposed = false;
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		~SwiftIteratorProtocolProxy ()
+		{
+			Dispose (false);
+		}
+
+		void Dispose (bool disposing)
+		{
+			if (!disposed) {
+				if (disposing) {
+					DisposeManagedResources ();
+				}
+				DisposeUnmanagedResources ();
+				disposed = true;
+			}
+		}
+
+		void DisposeManagedResources ()
+		{
+		}
+
+		void DisposeUnmanagedResources ()
+		{
+			SwiftCore.Release (SwiftObject);
+		}
+		#endregion
+
+		#region ISwiftObject implementation
+
+		public IntPtr SwiftObject { get; set; }
+
+		public static SwiftIteratorProtocolProxy<T> XamarinFactory (IntPtr p)
+		{
+			return new SwiftIteratorProtocolProxy<T> (p, SwiftObjectRegistry.Registry);
+		}
+
+		#endregion
+
+		public static SwiftMetatype GetSwiftMetatype ()
+		{
+			return IteratorProtocolPinvokes.IteratorProtocolMetadataAccessor (SwiftMetadataRequest.Complete, StructMarshal.Marshaler.Metatypeof (typeof (T)));
+		}
+
+		#region ISwiftIterator
+		public SwiftOptional<T> Next ()
+		{
+			if (proxiedType == null)
+				throw new NotSupportedException ("Non proxied types not supported yet");
+			return proxiedType.Next ();
+		}
+		#endregion
+	}
+
+	internal static class IteratorProtocolPinvokes {
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = "$s7XamGlue19newIteratorProtocolAA27iteratorprotocol_xam_helperCyxGylF")]
+		public static extern IntPtr NewIteratorProtocol (SwiftMetatype metadata);
+
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = "$s7XamGlue20IteratorProtocolNext6retval4thisySpyxSgG_AA27iteratorprotocol_xam_helperCyxGtlF")]
+		public static extern void IteratorProtocolNext (IntPtr retval, IntPtr self, SwiftMetatype metadata);
+
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = "$s7XamGlue27iteratorprotocol_xam_helperCMa")]
+		public static extern SwiftMetatype IteratorProtocolMetadataAccessor (SwiftMetadataRequest request, SwiftMetatype mt);
+
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = "$s7XamGlue31iteratorprotocol_set_xam_vtableyySV_ypXptF")]
+		public static extern void SetVtable (ref SwiftIteratorProtocolVtable vtable, SwiftMetatype mt);
+
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = "$s7XamGlue13iterateThings3ret4thisySpySSG_AA27iteratorprotocol_xam_helperCySiGtF")]
+		public static extern void IterateThings (IntPtr ret, IntPtr self);
+	}
+
+	public class SwiftListIterator<T> : ISwiftIterator<T> {
+		IEnumerator<T> enumerator;
+		public SwiftListIterator (IEnumerable<T> enumerable)
+		{
+			this.enumerator = enumerable.GetEnumerator ();
+		}
+
+		public SwiftOptional<T> Next ()
+		{
+			if (enumerator.MoveNext ()) {
+				return SwiftOptional<T>.Some (enumerator.Current);
+			} else {
+				return SwiftOptional<T>.None ();
+			}
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftIteratorProtocol.cs
+++ b/SwiftRuntimeLibrary/SwiftIteratorProtocol.cs
@@ -5,6 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using SwiftRuntimeLibrary.SwiftMarshal;
+#if !TOM_SWIFTY
+using Foundation;
+using ObjCRuntime;
+#endif
 
 namespace SwiftRuntimeLibrary {
 	// this code is preliminary and is likely to change
@@ -15,6 +19,9 @@ namespace SwiftRuntimeLibrary {
 		SwiftOptional<T> Next ();
 	}
 
+#if __IOS__
+	[MonoNativeFunctionWrapper]
+#endif
 	delegate void NextFunc (IntPtr returnVal, IntPtr self);
 
 	struct SwiftIteratorProtocolVtable {
@@ -24,9 +31,6 @@ namespace SwiftRuntimeLibrary {
 
 
 	public class SwiftIteratorProtocolProxy<T> : ISwiftObject, ISwiftIterator<T> {
-#if __IOS__
-		[MonoNativeFunctionWrapper]
-#endif
 		static SwiftIteratorProtocolProxy ()
 		{
 			SetVTable ();

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -260,6 +260,19 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return (IntPtr)pi.GetValue (null);
 		}
 
+		public IntPtr ProtocolConformanceof (Type interfaceType, Type withRespectTo)
+		{
+			return ProtocolConformanceof (interfaceType, Metatypeof (withRespectTo));
+		}
+
+		public IntPtr ProtocolConformanceof (Type interfaceType, SwiftMetatype withRespectTo)
+		{
+			if (!interfaceType.IsInterface)
+				throw new NotSupportedException ($"Type {interfaceType.Name} must be an interface.");
+			var nominalDescriptor = SwiftProtocolTypeAttribute.DescriptorForType (interfaceType);
+			return SwiftCore.ConformsToSwiftProtocol (withRespectTo, nominalDescriptor);
+		}
+
 		bool IsAction (Type t)
 		{
 			return t.FullName.StartsWith ("System.Action`", StringComparison.Ordinal) || t.FullName == "System.Action";

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -111,6 +111,7 @@
     <Compile Include="BaseProxy.cs" />
     <Compile Include="SwiftMarshal\SwiftTypeNameAttribute.cs" />
     <Compile Include="SwiftTypeRegistry.cs" />
+    <Compile Include="SwiftIteratorProtocol.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/swiftglue/iteratorprotocolhelpers.swift
+++ b/swiftglue/iteratorprotocolhelpers.swift
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+internal var iteratorprotocol_xam_helperVtableCache = [TypeCacheKey : iteratorprotocol_xam_vtable ] ()
+
+internal struct iteratorprotocol_xam_vtable
+{
+	internal var func0: (@convention(c)(UnsafeRawPointer, UnsafeRawPointer)->())?
+}
+
+internal func iteratorprotocol_get_xam_vtable(_ t0: Any.Type) -> iteratorprotocol_xam_vtable?
+{
+    return iteratorprotocol_xam_helperVtableCache[TypeCacheKey(types: ObjectIdentifier(t0))];
+}
+
+public class iteratorprotocol_xam_helper<Elem> : IteratorProtocol {
+	private var _xamarinClassIsInitialized: Bool = false;
+	
+	public init ()
+	{
+		_xamarinClassIsInitialized = true;
+	}
+	
+	public func next() -> Elem? {
+		let vt = iteratorprotocol_get_xam_vtable(Elem.self)!
+		let retval = UnsafeMutablePointer<Elem?>.allocate(capacity: 1)
+		vt.func0!(toIntPtr(value: retval), toIntPtr(value: self))
+		let actualRetval = retval.move()
+		retval.deallocate();
+		return actualRetval
+	}
+}
+
+public func iteratorprotocol_set_xam_vtable (_ vt0: UnsafeRawPointer, _ t0: Any.Type)
+{
+	let vt: UnsafePointer<iteratorprotocol_xam_vtable> = fromIntPtr(ptr: vt0)
+	
+	iteratorprotocol_xam_helperVtableCache [ TypeCacheKey(types: ObjectIdentifier(t0)) ] = vt.pointee
+}
+
+public func newIteratorProtocol<T>() -> iteratorprotocol_xam_helper<T>
+{
+	return iteratorprotocol_xam_helper<T> ()
+}
+
+public func anyIteratorProtocolNext<T>(retval: UnsafeMutablePointer<T.Element?>, this: UnsafeMutablePointer<T> ) where T:IteratorProtocol
+{
+	retval.initialize(to: this.pointee.next())
+}
+

--- a/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
@@ -287,6 +287,30 @@ namespace SwiftReflector {
 			WrapGenNonVirtClassReturnFunc ("Struct", "BarWGNVCRFStruct", "new BarWGNVCRFStruct(12)", "GenericFunctionTests.BarWGNVCRFStruct\n");
 		}
 
+		void WrapGenReallyVirtClassReturnFunc (string appendage, string cstype, string val1, string expected)
+		{
+			string swiftCode =
+		$"public struct BarRYWGVCR{appendage} {{\npublic var X:Int32 = 0;\npublic init(x:Int32) {{\n X = x;\n}}\n}}\n" +
+		$"open class FooRYWGVCR{appendage}<T> {{\npublic init() {{ }}\nopen func Func(a:T)-> T {{\nreturn a;\n}}\n}}\n";
+
+			CSLine fooDecl = CSVariableDeclaration.VarLine (new CSSimpleType ($"FooRYWGVCR{appendage}", false,
+										    new CSSimpleType (cstype)),
+								   "foo", new CSFunctionCall ($"FooRYWGVCR{appendage}<{cstype}>", true));
+			CSLine printer = CSFunctionCall.ConsoleWriteLine (CSFunctionCall.Function ("foo.Func", (CSIdentifier)val1));
+
+			CSCodeBlock callingCode = CSCodeBlock.Create (fooDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapGenReallyVirtClassReturnFunc{appendage}");
+		}
+
+		[Test]
+		[Ignore ("Error in swift code generation")]
+		public void TestGenReallyVirtClassReturnBool ()
+		{
+			WrapGenReallyVirtClassReturnFunc ("BoolT", "bool", "true", "True\n");
+			WrapGenReallyVirtClassReturnFunc ("BoolF", "bool", "false", "False\n");
+		}
+
 		void WrapGenVirtClassReturnFunc (string appendage, string cstype, string val1, string expected)
 		{
 			string swiftCode =

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace tomwiftytest.SwiftReflector {
+	public class ProtocolConformanceTests {
+		public ProtocolConformanceTests ()
+		{
+		}
+	}
+}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -1,8 +1,102 @@
-﻿using System;
-namespace tomwiftytest.SwiftReflector {
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Dynamo.CSLang;
+using NUnit.Framework;
+using tomwiftytest;
+
+namespace SwiftReflector {
+	[TestFixture]
 	public class ProtocolConformanceTests {
-		public ProtocolConformanceTests ()
+		[Test]
+		public void CanGetProtocolConformanceDesc ()
 		{
+			// var nomDesc = SwiftProtocolTypeAttribute.DescriptorForType (typeof (ISwiftIterator<>));
+			// var confDesc = SwiftCore.ConformsToSwiftProtocol (StructMarshal.Marshaler.Metatypeof (typeof (SwiftIteratorProtocolProxy<nint>)),
+			//                                          nomDesc);
+			// Console.WriteLine (confDesc != IntPtr.Zero);
+
+			var swiftCode = @"
+public func canGetProtocolConfDesc () {
+}
+";
+			var nomDescID = new CSIdentifier ("nomDesc");
+			var confDescID = new CSIdentifier ("confDesc");
+
+			var nomDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, nomDescID,
+				new CSFunctionCall ("SwiftProtocolTypeAttribute.DescriptorForType", false, new CSSimpleType ("ISwiftIterator<>").Typeof ()));
+
+			var metaTypeCall = new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, new CSSimpleType ("SwiftIteratorProtocolProxy<nint>").Typeof ());
+			var confDescDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, confDescID,
+				new CSFunctionCall ("SwiftCore.ConformsToSwiftProtocol", false, metaTypeCall, nomDescID));
+			var printer = CSFunctionCall.ConsoleWriteLine (confDescID != new CSIdentifier ("IntPtr.Zero"));
+
+			var callingCode = CSCodeBlock.Create (nomDecl, confDescDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
+		}
+
+
+		[Test]
+		public void CanGetProtocolConformanceDescMarshal ()
+		{
+			// var confDesc = StructMarshal.Marshaler.ProtocolConformanceof (typeof (ISwiftIterator<>),
+			//		typeof (SwiftIteratorProtocolProxy<nint>);
+			// Console.WriteLine (confDesc != IntPtr.Zero);
+
+			var swiftCode = @"
+public func canGetProtocolConfDescMarshal () {
+}
+";
+			var confDescID = new CSIdentifier ("confDesc");
+
+			var concreteType = new CSSimpleType ("SwiftIteratorProtocolProxy<nint>").Typeof ();
+			var ifaceType = new CSSimpleType ("ISwiftIterator<>").Typeof ();
+			var confDescDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, confDescID,
+				new CSFunctionCall ("StructMarshal.Marshaler.ProtocolConformanceof", false, ifaceType, concreteType));
+			var printer = CSFunctionCall.ConsoleWriteLine (confDescID != new CSIdentifier ("IntPtr.Zero"));
+
+			var callingCode = CSCodeBlock.Create (confDescDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
+		}
+
+		[Test]
+		public void CanIterateAdapting ()
+		{
+			var swiftCode = @"
+public func iterateThings (this: iteratorprotocol_xam_helper<Int>) -> String
+{
+	var s = """";
+	while let i = this.next () {
+	    let isFirst = s == """"
+	    if !isFirst {
+	    	s = s + "" ""
+	    }
+		s = s + String (i)
+	}
+	return s
+}
+";
+			//var list = new List<nint> () { 13, -4, 2 };
+			//var iter = new SwiftListIterator<nint> (list);
+			//var adapt = new SwiftIteratorProtocolProxy<nint> (iter);
+			//var s = TopLevelEntities.IterateThings (adapt);
+			//Console.WriteLine (s.ToString)
+
+			var listID = new CSIdentifier ("list");
+			var iterID = new CSIdentifier ("iter");
+			var adaptID = new CSIdentifier ("adapt");
+			var sID = new CSIdentifier ("s");
+			var listDecl = CSVariableDeclaration.VarLine (listID, new CSListInitialized (new CSSimpleType ("nint"),
+				CSConstant.Val (13), CSConstant.Val (-4), CSConstant.Val (2)));
+			var iterDecl = CSVariableDeclaration.VarLine (iterID, new CSFunctionCall ("SwiftListIterator<nint>", true, listID));
+			var adaptDecl = CSVariableDeclaration.VarLine (adaptID, new CSFunctionCall ("SwiftIteratorProtocolProxy<nint>", true, iterID));
+			var sDecl = CSVariableDeclaration.VarLine (sID, new CSFunctionCall ("TopLevelEntities.IterateThings", false, adaptID));
+			var printer = CSFunctionCall.ConsoleWriteLine (sID);
+
+			var callingCode = CSCodeBlock.Create (listDecl, iterDecl, sDecl, printer);
 		}
 	}
 }

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -110,6 +110,7 @@
     <Compile Include="SwiftReflector\ProtocolListTests.cs" />
     <Compile Include="SwiftReflector\SwiftTypeAttributeNameTests.cs" />
     <Compile Include="SwiftReflector\SwiftTypeRegistryTests.cs" />
+    <Compile Include="SwiftReflector\ProtocolConformanceTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
This is a first stab at modeling a protocol with associated types in C#.

There are 4 parts to it:

1. The generic interface definition
2. A generic swift class that adopts the protocol generically
3. A C# proxy binding to the generic swift class
4. A C# convenience adapter that maps `IEnumerator<T>` -> `ISwiftIterator<T>`

Like previous type modeling, the C# implementation goes through a vtable in swift that is populated with function pointers from C#.

NB: This is only a model of "we want this C# type usable in swift". The other half of the problem, "we want this swift type usable in C#" will come later, much later will be teaching BtfS to generate all of that.

Included in this is also hooks into swift for getting the protocol conformance descriptor for a given C# type. This will be used later for calling fully generic methods on the type.

There is a test that runs on the specific adapter to see if the calls back into C# work. They do.
There are also tests on the protocol conformance descriptor.

Currently the type for that is an IntPtr. That will change in the future when I figure out what I want /need to expose to operate on it.

I added two helpers to Dynamo - an expression for an initialized `List<T>` and a simplified var line that uses the C# `var` syntax instead of a type.