### PR TITLE
[Type-o-Matic] FileProvider

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -34,6 +34,8 @@ IOS_NAMESPACES= \
 	EventKit \
 	EventKitUI \
 	ExternalAccessory \
+	FileProvider \
+	FileProviderUI \
 	Foundation \
 	HealthKit \
 	HealthKitUI \


### PR DESCRIPTION
Adds FileProvider and FileProviderUI to list of namespaces to include. Does not require any new type name maps.
