### PR TITLE
[Type-o-Matic] LocalAuthentication

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -50,6 +50,7 @@ IOS_NAMESPACES= \
 	Intents \
 	IntentsUI \
 	JavaScriptCore \
+	LocalAuthentication \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds LocalAuthentication to list of namespaces to include. Does not require any new type name maps.
