### PR TITLE
Get assoc types

### DIFF
--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -268,6 +268,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolConformanceDescriptor.cs">
       <Link>SwiftMarshal\SwiftProtocolConformanceDescriptor.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolWitnessTable.cs">
+      <Link>SwiftMarshal\SwiftProtocolWitnessTable.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -273,6 +273,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolConformanceDescriptor.cs">
       <Link>SwiftMarshal\SwiftProtocolConformanceDescriptor.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolWitnessTable.cs">
+      <Link>SwiftMarshal\SwiftProtocolWitnessTable.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="mkdir -p GeneratedCode" />

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -1964,7 +1964,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			var protoConformance = witness.Conformance;
 
 			var finalTypes = new Type [expectedAssociatedTypeCount];
-			for (int i=0; i < expectedAssociatedTypeCount; i++) {
+			for (int i = 0; i < expectedAssociatedTypeCount; i++) {
 				var metadata = SwiftCore.AssociatedTypeMetadataRequest (implementingType, witness, protoConformance, i);
 				Type csType = null;
 				if (!SwiftTypeRegistry.Registry.TryGetValue (metadata, out csType))
@@ -2022,4 +2022,3 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		}
 	}
 }
-

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
@@ -242,6 +242,11 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				return ResilientWitnessHeaderOffset + (HasResilientWitnesses ? 1 : 0);
 			}
 		}
+
+		internal IntPtr ResilientWitnessPointer (int index)
+		{
+			return HandleOffsetBy (ResilientWitnessEntryOffset + (index * kResilientWitnessSize));
+		}
 		// note for future coders - a resilient witness table entry is:
 		// int32 indirectable relative pointer to descriptor, low bit is indirectability
 		//      descriptor may be an associated type descriptor or a method descriptor or ... ?

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolConformanceDescriptor.cs
@@ -247,6 +247,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		{
 			return HandleOffsetBy (ResilientWitnessEntryOffset + (index * kResilientWitnessSize));
 		}
+
 		// note for future coders - a resilient witness table entry is:
 		// int32 indirectable relative pointer to descriptor, low bit is indirectability
 		//      descriptor may be an associated type descriptor or a method descriptor or ... ?

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolWitnessTable.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolWitnessTable.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SwiftRuntimeLibrary.SwiftMarshal {
+	public struct SwiftProtocolWitnessTable {
+
+		IntPtr handle;
+		public SwiftProtocolWitnessTable (IntPtr handle)
+		{
+			this.handle = handle;
+		}
+
+		public IntPtr Handle => handle;
+
+		public SwiftProtocolConformanceDescriptor Conformance {
+			get {
+				if (handle == IntPtr.Zero)
+					throw new InvalidOperationException ();
+				return new SwiftProtocolConformanceDescriptor (Marshal.ReadIntPtr (handle));
+			}
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -113,6 +113,7 @@
     <Compile Include="SwiftTypeRegistry.cs" />
     <Compile Include="SwiftIteratorProtocol.cs" />
     <Compile Include="SwiftMarshal\SwiftProtocolConformanceDescriptor.cs" />
+    <Compile Include="SwiftMarshal\SwiftProtocolWitnessTable.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftVersion.mk
+++ b/SwiftVersion.mk
@@ -2,4 +2,4 @@
 SWIFT_BRANCH=swift-5.0-branch-tomswifty
 SWIFT_SCHEME=swift-5.0-branch
 # this hash should be the most recent in the above branch
-SWIFT_HASH=ecf763a5b825fe076906e5e4f3050837f09a9ba1
+SWIFT_HASH=b6d821d3d70df4030fde1e0e2ed0f026d779e034

--- a/SwiftVersion.mk
+++ b/SwiftVersion.mk
@@ -2,4 +2,4 @@
 SWIFT_BRANCH=swift-5.0-branch-tomswifty
 SWIFT_SCHEME=swift-5.0-branch
 # this hash should be the most recent in the above branch
-SWIFT_HASH=b6d821d3d70df4030fde1e0e2ed0f026d779e034
+SWIFT_HASH=ecf763a5b825fe076906e5e4f3050837f09a9ba1

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -13,7 +13,7 @@ namespace SwiftReflector {
 		public void CanGetProtocolConformanceDesc ()
 		{
 			// var nomDesc = SwiftProtocolTypeAttribute.DescriptorForType (typeof (ISwiftIterator<>));
-			// var confDesc = SwiftCore.ConformsToSwiftProtocol (StructMarshal.Marshaler.Metatypeof (typeof (SwiftIteratorProtocolProxy<nint>)),
+			// var witTable = SwiftCore.ConformsToSwiftProtocol (StructMarshal.Marshaler.Metatypeof (typeof (SwiftIteratorProtocolProxy<nint>)),
 			//                                          nomDesc);
 			// Console.WriteLine (confDesc != IntPtr.Zero);
 
@@ -22,15 +22,15 @@ public func canGetProtocolConfDesc () {
 }
 ";
 			var nomDescID = new CSIdentifier ("nomDesc");
-			var confDescID = new CSIdentifier ("confDesc");
+			var witTableID = new CSIdentifier ("witTable");
 
 			var nomDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, nomDescID,
 				new CSFunctionCall ("SwiftProtocolTypeAttribute.DescriptorForType", false, new CSSimpleType ("ISwiftIterator<>").Typeof ()));
 
 			var metaTypeCall = new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, new CSSimpleType ("SwiftIteratorProtocolProxy<nint>").Typeof ());
-			var confDescDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, confDescID,
+			var confDescDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, witTableID,
 				new CSFunctionCall ("SwiftCore.ConformsToSwiftProtocol", false, metaTypeCall, nomDescID));
-			var printer = CSFunctionCall.ConsoleWriteLine (confDescID != new CSIdentifier ("IntPtr.Zero"));
+			var printer = CSFunctionCall.ConsoleWriteLine (witTableID.Dot (new CSIdentifier ("Handle")) != new CSIdentifier ("IntPtr.Zero"));
 
 			var callingCode = CSCodeBlock.Create (nomDecl, confDescDecl, printer);
 


### PR DESCRIPTION
This addresses a couple problems:
`ConformsToSwiftProtocol` was being treated as if it returns a `SwiftProtocolConformanceDescriptor`. In actuality, it returns a `ProtocolWitnessTable`.

I've added a type for the witness table type as well as an accessor to get the protocol conformance descriptor from it. I've updated the test to match that.

I've added a hook to `swift_getAssociatedTypeWitness` to pull the metadata from a conforming type, a protocol witness table, a protocol descriptor, and an index for the associated type.

I've added a wrapper over that to extract the associated types as C# types.
Initial tests were triggering other issues. I'm going to sort those out first.