### PR TITLE
[Type-o-Matic] JavaScriptCore

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -49,6 +49,7 @@ IOS_NAMESPACES= \
 	ImageIO \
 	Intents \
 	IntentsUI \
+	JavaScriptCore \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds JavaScriptCore to list of namespaces to include. Does not require any new type name maps.
