### PR TITLE
Added data type for protocol conformance descriptor

### DIFF
--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -265,6 +265,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftIteratorProtocol.cs">
       <Link>SwiftIteratorProtocol.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolConformanceDescriptor.cs">
+      <Link>SwiftMarshal\SwiftProtocolConformanceDescriptor.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -270,6 +270,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftIteratorProtocol.cs">
       <Link>SwiftIteratorProtocol.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolConformanceDescriptor.cs">
+      <Link>SwiftMarshal\SwiftProtocolConformanceDescriptor.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="mkdir -p GeneratedCode" />

--- a/SwiftRuntimeLibrary/Enums.cs
+++ b/SwiftRuntimeLibrary/Enums.cs
@@ -109,5 +109,10 @@ namespace SwiftRuntimeLibrary {
 		None = 0,
 		Error = 1,
 	}
+
+	public enum ProtocolDispatchStrategy {
+		ObjC = 0,
+		Swift = 1,
+	}
 }
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -260,17 +260,17 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return (IntPtr)pi.GetValue (null);
 		}
 
-		public IntPtr ProtocolConformanceof (Type interfaceType, Type withRespectTo)
+		public SwiftProtocolConformanceDescriptor ProtocolConformanceof (Type interfaceType, Type withRespectTo)
 		{
 			return ProtocolConformanceof (interfaceType, Metatypeof (withRespectTo));
 		}
 
