### PR TITLE
[Type-o-Matic] Remove AddressBook namespace

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -14,7 +14,6 @@ MAC_NAMESPACES= \
 	Foundation \
 
 IOS_NAMESPACES= \
-	AddressBook	\
 	CoreGraphics \
 	Foundation \
 	UIKit \


### PR DESCRIPTION
Accidentally left in the `AddressBook` namespace I had for testing. This PR just removes this one line