### PR TITLE
[Type-o-Matic] AudioToolbox

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -87,7 +87,7 @@ namespace SwiftReflector.Importing {
 			"AudioToolbox.MusicPlayerStatus", // can't find it
 			"AudioToolbox.SmpteTime", // wrong namespace
 			"AudioToolbox.SmpteTimeFlags", // wrong namespace
-			"AudioToolbox.SmpteTimeType",
+			"AudioToolbox.SmpteTimeType", // wrong namespace
 			// CoreGraphics
 	    		"CoreGraphics.CGColorConverterTransformType",
 			"CoreGraphics.CGTextEncoding", // Deprecated

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -51,6 +51,43 @@ namespace SwiftReflector.Importing {
 			// AssetsLibrary
 			"AssetsLibrary.ALAssetsError", // not an enum
 			"AssetsLibrary.ALAssetType", // not an enum
+			// AudioToolbox
+			"AudioToolbox.AudioCodecComponentType", // not an enum
+			"AudioToolbox.AudioConverterError", // not an enum
+			"AudioToolbox.AudioConverterPrimeMethod", // not an enum
+			"AudioToolbox.AudioConverterQuality", // not an enum
+			"AudioToolbox.AudioConverterSampleRateConverterComplexity", // not an enum
+			"AudioToolbox.AudioFileChunkType", // can't find it
+			"AudioToolbox.AudioFileError", // not an enum
+			"AudioToolbox.AudioFileLoopDirection", // not an enum
+			"AudioToolbox.AudioFileMarkerType", // not an enum
+			"AudioToolbox.AudioFileProperty", // not an enum
+			"AudioToolbox.AudioFileStreamProperty", // not an enum
+			"AudioToolbox.AudioFileStreamStatus", // can't find it
+			"AudioToolbox.AudioFileType", // not an enum
+			"AudioToolbox.AudioFormatError", // not an enum
+			"AudioToolbox.AudioFormatType", // can't find it
+			"AudioToolbox.AudioQueueDeviceProperty", // not an enum
+			"AudioToolbox.AudioQueueHardwareCodecPolicy", // not an enum
+			"AudioToolbox.AudioQueueParameter", // not an enum
+			"AudioToolbox.AudioQueueProperty", // not an enum
+			"AudioToolbox.AudioQueueStatus", // can't find it
+			"AudioToolbox.AudioQueueTimePitchAlgorithm", // not an enum
+			"AudioToolbox.AudioServicesError", // can't find it
+			"AudioToolbox.AudioSessionActiveFlags", // not an enum
+			"AudioToolbox.AudioSessionCategory", // not an enum
+			"AudioToolbox.AudioSessionErrors", // not an enum
+			"AudioToolbox.AudioSessionInputRouteKind", // not an enum, not in Swift
+			"AudioToolbox.AudioSessionInterruptionState", // not an enum
+			"AudioToolbox.AudioSessionMode", // not an enum
+			"AudioToolbox.AudioSessionOutputRouteKind", // not an enum, not in Swift
+			"AudioToolbox.AudioSessionProperty", // not an enum
+			"AudioToolbox.AudioSessionRouteChangeReason", // not an enum
+			"AudioToolbox.AudioSessionRoutingOverride", // not an enum
+			"AudioToolbox.MusicPlayerStatus", // can't find it
+			"AudioToolbox.SmpteTime", // wrong namespace
+			"AudioToolbox.SmpteTimeFlags", // wrong namespace
+			"AudioToolbox.SmpteTimeType",
 			// CoreGraphics
 	    		"CoreGraphics.CGColorConverterTransformType",
 			"CoreGraphics.CGTextEncoding", // Deprecated
@@ -174,6 +211,15 @@ namespace SwiftReflector.Importing {
 
 		static partial void TypeNamesToMapIOS (ref Dictionary <string, string> result) { result = iOSTypeNamesToMap; }
 		static Dictionary<string, string> iOSTypeNamesToMap = new Dictionary<string, string> {
+			// AudioToolbox
+			{ "AudioToolbox.AudioChannelBit", "AudioChannelBitmap" },
+			{ "AudioToolbox.AudioFilePermission", "AudioFilePermissions" },
+			{ "AudioToolbox.AudioFileSmpteTime", "AudioFile_SMPTE_Time" },
+			{ "AudioToolbox.AudioFileStreamPropertyFlag", "AudioFileStreamPropertyFlags" },
+			{ "AudioToolbox.AudioFormat", "AudioFormatListItem" },
+			{ "AudioToolbox.MidiChannelMessage", "MIDIChannelMessage" },
+			{ "AudioToolbox.MidiNoteMessage", "MIDINoteMessage" },
+			{ "AudioToolbox.PanningMode", "AudioPanningMode" },
 	    		// Foundation
 			{ "Foundation.NSBundle", "Bundle" },
 			{ "Foundation.NSCalendarType", "NSCalendar.Identifier" },

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -19,6 +19,7 @@ IOS_NAMESPACES= \
 	AddressBookUI \
 	AdSupport \
 	AssetsLibrary \
+	AudioToolbox \
 	CoreGraphics \
 	Foundation \
 	HealthKit \


### PR DESCRIPTION
Adds type name maps for AudioToolbox.

We skip several smart enums in Xamarin, which are not enums in Apple's API:
 - [AudioCodecComponentType](https://developer.apple.com/documentation/audiotoolbox/audio_format_services/1494086-audio_codec_component_constants)
 - [AudioConverterError](https://developer.apple.com/documentation/audiotoolbox/audio_converter_services)
 - [AudioConverterPrimeMethod](https://developer.apple.com/documentation/audiotoolbox/audio_converter_services/1559927-converter_priming_constants)
 - [AudioConverterQuality](https://developer.apple.com/documentation/audiotoolbox/audio_converter_services/1559924-sample_rate_conversion_quality_i)
 - [AudioConverterSampleRateConverterComplexity](https://developer.apple.com/documentation/audiotoolbox/audio_converter_services/1559923-sample_rate_conversion_complexit)
 - [AudioFileError](https://developer.apple.com/documentation/audiotoolbox/audio_file_services#1654968)
 - [AudioFileLoopDirection](https://developer.apple.com/documentation/audiotoolbox/audio_file_services/1576494-audio_file_loop_direction_consta)
 - [AudioFileMarkerType](https://developer.apple.com/documentation/audiotoolbox/audio_file_services/1576492-audio_file_marker_types)
 - [AudioFileProperty](https://developer.apple.com/documentation/audiotoolbox/audio_file_services/1576499-audio_file_properties)
 - [AudioFileStreamProperty](https://developer.apple.com/documentation/audiotoolbox/audio_file_stream_services/1391506-audio_file_stream_properties)
 - [AudioFileType](https://developer.apple.com/documentation/audiotoolbox/audiofiletypeid#topics)
 - [AudioFormatError](https://developer.apple.com/documentation/audiotoolbox/audio_format_services)
 - [AudioQueueDeviceProperty](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1552629-anonymous)
 - [AudioQueueHardwareCodecPolicy](https://developer.apple.com/documentation/audiotoolbox/audio_queue_services/1618724-hardware_codec_policy_keys)
 - [AudioQueueParameter](https://developer.apple.com/documentation/audiotoolbox/audio_queue_services/1552626-audio_queue_parameters)
 - [AudioQueueProperty](https://developer.apple.com/documentation/audiotoolbox/audioqueuepropertyid)
 - [AudioQueueTimePitchAlgorithm](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1552630-anonymous)
 - [AudioSessionActiveFlags](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618357-audio_session_activation_flags)
 - [AudioSessionCategory](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618427-audio_session_categories)
 - [AudioSessionErrors](https://developer.apple.com/documentation/audiotoolbox/audio_session_services#1670127)
 - [AudioSessionInterruptionState](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618425-audio_session_interruption_state)
 - [AudioSessionMode](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618405-audio_session_modes)
 - [AudioSessionProperty](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618455-audio_session_property_identifie)
 - [AudioSessionRouteChangeReason](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618380-audio_route_change_reasons)
 - [AudioSessionRoutingOverride](https://developer.apple.com/documentation/audiotoolbox/audio_session_services/1618372-audio_session_category_route_ove)