### PR TITLE
Reactivated failing test, added test cases, adjusted incorrect failure language

### DIFF
--- a/SwiftVersion.mk
+++ b/SwiftVersion.mk
@@ -2,4 +2,4 @@
 SWIFT_BRANCH=swift-5.0-branch-tomswifty
 SWIFT_SCHEME=swift-5.0-branch
 # this hash should be the most recent in the above branch
-SWIFT_HASH=b8f5051e09df883a099b72665bafea3f837b138c
+SWIFT_HASH=872054a463ffb15b7a45a5c2cdab643d0c04424b

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1086,13 +1086,13 @@ public protocol HoldsThing {
 			var assoc = protocol.AssociatedTypes [0];
 			Assert.AreEqual ("Thing", assoc.Name, "wrong name");
 			Assert.AreEqual (1, assoc.ConformingProtocols.Count, "wrong number of conf");
+			Assert.AreEqual ("Swift.IteratorProtocol", assoc.ConformingProtocols [0].ToString ());
 			Assert.IsNull (assoc.SuperClass, "non-null superclass");
 			Assert.IsNull (assoc.DefaultType, "non-null default type");
 		}
 
 
 		[Test]
-		[Ignore("Missing ending quote in super class")]
 		public void AssocTypeSuper ()
 		{
 			var code = @"
@@ -1113,8 +1113,8 @@ public protocol HoldsThing {
 			var assoc = protocol.AssociatedTypes [0];
 			Assert.AreEqual ("Thing", assoc.Name, "wrong name");
 			Assert.AreEqual (0, assoc.ConformingProtocols.Count, "wrong number of conf");
-			Assert.IsNull (assoc.SuperClass, "non-null superclass");
-			Assert.IsNotNull (assoc.DefaultType, "null default type");
+			Assert.IsNotNull (assoc.SuperClass, "null superclass");
+			Assert.AreEqual ("SomeModule.Foo", assoc.SuperClass.ToString ());
 			Assert.IsNull (assoc.DefaultType, "non-null default type");
 		}
 


### PR DESCRIPTION
Integrated new reflector, fixing issues [203](https://github.com/xamarin/binding-tools-for-swift/issues/203), [202](https://github.com/xamarin/binding-tools-for-swift/issues/202), and [200](https://github.com/xamarin/binding-tools-for-swift/issues/200).

Bumped the swift reflector.
Added test case for checking protocol conformance name
Unignored `AssocTypeSuper` test
Fixed some incorrect failure language