### PR TITLE
Fix for returning Swift.Any

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -520,7 +520,7 @@ namespace SwiftReflector {
 					identifiersUsed.Add (returnContainerName);
 					var returnContainerId = new CSIdentifier (returnContainerName);
 					body.Add (CSVariableDeclaration.VarLine (CSSimpleType.Var, returnContainerId, new CSFunctionCall ("SwiftObjectRegistry.Registry.ExistentialContainerForProtocols", false, containerExprs.ToArray ())));
-					body.Add (CSFunctionCall.FunctionCallLine ($"{returnContainerName}.CopyTo", false, delegateParams [0].Name));
+					body.Add (CSFunctionCall.FunctionCallLine ($"{returnContainerName}.CopyTo", false, new CSUnaryExpression (CSUnaryOperator.Ref, delegateParams [0].Name)));
 					
 				} else {
 					if (returnIsClosure) {

--- a/SwiftRuntimeLibrary/ExistentialContainers.cs
+++ b/SwiftRuntimeLibrary/ExistentialContainers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 
@@ -15,7 +16,7 @@ namespace SwiftRuntimeLibrary {
 		int Count { get; }
 		int SizeOf { get; }
 		unsafe IntPtr CopyTo (IntPtr memory);
-		void CopyTo (ISwiftExistentialContainer container);
+		void CopyTo <T>(ref T container) where T : ISwiftExistentialContainer;
 	}
 
 	public struct SwiftExistentialContainer0 : ISwiftExistentialContainer {
@@ -29,6 +30,7 @@ namespace SwiftRuntimeLibrary {
 		public int Count { get { return 0; } }
 		public int SizeOf { get { return (Count + 3) * IntPtr.Size; } }
 
+		// copy into memory
 		public IntPtr CopyTo (IntPtr memory)
 		{
 			Marshal.WriteIntPtr (memory, Data0);
@@ -42,11 +44,13 @@ namespace SwiftRuntimeLibrary {
 			return memory;
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		// copy to another container (of the same size, presumably
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			Copy (this, to);
+			Copy (this, ref to);
 		}
 
+		// copy from a container to memory
 		internal static IntPtr CopyTo (ISwiftExistentialContainer from, IntPtr memory)
 		{
 			Marshal.WriteIntPtr (memory, from.Data0);
@@ -65,18 +69,88 @@ namespace SwiftRuntimeLibrary {
 			return memory;
 		}
 
-		internal static void Copy (ISwiftExistentialContainer from, ISwiftExistentialContainer to)
+		// copy from one container to another implementation
+		internal static void Copy<T> (ISwiftExistentialContainer from, ref T to) where T : ISwiftExistentialContainer
 		{
 			if (from.Count != to.Count)
 				throw new ArgumentOutOfRangeException ($"{nameof (from)} and {nameof (to)} must have matching Count properties");
 			to.Data0 = from.Data0;
 			to.Data1 = from.Data1;
 			to.Data2 = from.Data2;
+			to.ObjectMetadata = from.ObjectMetadata;
 			for (int i = 0; i < from.Count; i++) {
 				to [i] = from [i];
 			}
 		}
+
+		// copy from memory to a container0, used for boxing
+		internal static void CopyTo (IntPtr memoryFrom, ref SwiftExistentialContainer0 to)
+		{
+			to.Data0 = Marshal.ReadIntPtr (memoryFrom);
+			memoryFrom += IntPtr.Size;
+			to.Data1 = Marshal.ReadIntPtr (memoryFrom);
+			memoryFrom += IntPtr.Size;
+			to.Data2 = Marshal.ReadIntPtr (memoryFrom);
+			memoryFrom += IntPtr.Size;
+			to.ObjectMetadata = new SwiftMetatype (Marshal.ReadIntPtr (memoryFrom));
+			memoryFrom += IntPtr.Size;
+
+			for (int i = 0; i < to.Count; i++) {
+				to [i] = Marshal.ReadIntPtr (memoryFrom);
+				memoryFrom += IntPtr.Size;
+			}
+		}
+
 		public const int MaximumContainerSize = 8;
+
+		public unsafe static object Unbox(ISwiftExistentialContainer container)
+		{
+			Type targetType;
+			if (!SwiftTypeRegistry.Registry.TryGetValue (container.ObjectMetadata, out targetType))
+				throw new SwiftRuntimeException ($"Unable to unbox swift type {container.ObjectMetadata.TypeName}.");
+
+			byte* anyPtr = stackalloc byte [container.SizeOf];
+			var anyIntPtr = new IntPtr (anyPtr);
+			CopyTo (container, anyIntPtr);
+
+			byte* resultPtr = stackalloc byte [(int)SwiftCore.StrideOf (container.ObjectMetadata)];
+			var resultIntPtr = new IntPtr (resultPtr);
+			AnyPinvokes.FromAny (resultIntPtr, anyIntPtr, container.ObjectMetadata);
+			return StructMarshal.Marshaler.ToNet (resultIntPtr, targetType);
+		}
+
+		public static T Unbox<T> (ISwiftExistentialContainer container)
+		{
+			var targetType = typeof (T);
+			var obj = Unbox (container);
+			// this shouldn't ever happen, but...
+			if (obj == null)
+				throw new SwiftRuntimeException ($"Unexpected null from unboxing a container of type {container.ObjectMetadata.TypeName}");
+			if (!targetType.IsAssignableFrom (obj.GetType ()))
+				throw new SwiftRuntimeException ($"C# type {targetType.Name} can't be set from actual type {obj.GetType ()}");
+			return (T)obj;
+		}
+
+		public static unsafe SwiftExistentialContainer0 Box (object o)
+		{
+			if (o == null)
+				throw new ArgumentNullException (nameof (o));
+			var mt = StructMarshal.Marshaler.Metatypeof (o.GetType ());
+			SwiftExistentialContainer0 result = new SwiftExistentialContainer0 ();
+			byte* anyPtr = stackalloc byte [result.SizeOf];
+			var anyIntPtr = new IntPtr (anyPtr);
+
+			byte* argPtr = stackalloc byte [StructMarshal.Marshaler.Strideof (o.GetType ())];
+			var argIntPtr = new IntPtr (argPtr);
+
+			StructMarshal.Marshaler.ToSwift (o, argIntPtr);
+
+			AnyPinvokes.ToAny (anyIntPtr, argIntPtr, mt);
+			CopyTo (anyIntPtr, ref result);
+
+			return result;
+		}
+
 	}
 
 	public struct SwiftExistentialContainer1 : ISwiftExistentialContainer {
@@ -140,9 +214,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -178,9 +252,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -218,9 +292,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -260,9 +334,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -304,9 +378,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -350,9 +424,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -398,9 +472,9 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
@@ -448,10 +522,16 @@ namespace SwiftRuntimeLibrary {
 			return SwiftExistentialContainer0.CopyTo (this, memory);
 		}
 
-		public void CopyTo (ISwiftExistentialContainer to)
+		public void CopyTo<T> (ref T to) where T : ISwiftExistentialContainer
 		{
-			SwiftExistentialContainer0.Copy (this, to);
+			SwiftExistentialContainer0.Copy (this, ref to);
 		}
 	}
 
+	internal static class AnyPinvokes {
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.ToAny)]
+		public static extern void ToAny (IntPtr anyPtr, IntPtr argPtr, SwiftMetatype argPtrType);
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.FromAny)]
+		public static extern void FromAny (IntPtr resultPtr, IntPtr anyPtr, SwiftMetatype resultType);
+	}
 }

