### PR TITLE
[Type-o-Matic] GameplayKit

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -39,6 +39,7 @@ IOS_NAMESPACES= \
 	Foundation \
 	GameController \
 	GameKit \
+	GameplayKit \
 	GLKit \
 	HealthKit \
 	HealthKitUI \


### PR DESCRIPTION
Adds GameplayKit to list of namespaces to include. Does not require any new type name maps.
