### PR TITLE
[Type-o-Matic] IdentityLookup

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -45,6 +45,7 @@ IOS_NAMESPACES= \
 	HealthKitUI \
 	HomeKit \
 	iAd \
+	IdentityLookup \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds IdentityLookup to list of namespaces to include. Does not require any new type name maps.