--- a/SwiftRuntimeLibrary/SwiftMetatype.cs
+++ b/SwiftRuntimeLibrary/SwiftMetatype.cs
@@ -74,6 +74,15 @@ namespace SwiftRuntimeLibrary {
 			throw new NotSupportedException ($"Can't get nominal type descriptor for {kind}");
 		}
 
+		public string TypeName {
+			get {
+				if (!HasNominalDescriptor)
+					return "#Unknown";
+				var nomDesc = GetNominalTypeDescriptor ();
+				return nomDesc.GetFullName ();
+			}
+		}
+
 		#region Classes
 		// Class metadata is TargetClassMetadata
 		// A TargetClassMetadata is:

--- a/bindings/SwiftCore.xml
+++ b/bindings/SwiftCore.xml
@@ -127,7 +127,7 @@
         <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="SwiftAnyObject" entityType="Class" blitable="NonBlitable" size="0" stride="0">
             <typedeclaration kind="class" name="Swift.AnyObject" module="Swift" accessibility="Public" isObjC="false" isFinal="true"  />
         </entity>
-        <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="SwiftAny" entityType="Protocol" blitable="NonBlitable" size="0" stride="0">
+        <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="SwiftExistentialContainer0" entityType="Protocol" blitable="NonBlitable" size="0" stride="0">
             <typedeclaration kind="protocol" name="Swift.Any" module = "Swift" accessitibility="Public" isObjC="false" isFinal="true" />
         </entity>
         <entity sharpNameSpace="SwiftRuntimeLibrary" sharpTypeName="ISwiftHashable" entityType="Protocol" discretionaryConstraint="true" blitable="NonBlitable" size="0" stride="0">

