### PR TITLE
[Type-o-Matic] Refactor Makefile to use variable for namespaces

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -10,14 +10,22 @@ clean:
 
 MODULENAME=XamGlue
 BINDIR=bin
+MAC_NAMESPACES= 						\
+	Foundation 							\
+
+IOS_NAMESPACES= 						\
+	AddressBook							\
+	CoreGraphics 						\
+	Foundation 							\
+	UIKit 								\
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone --namespace=Foundation --namespace=UIKit --namespace=CoreGraphics > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=iphone $(addprefix --namespace=, $(IOS_NAMESPACES)) > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 bindingmetadata.macos.swift:
-	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=mac --namespace=Foundation > $@.tmp)
+	$(Q) $(shell $(TYPE_O_MATIC) --swift-lib-path=$(UNPACKAGED_SWIFTLIB) --platform=mac $(addprefix --namespace=, $(MAC_NAMESPACES)) > $@.tmp)
 	$(Q) echo "" >> $@.tmp
 	$(Q) mv $@.tmp $@
 

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -10,14 +10,14 @@ clean:
 
 MODULENAME=XamGlue
 BINDIR=bin
-MAC_NAMESPACES= 						\
-	Foundation 							\
+MAC_NAMESPACES= \
+	Foundation \
 
-IOS_NAMESPACES= 						\
-	AddressBook							\
-	CoreGraphics 						\
-	Foundation 							\
-	UIKit 								\
+IOS_NAMESPACES= \
+	AddressBook	\
+	CoreGraphics \
+	Foundation \
+	UIKit \
 
 # this creates a bindings file for type metadata
 bindingmetadata.iphone.swift:


### PR DESCRIPTION
Replaced repetitive `--namespace=` tags with variable. Uses the [make `addprefix` function](http://www.gnu.org/software/make/manual/make.html#index-addprefix) to add the `--namespace=` prefix to each namespace listed in `IOS_NAMESPACES` and `MAC_NAMESPACES`. This change will make the merge conflicts from all the other Type-o-Matic PR's much easier to handle.