### PR TITLE
[Type-o-Matic] ExternalAccessory

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -33,6 +33,7 @@ IOS_NAMESPACES= \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \
+	ExternalAccessory \
 	Foundation \
 	HealthKit \
 	HealthKitUI \


### PR DESCRIPTION
Adds ExternalAccessory to list of namespaces to include. Does not require any new type name maps.
