### PR TITLE
[Type-o-Matic] MultipeerConnectivity

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -62,6 +62,7 @@ IOS_NAMESPACES= \
 	MetalPerformanceShaders \
 	MobileCoreServices \
 	ModelIO \
+	MultipeerConnectivity \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds MultipeerConnectivity to list of namespaces to include. Does not require any new type name maps.
