### PR TITLE
[Type-o-Matic] MobileCoreServices

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -60,6 +60,7 @@ IOS_NAMESPACES= \
 	Metal \
 	MetalKit \
 	MetalPerformanceShaders \
+	MobileCoreServices \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds MobileCoreServices to list of namespaces to include. Does not require any new type name maps.
