### PR TITLE
[Type-o-Matic] GameController

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -37,6 +37,7 @@ IOS_NAMESPACES= \
 	FileProvider \
 	FileProviderUI \
 	Foundation \
+	GameController \
 	GLKit \
 	HealthKit \
 	HealthKitUI \


### PR DESCRIPTION
Adds GameController to list of namespaces to include. Does not require any new type name maps.
