### PR TITLE
[Type-o-Matic] NotificationCenter

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -65,6 +65,7 @@ IOS_NAMESPACES= \
 	MultipeerConnectivity \
 	NetworkExtension \
 	NewsstandKit \
+	NotificationCenter \
 	PassKit \
 	PdfKit \
 	PushKit \


### PR DESCRIPTION
Adds NotificationCenter to list of namespaces to include. Does not require any new type name maps.
