### PR TITLE
Added some Associated Type tools

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace SwiftReflector.SwiftXmlReflection {
@@ -17,7 +18,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return new ProtocolDeclaration ();
 		}
 
-		protected virtual void GatherXObjects (List<XObject> xobjects)
+		protected override void GatherXObjects (List<XObject> xobjects)
 		{
 			base.GatherXObjects (xobjects);
 			if (AssociatedTypes.Count <= 0)
@@ -31,7 +32,22 @@ namespace SwiftReflector.SwiftXmlReflection {
 			xobjects.Add (new XElement ("associatedtypes", assocTypes.ToArray ()));
 		}
 
+		protected override void CompleteUnrooting (TypeDeclaration unrooted)
+		{
+			base.CompleteUnrooting (unrooted);
+			if (unrooted is ProtocolDeclaration pd) {
+				pd.AssociatedTypes.AddRange (AssociatedTypes);
+			}
+		}
+
 		public List<AssociatedTypeDeclaration> AssociatedTypes { get; private set; }
+
+		public bool HasAssociatedTypes => AssociatedTypes.Count > 0;
+
+		public AssociatedTypeDeclaration AssociatedTypeNamed (string name)
+		{
+			return AssociatedTypes.FirstOrDefault (at => at.Name == name);
+		}
 	}
 }
 

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1118,5 +1118,24 @@ public protocol HoldsThing {
 			Assert.IsNull (assoc.DefaultType, "non-null default type");
 		}
 
+		[Test]
+		public void FindsAssocTypeByName ()
+		{
+			var code = @"
+public protocol HoldsThing {
+	associatedtype Thing
+	func doThing() -> Thing
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var protocol = module.Protocols.Where (p => p.Name == "HoldsThing").FirstOrDefault ();
+			Assert.IsNotNull (protocol, "no protocol");
+			Assert.IsTrue (protocol.HasAssociatedTypes, "no associated types?!");
+			var assoc = protocol.AssociatedTypeNamed ("Thing");
+			Assert.IsNotNull (assoc, "couldn't find associated type");
+			assoc = protocol.AssociatedTypeNamed ("ThroatwarblerMangrove");
+			Assert.IsNull (assoc, "Found a non-existent associated type");
+		}
 	}
 }


### PR DESCRIPTION
Added a predicate and a tool to find an associated type by name.

Also fixed a warning on `GatherXObjects` and implemented `CompleteUnrooting`.

As a side note, when we emit XML type binding information, we go through a process of unrooting which eliminates all (potential) circular references in the type. Primarily, this is like a copy constructor that rips out the `Parent` pointer but leaves enough information to reconstruct it later.

Since it's a copier, we should actually, you know, copy things.