### PR TITLE
[Type-o-Matic] GLKit

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -37,6 +37,7 @@ IOS_NAMESPACES= \
 	FileProvider \
 	FileProviderUI \
 	Foundation \
+	GLKit \
 	HealthKit \
 	HealthKitUI \
 	HomeKit \


### PR DESCRIPTION
Adds GLKit to list of namespaces to include. Does not require any new type name maps.
