### PR TITLE
[Type-o-Matic] HomeKit and alphabetization

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -40,48 +40,20 @@ namespace SwiftReflector.Importing {
 
 		static partial void TypesToSkipIOS (ref HashSet<string> result) { result = iOSTypesToSkip; }
 		static HashSet<string> iOSTypesToSkip = new HashSet<string> () {
-			"Messages.MSMessagesAppPresentationContext",
-	    		"IntentsUI.INUIAddVoiceShortcutButton",
-			"IdentityLookup.ILClassificationAction",
+			// Accounts
+			"Accounts.ACFacebookAudience",
+			// CoreGraphics
+	    		"CoreGraphics.CGColorConverterTransformType",
+			"CoreGraphics.CGTextEncoding", // Deprecated
+	    		"CoreGraphics.CGImagePixelFormatInfo", // can't find it?
+			"CoreGraphics.CGBitmapFlags", // can't find it
+	    		"CoreGraphics.CGImageColorModel", // can't find it
+			"CoreGraphics.CGColorConverterTriple", // can't find it
+	    		"CoreGraphics.GColorConversionInfoTriple", // can't find it
+			"CoreGraphics.MatrixOrder",
+			// CoreTelephony
 	    		"CoreTelephony.CTErrorDomain",
 	    		"CoreTelephony.CTCellularPlanProvisioningAddPlanResult",
-			"Accounts.ACFacebookAudience",
-	    		"Vision.VNBarcodeObservationRequestRevision",
-			"Vision.VNCoreMLRequestRevision",
-	    		"Vision.VNDetectBarcodesRequestRevision",
-			"Vision.VNDetectedObjectObservationRequestRevision",
-	    		"Vision.VNDetectFaceLandmarksRequestRevision",
-			"Vision.VNDetectFaceRectanglesRequestRevision",
-	    		"Vision.VNDetectHorizonRequestRevision",
-			"Vision.VNDetectRectanglesRequestRevision",
-	    		"Vision.VNDetectTextRectanglesRequestRevision",
-			"Vision.VNFaceObservationRequestRevision",
-	    		"Vision.VNHomographicImageRegistrationRequestRevision",
-			"Vision.VNRecognizedObjectObservationRequestRevision",
-	    		"Vision.VNRectangleObservationRequestRevision",
-			"Vision.VNRequestRevision",
-	    		"Vision.VNTextObservationRequestRevision",
-			"Vision.VNTranslationalImageRegistrationRequestRevision",
-	    		"Vision.VNTrackObjectRequestRevision",
-			"Vision.VNTrackRectangleRequestRevision",
-			"SafariServices.SFSafariViewControllerDismissButtonStyle",
-	    		"IntentsUI.INUIAddVoiceShortcutButtonStyle",
-			"VideoToolbox.VTStatus",
-			"VideoToolbox.VTProfileLevel",
-			"VideoToolbox.VTH264EntropyMode",
-	    		"VideoToolbox.VTFieldCount",
-	    		"VideoToolbox.VTFieldDetail",
-	    		"VideoToolbox.VTColorPrimaries",
-	    		"VideoToolbox.VTFTransferFunction",
-	    		"VideoToolbox.VTFieldCount",
-			"VideoToolbox.VTYCbCrMatrix",
-	    		"VideoToolbox.VTFieldMode",
-			"VideoToolbox.VTDeinterlaceMode",
-	    		"VideoToolbox.VTOnlyTheseFrames",
-			"VideoToolbox.VTPropertyType",
-	    		"VideoToolbox.VTReadWriteStatus",
-	    		"VideoToolbox.VTScalingMode",
-	    		"VideoToolbox.VTDownsamplingMode",
 			// Foundation
 			"Foundation.NSFileType",
 	    		"Foundation.NSUserDefaultsType",
@@ -108,7 +80,23 @@ namespace SwiftReflector.Importing {
 			"Foundation.NSUrlSessionMultipathServiceType",
 	    		"Foundation.NSRunLoopMode",
 			"Foundation.NSTextWritingDirection", // deprecated in 9.0
-	    		// UIKit
+			// HomeKit
+			"HomeKit.HMAccessoryCategoryType", // not an enum
+			"HomeKit.HMActionSetType", // not an enum
+			"HomeKit.HMCharacteristicMetadataFormat", // not an enum
+			"HomeKit.HMCharacteristicMetadataUnits", // not an enum
+			"HomeKit.HMCharacteristicType", // not an enum
+			"HomeKit.HMServiceType", // not an enum
+			// IdentityLookup
+			"IdentityLookup.ILClassificationAction",
+			// IntentsUI
+	    		"IntentsUI.INUIAddVoiceShortcutButton",
+			"IntentsUI.INUIAddVoiceShortcutButtonStyle",
+			// Messages
+			"Messages.MSMessagesAppPresentationContext",
+			// SafariServices
+			"SafariServices.SFSafariViewControllerDismissButtonStyle",
+			// UIKit
 			"UIKit.UIAccessibilityPostNotification", // method in swift - not needed.
 	    		"UIKit.UIFontDescriptorAttribute",
 			"UIKit.NSTextEffect",
@@ -133,22 +121,42 @@ namespace SwiftReflector.Importing {
 			"UIKit.UITransitionViewControllerKind", // can't find it?
 	    		"UIKit.UIUserInterfaceStyle", // can't find it?
 			"UIKit.UIUserNotificationActionContext", // deprecated
-			// CoreGraphics
-	    		"CoreGraphics.CGColorConverterTransformType",
-			"CoreGraphics.CGTextEncoding", // Deprecated
-	    		"CoreGraphics.CGImagePixelFormatInfo", // can't find it?
-			"CoreGraphics.CGBitmapFlags", // can't find it
-	    		"CoreGraphics.CGImageColorModel", // can't find it
-			"CoreGraphics.CGColorConverterTriple", // can't find it
-	    		"CoreGraphics.GColorConversionInfoTriple", // can't find it
-			"CoreGraphics.MatrixOrder",
-			// HomeKit
-			"HomeKit.HMAccessoryCategoryType", // not an enum
-			"HomeKit.HMActionSetType", // not an enum
-			"HomeKit.HMCharacteristicMetadataFormat", // not an enum
-			"HomeKit.HMCharacteristicMetadataUnits", // not an enum
-			"HomeKit.HMCharacteristicType", // not an enum
-			"HomeKit.HMServiceType", // not an enum
+			// VideoToolbox
+			"VideoToolbox.VTStatus",
+			"VideoToolbox.VTProfileLevel",
+			"VideoToolbox.VTH264EntropyMode",
+	    		"VideoToolbox.VTFieldCount",
+	    		"VideoToolbox.VTFieldDetail",
+	    		"VideoToolbox.VTColorPrimaries",
+	    		"VideoToolbox.VTFTransferFunction",
+	    		"VideoToolbox.VTFieldCount",
+			"VideoToolbox.VTYCbCrMatrix",
+	    		"VideoToolbox.VTFieldMode",
+			"VideoToolbox.VTDeinterlaceMode",
+	    		"VideoToolbox.VTOnlyTheseFrames",
+			"VideoToolbox.VTPropertyType",
+	    		"VideoToolbox.VTReadWriteStatus",
+	    		"VideoToolbox.VTScalingMode",
+	    		"VideoToolbox.VTDownsamplingMode",
+			// Vision
+	    		"Vision.VNBarcodeObservationRequestRevision",
+			"Vision.VNCoreMLRequestRevision",
+	    		"Vision.VNDetectBarcodesRequestRevision",
+			"Vision.VNDetectedObjectObservationRequestRevision",
+	    		"Vision.VNDetectFaceLandmarksRequestRevision",
+			"Vision.VNDetectFaceRectanglesRequestRevision",
+	    		"Vision.VNDetectHorizonRequestRevision",
+			"Vision.VNDetectRectanglesRequestRevision",
+	    		"Vision.VNDetectTextRectanglesRequestRevision",
+			"Vision.VNFaceObservationRequestRevision",
+	    		"Vision.VNHomographicImageRegistrationRequestRevision",
+			"Vision.VNRecognizedObjectObservationRequestRevision",
+	    		"Vision.VNRectangleObservationRequestRevision",
+			"Vision.VNRequestRevision",
+	    		"Vision.VNTextObservationRequestRevision",
+			"Vision.VNTranslationalImageRegistrationRequestRevision",
+	    		"Vision.VNTrackObjectRequestRevision",
+			"Vision.VNTrackRectangleRequestRevision",
 		};
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -141,7 +141,14 @@ namespace SwiftReflector.Importing {
 	    		"CoreGraphics.CGImageColorModel", // can't find it
 			"CoreGraphics.CGColorConverterTriple", // can't find it
 	    		"CoreGraphics.GColorConversionInfoTriple", // can't find it
-			"CoreGraphics.MatrixOrder"
+			"CoreGraphics.MatrixOrder",
+			// HomeKit
+			"HomeKit.HMAccessoryCategoryType", // not an enum
+			"HomeKit.HMActionSetType", // not an enum
+			"HomeKit.HMCharacteristicMetadataFormat", // not an enum
+			"HomeKit.HMCharacteristicMetadataUnits", // not an enum
+			"HomeKit.HMCharacteristicType", // not an enum
+			"HomeKit.HMServiceType", // not an enum
 		};
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }
@@ -384,6 +391,9 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIDocumentBrowserViewControllerBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
 	    		{ "UIKit.UIDocumentBrowserImportMode", "UIDocumentBrowserViewController.ImportMode" },
 			{ "UIKit.UIDocumentBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
+			// HomeKit
+			{ "HomeKit.HMCharacteristicValueAirParticulate", "HMCharacteristicValueAirParticulateSize" },
+			{ "HomeKit.HMCharacteristicValueLockMechanism", "HMCharacteristicValueLockMechanismLastKnownAction" }
 		};
 	}
 }

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -161,12 +161,6 @@ namespace SwiftReflector.Importing {
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }
 		static Dictionary<string, string> iOSTypeNamesToMap = new Dictionary<string, string> {
-			{ "SafariServices.SFErrorCode", "SFError.Code" },
-			{ "LocalAuthentication.LAStatus", "LAError" },
-			{ "WatchConnectivity.WCErrorCode", "WCError.Code" },
-			{ "WebKit.WKErrorCode", "WKError.Code" },
-			{ "UserNotifications.UNErrorCode", "UNError.Code" },
-			{ "SystemConfiguration.NetworkReachabilityFlags", "SCNetworkReachabilityFlags" },
 	    		// Foundation
 			{ "Foundation.NSBundle", "Bundle" },
 			{ "Foundation.NSCalendarType", "NSCalendar.Identifier" },
@@ -267,9 +261,15 @@ namespace SwiftReflector.Importing {
 			// HomeKit
 			{ "HomeKit.HMCharacteristicValueAirParticulate", "HMCharacteristicValueAirParticulateSize" },
 			{ "HomeKit.HMCharacteristicValueLockMechanism", "HMCharacteristicValueLockMechanismLastKnownAction" },
+			// LocalAuthentication
+			{ "LocalAuthentication.LAStatus", "LAError" },
+			// SafariServices
+			{ "SafariServices.SFErrorCode", "SFError.Code" },
 			// StoreKit
 			{ "StoreKit.SKProductDiscountPaymentMode", "SKProductDiscount.PaymentMode" },
 			{ "StoreKit.SKProductPeriodUnit", "SKProduct.PeriodUnit" },
+			// SystemConfiguration
+			{ "SystemConfiguration.NetworkReachabilityFlags", "SCNetworkReachabilityFlags" },
 			// UIKit
 			{ "UIKit.NSControlCharacterAction", "NSLayoutManager.ControlCharacterAction" },
 			{ "UIKit.NSGlyphProperty", "NSLayoutManager.GlyphProperty" },
@@ -408,6 +408,12 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIDocumentBrowserViewControllerBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
 	    		{ "UIKit.UIDocumentBrowserImportMode", "UIDocumentBrowserViewController.ImportMode" },
 			{ "UIKit.UIDocumentBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
+			// UserNotifications
+			{ "UserNotifications.UNErrorCode", "UNError.Code" },
+			// WatchConnectivity
+			{ "WatchConnectivity.WCErrorCode", "WCError.Code" },
+			// WebKit
+			{ "WebKit.WKErrorCode", "WKError.Code" },
 		};
 	}
 }

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -13,7 +13,7 @@ BINDIR=bin
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics --namespace=HomeKit > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 bindingmetadata.macos.swift:


### PR DESCRIPTION
Adds type name maps for namespace.

Note that in this case 6 enum types defined in the Xamarin iOS SDK are skipped; this is because there are no corresponding enums provided by Apple. Rather, they have pages in their documentation collecting all the global variables, but no enumeration. The pertinent enums and their corresponding Apple documentation pages are [HMAccessoryCategoryType](https://developer.apple.com/documentation/homekit/hmaccessorycategory/accessory_category_types), [HMActionSetType](https://developer.apple.com/documentation/homekit/hmactionset/action_set_types), [HMCharacteristicMetadataFormat](https://developer.apple.com/documentation/homekit/hmcharacteristicmetadata/characteristic_data_formats), [HMCharacteristicMetadataUnits](https://developer.apple.com/documentation/homekit/hmcharacteristicmetadata/characteristic_units), [HMCharacteristicType](https://developer.apple.com/documentation/homekit/hmcharacteristic/characteristic_types), and [HMServiceType](https://developer.apple.com/documentation/homekit/hmservice/accessory_service_types).