### PR TITLE
[Type-o-Matic] SafariServices

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -73,6 +73,7 @@ IOS_NAMESPACES= \
 	PhotosUI \
 	QuickLook \
 	ReplayKit \
+	SafariServices \
 	StoreKit \
 	UIKit \
 	UserNotifications \


### PR DESCRIPTION
Adds SafariServices to list of namespaces to include. Does not require any new type name maps.
