### PR TITLE
Stubbed out preliminary functionality on protocol conformance descriptors

### DIFF
--- a/SwiftRuntimeLibrary/Enums.cs
+++ b/SwiftRuntimeLibrary/Enums.cs
@@ -114,5 +114,12 @@ namespace SwiftRuntimeLibrary {
 		ObjC = 0,
 		Swift = 1,
 	}
+
+	public enum SwiftProtocolConformanceTypeDescriptorKind {
+		DirectTypeDescriptor,
+		IndirectTypeDescriptor,
+		DirectObjCClassName,
+		IndirectObjCClass,
+	}
 }
 

--- a/SwiftRuntimeLibrary/SwiftCore.cs
+++ b/SwiftRuntimeLibrary/SwiftCore.cs
@@ -73,6 +73,9 @@ namespace SwiftRuntimeLibrary {
 			return p;
 		}
 
+		[DllImport ("libobjc.A.dylib")]
+		internal static extern IntPtr objc_lookUpClass (IntPtr utf8Name);
+
 		[DllImport (SwiftCoreConstants.LibSwiftCore)]
 		static extern void swift_unownedRetain (IntPtr p);
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
@@ -3,8 +3,39 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SwiftRuntimeLibrary.SwiftMarshal {
+	internal struct ResilientWitnessEntry {
+		public IntPtr ProtocolRequirement;
+		public string WitnessRequirement;
+		public static ResilientWitnessEntry FromMemory (IntPtr memory)
+		{
+			var protoPtrOffset = Marshal.ReadInt32 (memory);
+			var isIndirect = (protoPtrOffset & 1) != 0;
+			protoPtrOffset &= ~1;
+			var protoRequirement = isIndirect ? Marshal.ReadIntPtr (memory + protoPtrOffset) : memory + protoPtrOffset;
+
+			memory = memory + sizeof (int);
+			var strPtrOffset = Marshal.ReadInt32 (memory) & ~1;
+			var str = FromUTF8 (memory + strPtrOffset);
+
+			return new ResilientWitnessEntry {
+				ProtocolRequirement = protoRequirement,
+				WitnessRequirement = str
+			};
+		}
+		static string FromUTF8 (IntPtr ptr)
+		{
+			unsafe {
+				var len = 0;
+				var bp = (byte *)ptr.ToPointer ();
+				while (bp [len] != 0) len++;
+				return Encoding.UTF8.GetString (bp, len);
+			}
+		}
+	}
+
 	public struct SwiftProtocolConformanceDescriptor {
 		const int kProtocolDescOffset = 0;
 		const int kTypeDescOffset = 1;
@@ -40,9 +71,44 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			}
 		}
 
+		// the kTypeDescOffset in this type is a union of 4 possible things:
+		// a pointer Nominal Type Descriptor of the implementing type
+		// an indirect pointer to a Nominal Type Descriptor of the implementing type
+		// a pointer to an ObjC class name
+		// a pointer to an ObjC class object
+		// 
+
 		public SwiftNominalTypeDescriptor ImplementingTypeDescriptor {
 			get {
-				return new SwiftNominalTypeDescriptor (HandleOffsetBy (kTypeDescOffset));
+				var kind = MetadataKind;
+				var ptr = ReadRelativePointerOffsetBy (kTypeDescOffset);
+				if (kind == SwiftProtocolConformanceTypeDescriptorKind.DirectTypeDescriptor) {
+					return new SwiftNominalTypeDescriptor (ptr);
+				} else if (kind == SwiftProtocolConformanceTypeDescriptorKind.IndirectTypeDescriptor) {
+					return new SwiftNominalTypeDescriptor (Marshal.ReadIntPtr (ptr));
+				}
+				throw new SwiftRuntimeException ($"Expected a protocol descriptor for a swift metadata kind, but was {MetadataKind}");
+			}
+		}
+
+		IntPtr ObjCClassName {
+			get {
+				unsafe {
+					return ReadRelativePointerOffsetBy (kTypeDescOffset);
+				}
+			}
+		}
+
+		public SwiftMetatype ObjCClass {
+			get {
+				var kind = MetadataKind;
+				var ptr = ReadRelativePointerOffsetBy (kTypeDescOffset);
+				if (kind == SwiftProtocolConformanceTypeDescriptorKind.IndirectObjCClass) {
+					return new SwiftMetatype (ptr);
+				} else if (kind == SwiftProtocolConformanceTypeDescriptorKind.DirectObjCClassName) {
+					return new SwiftMetatype (SwiftCore.objc_lookUpClass (ObjCClassName));
+				}
+				throw new SwiftRuntimeException ($"Expected a protocol descriptor for an ObjC metadata kind, but was {MetadataKind}");
 			}
 		}
 
@@ -50,6 +116,13 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			get {
 				return HandleOffsetBy (kWitnessOffset);
 			}
+		}
+
+		IntPtr ReadRelativePointerOffsetBy (int offset)
+		{
+			var targetHandle = HandleOffsetBy (offset);
+			var relPointer = Marshal.ReadInt32 (targetHandle);
+			return targetHandle + relPointer;
 		}
 
 		IntPtr ReadRelativeIndirectPointerOffsetBy (int offset)
@@ -84,34 +157,132 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			}
 		}
 
