### PR TITLE
[Type-o-Matic] Fix collisions between functions in different namespaces

### DIFF
--- a/type-o-matic/Program.cs
+++ b/type-o-matic/Program.cs
@@ -176,7 +176,7 @@ namespace typeomatic {
 			// Used to be MetaDataWrapperFor
 	    		// The size of this symbol gets magnified by the number of types.
 			// Removing 14 characters saves ~32K
-			return $"MDW_{type.Name}";
+			return $"MDW_{type.Namespace}_{type.Name}";
 		}
 
 		// for debugging


### PR DESCRIPTION
Adds namespace to the name of type definition functions, so `public func MDW_WKErrorCode()` would now be `public func MDW_WatchKit_WKErrorCode()`. Solves the collisions problem, without a massive space penalty (`bindingmetadata.iphone.swift` was 79 KB before the change, 84 KB after, a change of less than 7%). Fixes #216.