### PR TITLE
[Type-o-Matic] AudioUnit

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -88,6 +88,30 @@ namespace SwiftReflector.Importing {
 			"AudioToolbox.SmpteTime", // wrong namespace
 			"AudioToolbox.SmpteTimeFlags", // wrong namespace
 			"AudioToolbox.SmpteTimeType", // wrong namespace
+			// AudioUnit
+			"AudioUnit.AudioCodecManufacturer", // not an enum
+			"AudioUnit.AudioComponentManufacturerType", // can't find it
+			"AudioUnit.AudioComponentStatus", // can't find it
+			"AudioUnit.AudioComponentType", // can't find it
+			"AudioUnit.AudioObjectPropertyElement", // not an enum
+			"AudioUnit.AudioObjectPropertyScope", // wrong namespace
+			"AudioUnit.AudioObjectPropertySelector", // wrong namespace
+			"AudioUnit.AudioTypeConverter", // not an enum
+			"AudioUnit.AudioTypeEffect", // not an enum
+			"AudioUnit.AudioTypeGenerator", // not an enum
+			"AudioUnit.AudioTypeMixer", // not an enum
+			"AudioUnit.AudioTypeMusicDevice", // not an enum
+			"AudioUnit.AudioTypeOutput", // not an enum
+			"AudioUnit.AudioTypePanner", // unimplemented
+			"AudioUnit.AudioUnitClumpID", // not an enum
+			"AudioUnit.AudioUnitParameterType", // can't find it
+			"AudioUnit.AudioUnitPropertyIDType", // not an enum
+			"AudioUnit.AudioUnitScopeType", // not an enum
+			"AudioUnit.AudioUnitStatus", // can't find it
+			"AudioUnit.AudioUnitSubType", // not an enum
+			"AudioUnit.AUGraphError", // not an enum
+			"AudioUnit.ExtAudioFileError", // not an enum
+			"AudioUnit.InstrumentType", // not an enum
 			// CoreGraphics
 	    		"CoreGraphics.CGColorConverterTransformType",
 			"CoreGraphics.CGTextEncoding", // Deprecated
@@ -220,6 +244,13 @@ namespace SwiftReflector.Importing {
 			{ "AudioToolbox.MidiChannelMessage", "MIDIChannelMessage" },
 			{ "AudioToolbox.MidiNoteMessage", "MIDINoteMessage" },
 			{ "AudioToolbox.PanningMode", "AudioPanningMode" },
+			// AudioUnit
+			{ "AudioUnit.AudioComponentFlag", "AudioComponentFlags" },
+			{ "AudioUnit.AudioUnitBusType", "AUAudioUnitBusType" },
+			{ "AudioUnit.AudioUnitParameterFlag", "AudioUnitParameterOptions" },
+			{ "AudioUnit.ScheduledAudioSliceFlag", "AUScheduledAudioSliceFlags" },
+			{ "AudioUnit.SpatialMixerAttenuation", "AUSpatialMixerAttenuationCurve" },
+			{ "AudioUnit.SpatialMixerRenderingFlags", "AUSpatialMixerRenderingFlags" },
 	    		// Foundation
 			{ "Foundation.NSBundle", "Bundle" },
 			{ "Foundation.NSCalendarType", "NSCalendar.Identifier" },

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -20,6 +20,7 @@ IOS_NAMESPACES= \
 	AdSupport \
 	AssetsLibrary \
 	AudioToolbox \
+	AudioUnit \
 	CoreGraphics \
 	Foundation \
 	HealthKit \


### PR DESCRIPTION
Adds type name maps for AudioUnit.

Note that we skip several smart enums in Xamarin, which are not actually enums in Apple's API:
 - [AudioCodecManufacturer](https://developer.apple.com/documentation/audiotoolbox/audio_format_services/1620448-audio_codec_manufacturer_and_imp)
 - [AudioTypeConverter](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1584145-converter_audio_unit_subtypes)
 - [AudioTypeEffect](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1584154-effect_audio_unit_subtypes)
 - [AudioTypeGenerator](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1619493-generator_audio_unit_subtypes)
 - [AudioTypeMixer](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1584150-mixer_audio_unit_subtypes)
 - [AudioTypeMusicDevice](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1584149-music_instrument_audio_unit_subt)
 - [AudioTypeOutput](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1584139-input_output_audio_unit_subtypes)
 - [AudioUnitClumpID](https://developer.apple.com/documentation/audiounit/audio_unit_properties/1533986-reserved_audio_unit_clump_identi)
 - [AudioUnitPropertyIDType](https://developer.apple.com/documentation/audiounit/audio_unit_properties/1534199-generic_audio_unit_properties)
 - [AudioUnitScopeType](https://developer.apple.com/documentation/audiounit/audio_unit_properties/1534214-audio_unit_scopes)
 - [AUGraphError](https://developer.apple.com/documentation/audiotoolbox/audio_unit_processing_graph_services#1670140)
 - [ExtAudioFileError](https://developer.apple.com/documentation/audiotoolbox/extended_audio_file_services#1665113)
 - [InstrumentType](https://developer.apple.com/documentation/audiotoolbox/audiotoolbox_enumerations/1534202-anonymous)
