### PR TITLE
[Type-o-Matic] DeviceCheck

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -26,6 +26,7 @@ IOS_NAMESPACES= \
 	Contacts \
 	ContactsUI \
 	CoreGraphics \
+	DeviceCheck \
 	Foundation \
 	HealthKit \
 	HealthKitUI \


### PR DESCRIPTION
Adds DeviceCheck to list of namespaces to include. Does not require any new type name maps.
