### PR TITLE
Now handle functions that return `Any.Type`

### DIFF
--- a/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
+++ b/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
@@ -728,7 +728,7 @@ namespace SwiftReflector.Demangling {
 				new MatchRule () {
 					Name = "ExistentialMetatype",
 		    			NodeKind = NodeKind.ExistentialMetatype,
-					Reducer = ConvertFirstChildToSwiftType,
+					Reducer = ConvertToExistentialMetatype,
 		    			MatchChildCount = false
 				},
 				// Probably should be last
@@ -1651,6 +1651,18 @@ namespace SwiftReflector.Demangling {
 				}
 			}
 			return result;
+		}
+
+		SwiftType ConvertToExistentialMetatype (Node node, bool isReference, SwiftName name)
+		{
+			var child = ConvertFirstChildToSwiftType (node, false, name);
+			var childType = child as SwiftProtocolListType;
+			if (child is SwiftClassType classType) {
+				childType = new SwiftProtocolListType (classType, classType.IsReference, classType.Name);
+			}
+			if (childType == null)
+				return null;
+			return new SwiftExistentialMetaType (childType, isReference, null);
 		}
 
 		SwiftType ConvertToGenericFunction (Node node, bool isReference, SwiftName name)

--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -642,6 +642,16 @@ namespace SwiftReflector {
 				}
 			}));
 		}
+
+		public SwiftProtocolListType (SwiftClassType protocol, bool isReference, SwiftName name = null)
+		    : base (CoreCompoundType.ProtocolList, isReference, name)
+		{
+			Protocols = new List<SwiftClassType> ();
+			if (!protocol.IsProtocol)
+				throw new ArgumentOutOfRangeException ($"Type {protocol.ClassName.ToFullyQualifiedName ()} is not a protocol");
+			Protocols.Add (protocol);
+		}
+
 		public List<SwiftClassType> Protocols { get; private set; }
 
 		protected override bool LLEquals (SwiftType other)

--- a/SwiftReflector/XmlToTLFunctionMapper.cs
+++ b/SwiftReflector/XmlToTLFunctionMapper.cs
@@ -338,7 +338,7 @@ namespace SwiftReflector {
 				return TypeMatches (decl, ts, st as SwiftClassType);
 			case CoreCompoundType.MetaClass:
 				if (st is SwiftExistentialMetaType exist)
-					return TypeMatches (decl, ts, st as SwiftExistentialMetaType);
+					return TypeMatches (decl, ts, exist);
 				else
 					return TypeMatches (decl, ts, st as SwiftMetaClassType);
 			case CoreCompoundType.BoundGeneric:

--- a/SwiftReflector/XmlToTLFunctionMapper.cs
+++ b/SwiftReflector/XmlToTLFunctionMapper.cs
@@ -337,7 +337,10 @@ namespace SwiftReflector {
 			case CoreCompoundType.Class:
 				return TypeMatches (decl, ts, st as SwiftClassType);
 			case CoreCompoundType.MetaClass:
-				return TypeMatches (decl, ts, st as SwiftMetaClassType);
+				if (st is SwiftExistentialMetaType exist)
+					return TypeMatches (decl, ts, st as SwiftExistentialMetaType);
+				else
+					return TypeMatches (decl, ts, st as SwiftMetaClassType);
 			case CoreCompoundType.BoundGeneric:
 				return TypeMatches (decl, ts, st as SwiftBoundGenericType);
 			case CoreCompoundType.ProtocolList:
@@ -403,6 +406,25 @@ namespace SwiftReflector {
 			default:
 				throw new ArgumentOutOfRangeException ("st");
 			}
+		}
+
+		static bool TypeMatches (FunctionDeclaration decl, NamedTypeSpec ts, SwiftExistentialMetaType st)
+		{
+			if (st == null)
+				return false;
+			if (st.Protocol.Protocols.Count != 1)
+				return false;
+			var protoClass = st.Protocol.Protocols [0];
+			if (ts.Name == "Any.Type") {
+				return protoClass.ClassName.ToFullyQualifiedName () == "Swift.Any";
+			}
+			if (ts.Name == protoClass.ClassName.ToFullyQualifiedName ())
+				return true;
+			if (ts.Name.EndsWith (".Type", StringComparison.Ordinal)) {
+				var maybeClassName = ts.Name.Substring (0, ts.Name.Length - ".Type".Length);
+				return maybeClassName == protoClass.ClassName.ToFullyQualifiedName ();
+			}
+			return false;
 		}
 
 		static bool TypeMatches (FunctionDeclaration decl, NamedTypeSpec ts, SwiftMetaClassType st)

--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -271,6 +271,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolWitnessTable.cs">
       <Link>SwiftMarshal\SwiftProtocolWitnessTable.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftAssociatedTypeDescriptor.cs">
+      <Link>SwiftMarshal\SwiftAssociatedTypeDescriptor.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -276,6 +276,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftProtocolWitnessTable.cs">
       <Link>SwiftMarshal\SwiftProtocolWitnessTable.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftAssociatedTypeDescriptor.cs">
+      <Link>SwiftMarshal\SwiftAssociatedTypeDescriptor.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="mkdir -p GeneratedCode" />

--- a/SwiftRuntimeLibrary/SwiftCore.cs
+++ b/SwiftRuntimeLibrary/SwiftCore.cs
@@ -369,19 +369,15 @@ namespace SwiftRuntimeLibrary {
 
 		[DllImport (SwiftCoreConstants.LibSwiftCore)]
 		static extern MetadataResponse swift_getAssociatedTypeWitness (SwiftMetadataRequest request, SwiftProtocolWitnessTable witness,
-			SwiftMetatype conformingType, IntPtr conformanceStart, IntPtr conformanceRequest);
+			SwiftMetatype conformingType, IntPtr conformanceBaseDescriptor, IntPtr conformanceRequest);
 
 		internal static SwiftMetatype AssociatedTypeMetadataRequest (SwiftMetatype conformingType, SwiftProtocolWitnessTable witness,
-			SwiftProtocolConformanceDescriptor conformance, int index)
+			IntPtr protocolRequirementsBaseDescriptor, SwiftAssociatedTypeDescriptor assocDesc)
 		{
-			if (conformance.ResilientWitnessCount <= 0 || index >= conformance.ResilientWitnessCount)
-				throw new ArgumentOutOfRangeException (nameof (index));
-			var conformanceStart = conformance.ResilientWitnessPointer (0);
-			var conformanceRequest = conformance.ResilientWitnessPointer (index);
 			var response = swift_getAssociatedTypeWitness (SwiftMetadataRequest.Complete, witness, conformingType,
-				conformanceStart, conformanceRequest);
+				protocolRequirementsBaseDescriptor, assocDesc.Handle);
 			if (response.ResponseState > 1) // 0 and 1 are ok for us
