### PR TITLE
[Type-o-Matic] SpriteKit

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -78,6 +78,7 @@ IOS_NAMESPACES= \
 	Security \
 	Social \
 	Speech \
+	SpriteKit \
 	StoreKit \
 	UIKit \
 	UserNotifications \


### PR DESCRIPTION
Adds SpriteKit to list of namespaces to include. Does not require any new type name maps.
