### PR TITLE
[Type-o-Matic] MediaAccessibility

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -52,6 +52,7 @@ IOS_NAMESPACES= \
 	JavaScriptCore \
 	LocalAuthentication \
 	MapKit \
+	MediaAccessibility \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds MediaAccessibility to list of namespaces to include. Does not require any new type name maps.