-				throw new SwiftRuntimeException ($"Error retrieving associated type {index} from protocol - returned {response.ResponseState}");
+				throw new SwiftRuntimeException ($"Error retrieving associated type from protocol - returned {response.ResponseState}");
 			return response.Metadata;
 		}
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftAssociatedTypeDescriptor.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftAssociatedTypeDescriptor.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace SwiftRuntimeLibrary.SwiftMarshal {
+	internal enum ProtocolRequirementsKind {
+		BaseProtocol,
+		Method,
+		Init,
+		Getter,
+		Setter,
+		ReadCoroutine,
+		ModifyCoroutine,
+		AssociatedTypeAccessFunction,
+		AssociatedConformanceAccessFunction,
+	}
+
+	internal struct SwiftAssociatedTypeDescriptor {
+		IntPtr handle;
+		public SwiftAssociatedTypeDescriptor (IntPtr handle)
+		{
+			this.handle = handle;
+		}
+		public IntPtr Handle => handle;
+
+		public ProtocolRequirementsKind Kind {
+			get {
+				return (ProtocolRequirementsKind)(Marshal.ReadInt32 (handle) & 0xf);
+			}
+		}
+
+		public bool IsValid {
+			get {
+				return handle != IntPtr.Zero;
+			}
+		}
+
+		public bool IsInstance {
+			get {
+				return (Marshal.ReadInt32 (handle) & 0x10) != 0;
+			}
+		}
+
+		public IntPtr DefaultImplementation {
+			get {
+				var relPtr = handle + sizeof (int);
+				var ptrVal = Marshal.ReadInt32 (relPtr);
+				if (ptrVal == 0)
+					return IntPtr.Zero;
+				return relPtr + ptrVal;
+			}
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftMetatype.cs
+++ b/SwiftRuntimeLibrary/SwiftMetatype.cs
@@ -47,6 +47,14 @@ namespace SwiftRuntimeLibrary {
 			}
 		}
 
+		public bool HasNominalDescriptor
+		{
+			get {
+				return Kind == MetatypeKind.Class || Kind == MetatypeKind.Enum ||
+					Kind == MetatypeKind.Struct;
+			}
+		}
+
 		public SwiftNominalTypeDescriptor GetNominalTypeDescriptor ()
 		{
 			ThrowOnInvalid ();

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -114,6 +114,7 @@
     <Compile Include="SwiftIteratorProtocol.cs" />
     <Compile Include="SwiftMarshal\SwiftProtocolConformanceDescriptor.cs" />
     <Compile Include="SwiftMarshal\SwiftProtocolWitnessTable.cs" />
+    <Compile Include="SwiftMarshal\SwiftAssociatedTypeDescriptor.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/bindings/SwiftCore.xml
+++ b/bindings/SwiftCore.xml
@@ -148,5 +148,8 @@
         <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="SwiftDate" entityType="Struct" blitable="NonBlitable" size="0" stride="0">
         	<typedeclaration kind="struct" name="Foundation.Date" module="Foundation" accessibility="Public" isObjC="false" isFinal="true" />
         </entity>
+        <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="SwiftMetatype" entityType="Scalar" blitable="Blitable" size="8" stride="8">
+            <typedeclaration kind="struct" name="Any.Type" module="Any" accessibility="Public" isObjC="false" isFinal="true" />
+        </entity>
     </entities>
 </xamtypedatabase>

--- a/tests/tom-swifty-test/SwiftReflector/DecomposerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/DecomposerTests.cs
@@ -1050,6 +1050,20 @@ namespace SwiftReflector {
 			Assert.IsNotNull (tlf);
 
 		}
+
+		[Test]
+		public void DecomposeExistentialMetatype ()
+		{
+			var func = "_$s24ProtocolConformanceTests14blindAssocFuncypXpyF";
+			var tlf = Decomposer.Decompose (func, false) as TLFunction;
+			Assert.IsNotNull (tlf, "not a function");
+			var returnType = tlf.Signature.ReturnType as SwiftExistentialMetaType;
+			Assert.IsNotNull (returnType, "not an existential metatype");
+			var protoList = returnType.Protocol;
+			Assert.IsNotNull (protoList, "no protocol list");
+			var proto = protoList.Protocols [0];
+			Assert.AreEqual ("Swift.Any", proto.ClassName.ToFullyQualifiedName (), "class name mismatch");
+		}
 	}
 }
 

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -103,5 +103,44 @@ public func iterateThings (this: iteratorprotocol_xam_helper<Int>) -> String
 
 			TestRunning.TestAndExecute (swiftCode, callingCode, "13 -4 2\n");
 		}
