### PR TITLE
[Type-o-Matic] NewsstandKit

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -64,6 +64,7 @@ IOS_NAMESPACES= \
 	ModelIO \
 	MultipeerConnectivity \
 	NetworkExtension \
+	NewsstandKit \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds NewsstandKit to list of namespaces to include. Does not require any new type name maps.