-		public bool IsSwift {
+		public SwiftProtocolConformanceTypeDescriptorKind MetadataKind {
 			get {
-				return (Flags & (1 << 0)) != 0;
+				return (SwiftProtocolConformanceTypeDescriptorKind)((Flags >> 3) & 0x7);
 			}
 		}
 
-		public bool HasClassConstraint {
+		public bool IsRetroactive {
 			get {
-				return (Flags & (1 << 1)) != 0;
+				return (Flags & (1 << 6)) != 0;
 			}
 		}
 
-		public ProtocolDispatchStrategy DispatchStrategy {
+		bool IsSynthesizedNonUnique {
 			get {
-				return (ProtocolDispatchStrategy)((Flags >> 2) & 0xf);
+				return (Flags & (1 << 7)) != 0;
 			}
 		}
 
-		public SwiftSpecialProtocol SpecialProtocol {
+		int ConditionalRequirementCount {
 			get {
-				return (SwiftSpecialProtocol)((Flags >> 6) & 0xf);
+				return (Flags >> 8) & 0xff;
 			}
 		}
 
-		public bool IsResilient {
+		bool HasResilientWitnesses {
 			get {
-				return ((Flags >> 10) & 1) != 0;
+				return (Flags & (1 << 16)) != 0;
 			}
 		}
+
+		bool HasGenericWitnessTable {
+			get {
+				return (Flags & (1 << 17)) != 0;
+			}
+		}
+
+		public SwiftNominalTypeDescriptor ContextDescriptor {
+			get {
+				if (!IsRetroactive)
+					throw new NotSupportedException ();
+				return new SwiftNominalTypeDescriptor (ReadRelativePointerOffsetBy (kTrailingItemsOffset));
+			}
+		}
+
+		int GenericRequirementsOffset {
+			get {
+				return kTrailingItemsOffset + (IsRetroactive ? 1 : 0);
+			}
+		}
+
+		// note for future coders - a GenericRequirementDescriptor is this:
+		// int32 flags
+		// int32 relative direct pointer to mangled name of the type
+		// union {
+		//    relative pointer Type
+		//    relative pointer protocol descriptor protocol
+		//    relative indirectable pointer conformance
+		//    int32 generic layout kind
+		// }
+		// size - 3 int32s
+		const int kGenericRequirementSize = 3;
+
+		int ResilientWitnessHeaderOffset {
+			get {
+				return GenericRequirementsOffset + kGenericRequirementSize * ConditionalRequirementCount;
+			}
+		}
+
+		internal int ResilientWitnessCount {
+			get {
+				if (!HasResilientWitnesses)
+					return 0;
+				var ptr = HandleOffsetBy (ResilientWitnessHeaderOffset);
+				return Marshal.ReadInt32 (ptr);
+			}
+		}
+
+
+		internal int ResilientWitnessEntryOffset {
+			get {
+				return ResilientWitnessHeaderOffset + (HasResilientWitnesses ? 1 : 0);
+			}
+		}
+		// note for future coders - a resilient witness table entry is:
+		// int32 indirectable relative pointer to descriptor, low bit is indirectability
+		//      descriptor may be an associated type descriptor or a method descriptor or ... ?
+		// int32 direct relative pointer to mangled name of which, for some reason, has the low bit set.
+		// Weirdness that I see:
+		// in a static implementor of IteratorProtocol, this table is orderd as
+		// associated type descriptor for Element
+		// pointer to Si (Swift.Int) (low bit set)
+		// method descriptor for next ()->A.Element?
+		// pointer to protocol witness for next()->A.Element?
+		//
+		// The problem here is that ordering of this table is not yet apparent to me.
+		// It could be associated types first then members
+		// If it is that, what is the ordering of the associated types and what is the ordering of the members?
+		// How do I know how many associated types there are?
+		// size - 2 int32s
+
+		const int kResilientWitnessSize = 2;
+
+		internal ResilientWitnessEntry[] GetResilientWitnessEntries ()
+		{
+			var count = ResilientWitnessCount;
+			var entries = new ResilientWitnessEntry [count];
+			if (count > 0) {
+				var entryPtr = HandleOffsetBy (ResilientWitnessEntryOffset);
+				for (int i=0; i < count; i++) {
+					entries [i] = ResilientWitnessEntry.FromMemory (entryPtr);
+					entryPtr = entryPtr + (kResilientWitnessSize * sizeof (int));
+				}
+			}
+			return entries;
+		}
+
+		int GenericWitnessOffset {
+			get {
+				return ResilientWitnessEntryOffset + (ResilientWitnessCount * kResilientWitnessSize);
+			}
+		}
+
+		// note for future coders, a generic witness table contains the following:
+		// int16 witness table size in words
+		// int16 witness table private size in words
+		// int32 relative direct pointer to instantiator
+		// int32 relative direct pointer to private data
 	}
 }

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
@@ -31,7 +31,9 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				var len = 0;
 				var bp = (byte *)ptr.ToPointer ();
 				while (bp [len] != 0) len++;
-				return Encoding.UTF8.GetString (bp, len);
+				var buffer = new byte [len];
+				Marshal.Copy (ptr, buffer, 0, len);
+				return Encoding.UTF8.GetString (buffer);
 			}
 		}
 	}


### PR DESCRIPTION
The previous incarnation of `ProtocolConformanceDescriptor` was incomplete and in many cases, just plain wrong.

I've stubbed out the ability to get at the trailing objects in preparation for their use, which is why a lot of the API is private or internal.