### PR TITLE
[Type-o-Matic] PdfKit

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -96,6 +96,8 @@ namespace SwiftReflector.Importing {
 			"Messages.MSMessagesAppPresentationContext",
 			// PassKit
 			"PassKit.PKErrorCode", // does not exist
+			// PdfKit
+			"PdfKit.PdfPrintScalingMode", // macOS only
 			// SafariServices
 			"SafariServices.SFSafariViewControllerDismissButtonStyle",
 			// UIKit
@@ -123,8 +125,6 @@ namespace SwiftReflector.Importing {
 			"UIKit.UITransitionViewControllerKind", // can't find it?
 	    		"UIKit.UIUserInterfaceStyle", // can't find it?
 			"UIKit.UIUserNotificationActionContext", // deprecated
-			// PdfKit
-			"PdfKit.PdfPrintScalingMode", // macOS only
 			// VideoToolbox
 			"VideoToolbox.VTStatus",
 			"VideoToolbox.VTProfileLevel",

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -141,7 +141,9 @@ namespace SwiftReflector.Importing {
 	    		"CoreGraphics.CGImageColorModel", // can't find it
 			"CoreGraphics.CGColorConverterTriple", // can't find it
 	    		"CoreGraphics.GColorConversionInfoTriple", // can't find it
-			"CoreGraphics.MatrixOrder"
+			"CoreGraphics.MatrixOrder",
+			// PdfKit
+			"PdfKit.PdfPrintScalingMode", // macOS only
 		};
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }
@@ -384,6 +386,27 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIDocumentBrowserViewControllerBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
 	    		{ "UIKit.UIDocumentBrowserImportMode", "UIDocumentBrowserViewController.ImportMode" },
 			{ "UIKit.UIDocumentBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
+			// PdfKit
+			{ "PDFKit.PdfActionNamedName", "PDFActionNamedName" },
+			{ "PDFKit.PdfAnnotationHighlightingMode", "PDFAnnotationHighlightingMode" },
+			{ "PDFKit.PdfAnnotationKey", "PDFAnnotationKey" },
+			{ "PDFKit.PdfAnnotationLineEndingStyle", "PDFAnnotationLineEndingStyle" },
+			{ "PDFKit.PdfAnnotationSubtype", "PDFAnnotationSubtype" },
+			{ "PDFKit.PdfAnnotationTextIconType", "PDFAnnotationTextIconType" },
+			{ "PDFKit.PdfAnnotationWidgetSubtype", "PDFAnnotationWidgetSubtype" },
+			{ "PDFKit.PdfAreaOfInterest", "PDFAreaOfInterest" },
+			{ "PDFKit.PdfBorderStyle", "PDFBorderStyle" },
+			{ "PDFKit.PdfDisplayBox", "PDFDisplayBox" },
+			{ "PDFKit.PdfDisplayDirection", "PDFDisplayDirection" },
+			{ "PDFKit.PdfDisplayMode", "PDFDisplayMode" },
+			{ "PDFKit.PdfDocumentPermissions", "PDFDocumentPermissions" },
+			{ "PDFKit.PdfInterpolationQuality", "PDFInterpolationQuality" },
+			{ "PDFKit.PdfLineStyle", "PDFLineStyle" },
+			{ "PDFKit.PdfMarkupType", "PDFMarkupType" },
+			{ "PDFKit.PdfTextAnnotationIconType", "PDFTextAnnotationIconType" },
+			{ "PDFKit.PdfThumbnailLayoutMode", "PDFThumbnailLayoutMode" },
+			{ "PDFKit.PdfWidgetCellState", "PDFWidgetCellState" },
+			{ "PDFKit.PdfWidgetControlType", "PDFWidgetControlType" },
 		};
 	}
 }

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -13,7 +13,7 @@ BINDIR=bin
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics --namespace=PdfKit > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 bindingmetadata.macos.swift:


### PR DESCRIPTION
Adds type name maps for PdfKit.

Note that the differences in capitalization are essential; in the `iOSTypesToSkip` set it must be written `PdfKit`, but in the `iOSTypeNamesToMap` dictionary it must be written `PDFKit`.