### PR TITLE
[Type-o-Matic] AssetsLibrary

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -48,6 +48,9 @@ namespace SwiftReflector.Importing {
 			"AddressBook.ABPersonProperty", // not an enum
 			"AddressBook.ABPersonSortBy", // not an enum
 			"AddressBook.ABSourceProperty", // not an enum
+			// AssetsLibrary
+			"AssetsLibrary.ALAssetsError", // not an enum
+			"AssetsLibrary.ALAssetType", // not an enum
 			// CoreGraphics
 	    		"CoreGraphics.CGColorConverterTransformType",
 			"CoreGraphics.CGTextEncoding", // Deprecated

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -18,6 +18,7 @@ IOS_NAMESPACES= \
 	AddressBook \
 	AddressBookUI \
 	AdSupport \
+	AssetsLibrary \
 	CoreGraphics \
 	Foundation \
 	HealthKit \


### PR DESCRIPTION
Adds type name maps for AssetsLibrary.

Note that we skip two smart enums in Xamarin, which are not actually enums in Apple's API: [ALAssetsError](https://developer.apple.com/documentation/assetslibrary/alassetslibrary/1617912-error_codes) and [ALAssetType](https://developer.apple.com/documentation/assetslibrary/assetslibrary_constants)

We don't skip the enums which are deprecated (in iOS 9.0):
 - `ALAssetOrientation`
 - `ALAssetsGroupType`
 - `ALAuthorizationStatus`
