### PR TITLE
[Type-o-Matic] iAd

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -446,7 +446,7 @@ namespace SwiftReflector.Importing {
 			// WatchConnectivity
 			{ "WatchConnectivity.WCErrorCode", "WCError.Code" },
 			// WatchKit
-			{ "WatchKit.WKErrorCode", "WatchKitError.Code" },
+			{ "WatchKit.WKErrorCode", "WKError.Code" },
 			// WebKit
 			{ "WebKit.WKErrorCode", "WKError.Code" },
 		};

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -13,7 +13,7 @@ BINDIR=bin
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics --namespace=iAd > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 bindingmetadata.macos.swift:


### PR DESCRIPTION
Adds iAd to list of namespaces to include. Does not require any new type name maps.

Note that the following types are deprecated (in iOS 10.0), but left in by this change: 
 - `ADAdType`
 - `ADError`
 - `ADInterstitialPresentationPolicy`
They are left to give users the benefit of the doubt, per @stephen-hawley's advice. 