-		public IntPtr ProtocolConformanceof (Type interfaceType, SwiftMetatype withRespectTo)
+		public SwiftProtocolConformanceDescriptor ProtocolConformanceof (Type interfaceType, SwiftMetatype withRespectTo)
 		{
 			if (!interfaceType.IsInterface)
 				throw new NotSupportedException ($"Type {interfaceType.Name} must be an interface.");
 			var nominalDescriptor = SwiftProtocolTypeAttribute.DescriptorForType (interfaceType);
-			return SwiftCore.ConformsToSwiftProtocol (withRespectTo, nominalDescriptor);
+			return new SwiftProtocolConformanceDescriptor (SwiftCore.ConformsToSwiftProtocol (withRespectTo, nominalDescriptor));
 		}
 
 		bool IsAction (Type t)

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SwiftRuntimeLibrary.SwiftMarshal {
+	public struct SwiftProtocolConformanceDescriptor {
+		const int kProtocolDescOffset = 0;
+		const int kTypeDescOffset = 1;
+		const int kWitnessOffset = 2;
+		const int kFlagsOffset = 3;
+		const int kTrailingItemsOffset = 4;
+
+		readonly IntPtr handle;
+
+		public SwiftProtocolConformanceDescriptor (IntPtr handle)
+		{
+			this.handle = handle;
+		}
+
+		public IntPtr Handle => handle;
+
+		public bool IsValid {
+			get {
+				return handle != IntPtr.Zero;
+			}
+		}
+
+		void ThrowOnInvalid ()
+		{
+			if (!IsValid)
+				throw new InvalidOperationException ();
+		}
+
+		public SwiftNominalTypeDescriptor ProtocolDescriptor {
+			get {
+				ThrowOnInvalid ();
+				return new SwiftNominalTypeDescriptor (ReadRelativeIndirectPointerOffsetBy (kProtocolDescOffset));
+			}
+		}
+
+		public SwiftNominalTypeDescriptor ImplementingTypeDescriptor {
+			get {
+				return new SwiftNominalTypeDescriptor (HandleOffsetBy (kTypeDescOffset));
+			}
+		}
+
+		internal IntPtr WitnessTable {
+			get {
+				return HandleOffsetBy (kWitnessOffset);
+			}
+		}
+
+		IntPtr ReadRelativeIndirectPointerOffsetBy (int offset)
+		{
+			// offset is the number of int32 sized words offset from the handle
+			// a relative indirect pointer is either:
+			// a relative pointer to a pointer if the low bit is set
+			// a relative pointer to an object if the low bit is clear
+
+			var ptrAndFlag = PointerAndFlagOffsetBy (offset);
+
+			return ptrAndFlag.Item2 ? Marshal.ReadIntPtr (ptrAndFlag.Item1) : ptrAndFlag.Item1;
+		}
+
+		IntPtr HandleOffsetBy (int offset)
+		{
+			return handle + (offset * sizeof (int));
+		}
+
+		Tuple<IntPtr, bool> PointerAndFlagOffsetBy (int offset)
+		{
+			var targetHandle = HandleOffsetBy (offset);
+			var relPointer = Marshal.ReadInt32 (targetHandle);
+			var lowBit = (relPointer & 1) != 0;
+			targetHandle = targetHandle + (relPointer & ~1);
+			return new Tuple<IntPtr, bool> (targetHandle, lowBit);
+		}
+
+		int Flags {
+			get {
+				return Marshal.ReadInt32 (handle + (kFlagsOffset * sizeof (int)));
+			}
+		}
+
+		public bool IsSwift {
+			get {
+				return (Flags & (1 << 0)) != 0;
+			}
+		}
+
+		public bool HasClassConstraint {
+			get {
+				return (Flags & (1 << 1)) != 0;
+			}
+		}
+
+		public ProtocolDispatchStrategy DispatchStrategy {
+			get {
+				return (ProtocolDispatchStrategy)((Flags >> 2) & 0xf);
+			}
+		}
+
+		public SwiftSpecialProtocol SpecialProtocol {
+			get {
+				return (SwiftSpecialProtocol)((Flags >> 6) & 0xf);
+			}
+		}
+
+		public bool IsResilient {
+			get {
+				return ((Flags >> 10) & 1) != 0;
+			}
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -112,6 +112,7 @@
     <Compile Include="SwiftMarshal\SwiftTypeNameAttribute.cs" />
     <Compile Include="SwiftTypeRegistry.cs" />
     <Compile Include="SwiftIteratorProtocol.cs" />
+    <Compile Include="SwiftMarshal\SwiftProtocolConformanceDescriptor.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -55,7 +55,7 @@ public func canGetProtocolConfDescMarshal () {
 			var ifaceType = new CSSimpleType ("ISwiftIterator<>").Typeof ();
 			var confDescDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, confDescID,
 				new CSFunctionCall ("StructMarshal.Marshaler.ProtocolConformanceof", false, ifaceType, concreteType));
-			var printer = CSFunctionCall.ConsoleWriteLine (confDescID != new CSIdentifier ("IntPtr.Zero"));
+			var printer = CSFunctionCall.ConsoleWriteLine (confDescID.Dot (new CSIdentifier ("Handle")) != new CSIdentifier ("IntPtr.Zero"));
 
 			var callingCode = CSCodeBlock.Create (confDescDecl, printer);
 
@@ -63,9 +63,12 @@ public func canGetProtocolConfDescMarshal () {
 		}
 
 		[Test]
+		[Ignore ("Needs a type database entry, probably")]
 		public void CanIterateAdapting ()
 		{
 			var swiftCode = @"
+import XamGlue
+
 public func iterateThings (this: iteratorprotocol_xam_helper<Int>) -> String
 {
 	var s = """";
@@ -97,6 +100,8 @@ public func iterateThings (this: iteratorprotocol_xam_helper<Int>) -> String
 			var printer = CSFunctionCall.ConsoleWriteLine (sID);
 
 			var callingCode = CSCodeBlock.Create (listDecl, iterDecl, sDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "13 -4 2\n");
 		}
 	}
 }


### PR DESCRIPTION
Added a data type for protocol conformance descriptor.
This is data type is not complete - still need to add in the trailing objects.
Also noted that one of the previous tests wasn't actually running. It's now runnable, but it doesn't pass due to missing marshaling information. That will come later.