+
+		[Test]
+		public void CanGetAssocTypes ()
+		{
+			var swiftCode = @"
+private class Foo : IteratorProtocol {
+	public init () {
+	}
+	private var x = -1
+	public func next () -> Int? {
+		if x < 5 {
+			x = x + 1
+			return x
+		}
+		else {
+			return nil
+		}
+	}
+}
+public func blindAssocFunc () -> Any.Type {
+	return Foo.self
+}
+";
+			// var any = TopLevelEntities.BlindAssocFunc ();
+			// var types = StructMarshal.Marshaler.GetAssociatedTypes (any, typeof (ISwiftIterator<>), 1);
+			// Console.WriteLine (types[0].Name);
+
+			var anyID = new CSIdentifier ("any");
+			var anyDecl = CSVariableDeclaration.VarLine (anyID, new CSFunctionCall ("TopLevelEntities.BlindAssocFunc", false));
+			var assocTypesID = new CSIdentifier ("assoc");
+			var typesID = new CSIdentifier ("types");
+			var typesDecl = CSVariableDeclaration.VarLine (typesID, new CSFunctionCall ("StructMarshal.Marshaler.GetAssociatedTypes", false,
+				anyID, new CSSimpleType ("ISwiftIterator<>").Typeof (), CSConstant.Val (1)));
+			var printer = CSFunctionCall.ConsoleWriteLine (new CSIndexExpression (typesID, false, CSConstant.Val (0)).Dot (new CSIdentifier ("Name")));
+
+			var callingCode = CSCodeBlock.Create (anyDecl, typesDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "nint\n");
+		}
 	}
 }


### PR DESCRIPTION
Fixed a set of issues around being unable to bind to `Any.Type` fixing issue [178](https://github.com/xamarin/binding-tools-for-swift/issues/178)

This is an interesting issue. The main problem was the functions that return Any.Type don't bind properly, but things went a little deeper than that.
The first issue was that a this function `func someFunc () -> Any.Type` was reported as returning `Any.Type` in the reflection but the demangler only found a version that returns `Swift.Any`.
The problem was that the demangler got an existential metatype node and returned its first child as the type, which is wrong. An existential metatype is the type object of a given swift type.
Past Steve had already created the data structure to hold it so I just needed to wrap the child type into it.
On the far side of this, the type matching code needed to match the named type spec "Any.Type" to  `ExistentialMetatype(Swift.Any)`, so I adjusted the type matching code to handle this. Generally speaking, swift doesn't like you returning specific existential types from a function (Foo.Type), but I put in code to match those as well.
Finally, the static type database now maps `Any.Type` -> `SwiftMetatype`.

For testing a had a function that returns the type of a type that implements `IteratorProtocol`. The type itself is not visible to C# since it is private, so `Metatypeof` won't work. The testing code assumes its a PAT and pulls out the associated types and prints the matching C# type.

In addition, I added a demangling test as well.