### PR TITLE
[Type-o-Matic] AddressBook

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -141,7 +141,13 @@ namespace SwiftReflector.Importing {
 	    		"CoreGraphics.CGImageColorModel", // can't find it
 			"CoreGraphics.CGColorConverterTriple", // can't find it
 	    		"CoreGraphics.GColorConversionInfoTriple", // can't find it
-			"CoreGraphics.MatrixOrder"
+			"CoreGraphics.MatrixOrder",
+			// AddressBook
+			"AddressBook.ABAddressBookError", // not an enum
+			"AddressBook.ABPersonKind", // not an enum
+			"AddressBook.ABPersonProperty", // not an enum
+			"AddressBook.ABPersonSortBy", // not an enum
+			"AddressBook.ABSourceProperty", // not an enum
 		};
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -13,7 +13,7 @@ BINDIR=bin
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics --namespace=AddressBook --namespace=AddressBookUI > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 bindingmetadata.macos.swift:


### PR DESCRIPTION
Adds type name maps for AddressBook and AddressBookUI. 

Note that we skip several smart enums in Xamarin, which are not actually enums in Apple's API: [ABAddressBookError](https://developer.apple.com/documentation/addressbook/addressbook_enumerations/1622007-address_book_errors), ABPersonKind, [ABPersonProperty](https://developer.apple.com/documentation/addressbook/address_book_constants/default_person_properties), and [ABPersonSortBy](https://developer.apple.com/documentation/addressbook/addressbook_enumerations/1619730-sort_order).

We don't skip several enums which are deprecated (in iOS 9.0): 
 - `ABAuthorizationStatus`
 - `ABPersonCompositeNameFormat`
 - `ABPersonImageFormat`
 - `ABPropertyType`
 - `ABRecordType`
 - `ABSourceType`