--- a/swiftglue/pointerhelpers.swift
+++ b/swiftglue/pointerhelpers.swift
@@ -154,10 +154,6 @@ public func castAs<T>(retval: UnsafeMutablePointer<T?>, value: Any)
 	retval.initialize(to: value as? T)
 }
 
-public func toAny<T>(retval: UnsafeMutablePointer<Any>, value: T)
-{
-	retval.initialize(to: value)
-}
 
 public func sizeof<T>(_ ignored: T) -> Int
 {

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -604,8 +604,26 @@ public protocol Useless {
 			var getter = CSFunctionCall.FunctionCallLine ("SwiftProtocolTypeAttribute.DescriptorForType", false,
 				new CSSimpleType ("IUseless").Typeof ());
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+		
 			var callingCode = CSCodeBlock.Create (getter, printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
+
+		[Test]
+		public void TestReturnsAny ()
+		{
+			var swiftCode = @"
+public func returnsAny () -> Any {
+	return 7;
+}
+";
+
+			var any = new CSIdentifier ("any");
+			var anyDecl = CSVariableDeclaration.VarLine (any, new CSFunctionCall ("TopLevelEntities.ReturnsAny", false));
+			var unbox = new CSFunctionCall ("SwiftExistentialContainer0.Unbox<nint>", false, any);
+			var printer = CSFunctionCall.ConsoleWriteLine (unbox);
+			var callingCode = CSCodeBlock.Create (anyDecl, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 	}
 }

--- a/tools/symbolicator/XamGlueConstants.cs
+++ b/tools/symbolicator/XamGlueConstants.cs
@@ -299,6 +299,10 @@ namespace SwiftRuntimeLibrary {
 		[SymbolicatorInfo (Skip = true)]
 		internal const string EveryProtocolNew = "$s7XamGlue13EveryProtocolCACycfC";
 
+		// AnyHelpers
+		internal const string ToAny = "$s7XamGlue5toAny6result3valySpyypG_xtlF";
+		internal const string FromAny = "$s7XamGlue7fromAny6result3anyySpyxG_yptlF";
+
 	}
 }
 


### PR DESCRIPTION
Support for binding to functions that return `Swift.Any`, fixing issue [177](https://github.com/xamarin/binding-tools-for-swift/issues/177)

The story:
`Swift.Any` is an empty protocol that is not a protocol. It is essentially a universal box with a payload and metadata describing the type. This corresponds exactly to `SwiftExistentialContainer0`. I consider renaming `SwiftExistentialContainer0` to `SwiftAny`, but decided not to since we have code that depends on types being named `SwiftExistentialContainerN`.

We used to have (incorrect support) for this, but it went away when I refactored protocols.

To do this properly required changing the following:

1. The type DB mapping from `Swift.Any` -> `SwiftExistentialContainer0`
2. The `CopyTo` method needed the target to be by reference otherwise changes don't persist in value types.
3. Minor change in protocol marshaling to special case `Swift.Any` and change it's initializer and the post marshal action.
4. The addition of `Box` and `Unbox` methods to pull out values from existential containers.
5. The addition of a `TypeName` property to `SwiftMetatype` to make better exceptions.

Test, as per usual.