### PR TITLE
Code to wrap PATs

### DIFF
--- a/Dynamo/Dynamo.SwiftLang/SLImport.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLImport.cs
@@ -58,6 +58,8 @@ namespace Dynamo.SwiftLang {
 		{
 			if (OwningModule != null && use.Module == OwningModule)
 				return this;
+			if (use.Module == "Self")
+				return this;
 			Add (use);
 			return this;
 		}
@@ -67,6 +69,8 @@ namespace Dynamo.SwiftLang {
 		public void AddIfNotPresent (string package)
 		{
 			SLImport target = new SLImport (package);
+			if (package == "Self")
+				return;
 
 			if (package != OwningModule && !this.Exists (imp => imp.Contents == target.Contents))
 				Add (target);

--- a/SwiftReflector/IOUtils/SwiftModuleFinder.cs
+++ b/SwiftReflector/IOUtils/SwiftModuleFinder.cs
@@ -147,7 +147,7 @@ namespace SwiftReflector.IOUtils {
 
 			try {
 				foreach (string moduleName in allReferencedModules) {
-					if (moduleName == "Swift")
+					if (moduleName == "Swift" || moduleName == "Self")
 						continue;
 					ISwiftModuleLocation loc = SwiftModuleFinder.Find (inputModuleDirectories, moduleName, target);
 					if (loc == null) {

--- a/SwiftReflector/MarshalEngineSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineSwiftToCSharp.cs
@@ -32,8 +32,7 @@ namespace SwiftReflector {
 			postMarshalCode.Clear ();
 			ICodeElement returnLine = null;
 			var instanceEntity = typeMapper.GetEntityForTypeSpec (func.ParameterLists [0] [0].TypeSpec);
-			bool instanceIsProtocol = instanceEntity.EntityType == EntityType.Protocol;
-			//			bool returnIsGeneric = func.ReturnTypeSpec != null && func.IsGenericType(func.ReturnTypeSpec);
+			bool instanceIsProtocol = instanceEntity != null && instanceEntity.EntityType == EntityType.Protocol;
 			SLIdentifier returnIdent = null;
 
 			if (func.ParameterLists.Count != 2) {

--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -1092,13 +1092,14 @@ namespace SwiftReflector {
 
 		void WrapProtocol (ClassDeclaration cl, CodeWriter cw, ModuleInventory modInventory)
 		{
+			var protocol = cl as ProtocolDeclaration;
 			var overrider = new OverrideBuilder (typeMapper, cl, null, wrappingModule);
 			uniqueModuleReferences.Merge (overrider.ModuleReferences);
 			var file = new SLFile (overrider.Imports);
 			file.Classes.AddRange (overrider.ClassImplementations);
 			file.Functions.AddRange (overrider.Functions);
 			file.Declarations.AddRange (overrider.Declarations);
-			WrapClass (overrider.OriginalClass, cw, modInventory, file, null);
+			WrapClass (protocol.HasAssociatedTypes ? overrider.OverriddenClass : overrider.OriginalClass, cw, modInventory, file, null);
 			var entity = typeMapper.GetEntityForSwiftClassName (cl.ToFullyQualifiedName (true));
 			if (entity == null) {
 				throw ErrorHelper.CreateError (ReflectorError.kWrappingBase + 3, $"Unable to locate entity for {cl.ToFullyQualifiedName ()} in type database.");

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -1563,6 +1563,8 @@ namespace SwiftReflector {
 						errors.Add (ex);
 						continue;
 					}
+					if (decl.HasAssociatedTypes)
+						continue;
 					var use = new CSUsingPackages ("System", "System.Runtime.InteropServices");
 					string nameSpace = TypeMapper.MapModuleToNamespace (decl.Module.Name);
 					var nm = new CSNamespace (nameSpace);

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -19,7 +19,7 @@ namespace SwiftReflector {
 		string vtableName = null;
 		string vtableSetterName;
 		string vtableGetterName;
-		bool isProtocol;
+		bool isProtocol, hasAssociatedTypes;
 		const string kCSIntPtr = "csIntPtr";
 		static SLIdentifier kClassIsInitialized = new SLIdentifier ("_xamarinClassIsInitialized");
 
@@ -31,7 +31,10 @@ namespace SwiftReflector {
 
 		public OverrideBuilder (TypeMapper typeMapper, ClassDeclaration classToOverride, string overrideName, ModuleDeclaration targetModule)
 		{
-			isProtocol = classToOverride is ProtocolDeclaration;
+			if (classToOverride is ProtocolDeclaration protocol) {
+				isProtocol = true;
+				hasAssociatedTypes = protocol.HasAssociatedTypes;
+			}
 			if (classToOverride.IsFinal && !isProtocol)
 				throw new ArgumentException (String.Format ("Attempt to attach override to final class {0}.", classToOverride.ToFullyQualifiedName (true)));
 			this.typeMapper = Ex.ThrowOnNull (typeMapper, "typeMapper");
@@ -54,8 +57,13 @@ namespace SwiftReflector {
 				OverriddenClass = BuildOverrideDefinition (overrideName, targetModule);
 				EveryProtocolExtension = null;
 			} else {
-				EveryProtocolExtension = BuildExtensionDefinition (targetModule);
-				OverriddenClass = null;
+				if (hasAssociatedTypes) {
+					OverriddenClass = BuildAssociatedTypeOverride (overrideName, targetModule);
+					EveryProtocolExtension = null;
+				} else {
+					EveryProtocolExtension = BuildExtensionDefinition (targetModule);
+					OverriddenClass = null;
+				}
 			}
 			OverriddenVirtualMethods = new List<FunctionDeclaration> ();
 			if (!isProtocol) {
@@ -191,6 +199,32 @@ namespace SwiftReflector {
 			return decl;
 		}
 
+		ClassDeclaration BuildAssociatedTypeOverride (string name, ModuleDeclaration targetModule)
+		{
+			name = name ?? ProxyClassName (OriginalClass);
+			var protocol = OriginalClass as ProtocolDeclaration;
+
+			var decl = new ClassDeclaration ();
+			decl.Name = name;
+			decl.Module = targetModule;
+			foreach (var at in protocol.AssociatedTypes) {
+				var genName = GenericAssociatedTypeName (at);
+				var genDecl = new GenericDeclaration (genName);
+				if (at.SuperClass != null) {
+					genDecl.Constraints.Add (new InheritanceConstraint (genName, at.SuperClass));
+				} else if (at.ConformingProtocols.Count > 0) {
+					if (at.ConformingProtocols.Count == 1) {
+						genDecl.Constraints.Add (new InheritanceConstraint (genName, at.ConformingProtocols [0]));
+					} else {
+						genDecl.Constraints.Add (new InheritanceConstraint (genName, new ProtocolListTypeSpec (at.ConformingProtocols)));
+					}
+				}
+				decl.Generics.Add (genDecl);
+			}
+			decl.Inheritance.Add (new Inheritance (OriginalClass.ToFullyQualifiedName (), InheritanceKind.Class));
+			return decl.MakeUnrooted () as ClassDeclaration;
+		}
+
 		void CopyConstructors ()
 		{
 			OverriddenClass.Members.AddRange (OriginalClass.AllConstructors ().Select (c => MarkOverrideSurrogate (c, Reparent (new FunctionDeclaration (c), OverriddenClass))));
@@ -221,10 +255,18 @@ namespace SwiftReflector {
 			else
 				HandleSuperClassVirtualMethods (OriginalClass);
 			IndexOfFirstNewVirtualMethod = OverriddenVirtualMethods.Count;
-			OverriddenVirtualMethods.AddRange (VirtualMethodsForClass (OriginalClass).Select (m => MarkOverrideSurrogate (m, Reparent (new FunctionDeclaration (m), OverriddenClass))));
-			var members = isProtocol ? EveryProtocolExtension.Members : OverriddenClass.Members;
+			if (isProtocol && hasAssociatedTypes) {
+				OverriddenVirtualMethods.AddRange (VirtualMethodsForClass (OriginalClass).Select (m => MarkOverrideSurrogate (m, Reparent (RebuildFunctionDeclarationWithAssociatedTypes (OverriddenClass, m), OverriddenClass))));
+			} else {
+				OverriddenVirtualMethods.AddRange (VirtualMethodsForClass (OriginalClass).Select (m => MarkOverrideSurrogate (m, Reparent (new FunctionDeclaration (m), OverriddenClass))));
+			}
+			var members = isProtocol && !hasAssociatedTypes ? EveryProtocolExtension.Members : OverriddenClass.Members;
 			members.AddRange (OverriddenVirtualMethods);
-			members.AddRange (VirtualPropertiesForClass (OriginalClass).Select (p => Reparent (new PropertyDeclaration (p), OverriddenClass)));
+			if (isProtocol && hasAssociatedTypes) {
+				members.AddRange (VirtualPropertiesForClass (OriginalClass).Select (p => Reparent (RebuildPropertyDeclaration (p), OverriddenClass)));
+			} else {
+				members.AddRange (VirtualPropertiesForClass (OriginalClass).Select (p => Reparent (new PropertyDeclaration (p), OverriddenClass)));
+			}
 		}
 
 		void HandleProtocolMethods (ClassDeclaration decl)
@@ -296,10 +338,17 @@ namespace SwiftReflector {
 			return SLGenericReferenceType.DefaultNamer (depthIndex.Item1, depthIndex.Item2);
 		}
 
+		static string GenericName (ProtocolDeclaration pd, AssociatedTypeDeclaration at)
+		{
+			var depth = 0;
+			var index = pd.AssociatedTypes.IndexOf (at);
+			return SLGenericReferenceType.DefaultNamer (depth, index);
+		}
+
 		void CreateSLImplementation ()
 		{
 			SLClass cl = null;
-			if (isProtocol) {
+			if (isProtocol && !hasAssociatedTypes) {
 				cl = new SLClass (Visibility.None, new SLIdentifier ("EveryProtocol"), namedType: NamedType.Extension);
 			} else {
 				cl = new SLClass (Visibility.Public, OverriddenClass.Name);
@@ -314,8 +363,8 @@ namespace SwiftReflector {
 							EqualityConstraint eq = bc as EqualityConstraint;
 							if (eq != null) {
 								SLType secondType = OriginalClass.IsTypeSpecGeneric (eq.Type2Spec) ?
-								                                 new SLSimpleType (GenericName (OriginalClass, eq.Type2)) :
-								                                 typeMapper.OverrideTypeSpecMapper.MapType (OriginalClass, Imports, eq.Type2Spec, false);
+												 new SLSimpleType (GenericName (OriginalClass, eq.Type2)) :
+												 typeMapper.OverrideTypeSpecMapper.MapType (OriginalClass, Imports, eq.Type2Spec, false);
 								return new SLGenericConstraint (false, new SLSimpleType (GenericName (OriginalClass, gen.Name)),
 															   secondType);
 							} else {
@@ -323,8 +372,8 @@ namespace SwiftReflector {
 								if (inh == null)
 									throw ErrorHelper.CreateError (ReflectorError.kTypeMapBase + 40, $"Unexpected constraint type {bc.GetType ().Name}");
 								SLType secondType = OriginalClass.IsTypeSpecGeneric (inh.InheritsTypeSpec) ?
-								                                 new SLSimpleType (GenericName (OriginalClass, inh.Inherits)) :
-								                                 typeMapper.OverrideTypeSpecMapper.MapType (OriginalClass, Imports, inh.InheritsTypeSpec, false);
+												 new SLSimpleType (GenericName (OriginalClass, inh.Inherits)) :
+												 typeMapper.OverrideTypeSpecMapper.MapType (OriginalClass, Imports, inh.InheritsTypeSpec, false);
 								return new SLGenericConstraint (true, new SLSimpleType (GenericName (OriginalClass, gen.Name)),
 															   secondType);
 							}
@@ -338,6 +387,30 @@ namespace SwiftReflector {
 				foreach (string s in OriginalClass.Generics.Select (gen => GenericName (OriginalClass, gen.Name)).BracketInterleave ("<", ">", ", "))
 					sb.Append (s);
 				cl.Inheritance.Add (new SLIdentifier (sb.ToString ()));
+				var vtableStruct = DefineGenericVtableStruct ();
+				if (vtableStruct.Fields.Count > 0) {
+					ClassImplementations.Add (vtableStruct);
+					Declarations.Add (DefineGenericVtableDeclaration ());
+					Functions.Add (DefineGenericVtableSetter ());
+					Functions.Add (DefineGenericVtableGetter ());
+				}
+			} else if (OriginalClass is ProtocolDeclaration proto && proto.HasAssociatedTypes) {
+				foreach (var assoc in proto.AssociatedTypes) {
+					var genName = new SLIdentifier (GenericName (proto, assoc));
+					var genDecl = new SLGenericTypeDeclaration (genName);
+					var genType = new SLSimpleType (genName.Name);
+					if (assoc.SuperClass != null) {
+						var constraintType = typeMapper.TypeSpecMapper.MapType (proto, Imports, assoc.SuperClass, false);
+						genDecl.Constraints.Add (new SLGenericConstraint (true, genType, constraintType));
+					} else if (assoc.ConformingProtocols.Count > 0) {
+						foreach (var conformance in assoc.ConformingProtocols) {
+							var constraintType = typeMapper.TypeSpecMapper.MapType (proto, Imports, conformance, false);
+							genDecl.Constraints.Add (new SLGenericConstraint (true, genType, constraintType));
+						}
+					}
+					cl.Generics.Add (genDecl);
+				}
+				cl.Inheritance.Add (new SLIdentifier (OriginalClass.Name));
 				var vtableStruct = DefineGenericVtableStruct ();
 				if (vtableStruct.Fields.Count > 0) {
 					ClassImplementations.Add (vtableStruct);
@@ -367,6 +440,14 @@ namespace SwiftReflector {
 				foreach (FunctionDeclaration func in OverriddenClass.AllConstructors ().Where (f => f.Access == Accessibility.Public && !f.IsConvenienceInit)) {
 					cl.Methods.Add (ToConstructor (func));
 				}
+			} else if (hasAssociatedTypes) {
+				// public default constructor
+				var parameters = new List<SLParameter> ();
+				var body = new SLCodeBlock (null);
+
+				var slfunc = new SLFunc (Visibility.Public, FunctionKind.Constructor,
+							 null, null, new SLParameterList (parameters), body);
+				cl.Methods.Add (slfunc);
 			}
 			ClassImplementations.Add (cl);
 			var allOvers = DefineOverridesAndSupers ().ToList ();
@@ -978,7 +1059,7 @@ namespace SwiftReflector {
 
 
 			if (isProtocol) {
-				body = ifblock;
+				body.AddRange (ifblock);
 			} else {
 				var ifelse = new SLIfElse (condition, ifblock, elseblock);
 				body.Add (ifelse);
@@ -1034,16 +1115,8 @@ namespace SwiftReflector {
 			//     return _vtableName[TypeCacheKey(types:ObjectIdentifier(t0))]
 			// }
 			var parms = new List<SLParameter> ();
-			var exprs = new SLBaseExpr [OriginalClass.Generics.Count];
-			for (int i = 0; i < OriginalClass.Generics.Count; i++) {
-				var id = new SLIdentifier (String.Format ("t{0}", i));
-				exprs [i] = new SLFunctionCall ("ObjectIdentifier", true,
-				                                new SLArgument (new SLIdentifier ("_"), id));
-				parms.Add (new SLParameter (id, new SLSimpleType ("Any.Type")));
-			}
-			var typeCacheKeyExpr =
-				new SLFunctionCall ("TypeCacheKey", true, true,
-				                    new SLArgument (new SLIdentifier ("types"), new SLCommaListExpr (exprs)));
+			var exprs = BuildVTableArguments (parms);
+			var typeCacheKeyExpr = BuildTypeCacheKeyExpr (exprs);
 
 			SLCodeBlock body = new SLCodeBlock (null);
 			body.Add (SLReturn.ReturnLine (new SLSubscriptExpr (vtableName, typeCacheKeyExpr)));
@@ -1063,17 +1136,9 @@ namespace SwiftReflector {
 			var parms = new List<SLParameter> ();
 			var uvtID = new SLIdentifier ("uvt");
 			var vtID = new SLIdentifier ("vt");
-			parms.Add (new SLParameter (uvtID, new SLSimpleType ("UnsafeRawPointer")));
-			var exprs = new SLBaseExpr [OriginalClass.Generics.Count];
-			for (int i = 0; i < OriginalClass.Generics.Count; i++) {
-				var id = new SLIdentifier (String.Format ("t{0}", i));
-				exprs [i] = new SLFunctionCall ("ObjectIdentifier", true,
-				                                new SLArgument (new SLIdentifier ("_"), id));
-				parms.Add (new SLParameter (id, new SLSimpleType ("Any.Type")));
-			}
-			var typeCacheKeyExpr =
-				new SLFunctionCall ("TypeCacheKey", true, true,
-				                    new SLArgument (new SLIdentifier ("types"), new SLCommaListExpr (exprs)));
+			parms.Add (new SLParameter (new SLIdentifier ("_"), uvtID, new SLSimpleType ("UnsafeRawPointer")));
+			var exprs = BuildVTableArguments (parms);
+			var typeCacheKeyExpr = BuildTypeCacheKeyExpr (exprs);
 
 			var body = new SLCodeBlock (null);
 			body.Add (SLDeclaration.LetLine (vtID,
@@ -1085,6 +1150,30 @@ namespace SwiftReflector {
 			var func = new SLFunc (Visibility.Public, null, new SLIdentifier (vtableSetterName),
 			                       new SLParameterList (parms), body);
 			return func;
+		}
+
+		SLBaseExpr [] BuildVTableArguments (List<SLParameter> parms)
+		{
+			int count = 0;
+			if (OriginalClass is ProtocolDeclaration proto) {
+				count = proto.AssociatedTypes.Count;
+			} else {
+				count = OriginalClass.Generics.Count;
+			}
+			var exprs = new SLBaseExpr [count];
+			for (int i = 0; i < count; i++) {
+				var id = new SLIdentifier (String.Format ("t{0}", i));
+				exprs [i] = new SLFunctionCall ("ObjectIdentifier", true,
+								new SLArgument (new SLIdentifier ("_"), id));
+				parms.Add (new SLParameter (new SLIdentifier ("_"), id, new SLSimpleType ("Any.Type")));
+			}
+			return exprs;
+		}
+
+		SLFunctionCall BuildTypeCacheKeyExpr (SLBaseExpr [] exprs)
+		{
+			return new SLFunctionCall ("TypeCacheKey", true, true,
+						    new SLArgument (new SLIdentifier ("types"), new SLCommaListExpr (exprs), true));
 		}
 
 		SLFunc DefineInternalVTableSetter ()
@@ -1275,6 +1364,147 @@ namespace SwiftReflector {
 		static SLBaseExpr InitializedAndNullCheck (SLBaseExpr vtExpr)
 		{
 			return new SLBinaryExpr (BinaryOp.And, kClassIsInitialized, new SLBinaryExpr (BinaryOp.NotEqual, vtExpr, SLConstant.Nil));
+		}
+
+		static string GenericAssociatedTypeName (AssociatedTypeDeclaration at)
+		{
+			return $"AT{at.Name}";
+		}
+
+		PropertyDeclaration RebuildPropertyDeclaration (PropertyDeclaration prop)
+		{
+			var newProp = new PropertyDeclaration (prop);
+			newProp.TypeName = RebuildTypeSpec (OriginalClass as ProtocolDeclaration, prop.TypeSpec).ToString ();
+			return newProp;
+		}
+
+		FunctionDeclaration RebuildFunctionDeclarationWithAssociatedTypes (ClassDeclaration parent, FunctionDeclaration decl)
+		{
+			var newDecl = new FunctionDeclaration (decl);
+			newDecl.ParameterLists.Clear ();
+			var parameterLists = new List<List<ParameterItem>> ();
+			foreach (var pl in decl.ParameterLists) {
+				parameterLists.Add (RebuildFunctionDeclarationParameterListWithAssociatedTypes (decl, pl));
+			}
+			newDecl.ParameterLists.AddRange (parameterLists);
+			if (newDecl.ParameterLists.Count > 1) {
+				// instance method - change the type from the protocol to the new class
+				var newParm = new ParameterItem (newDecl.ParameterLists [0] [0]);
+				newParm.TypeName = parent.ToFullyQualifiedNameWithGenerics ();
+				newDecl.ParameterLists [0] [0] = newParm;
+			}
+			newDecl.ReturnTypeName = RebuildTypeSpec (OriginalClass as ProtocolDeclaration, decl.ReturnTypeSpec).ToString ();
+			return newDecl;
+		}
+
+		List<ParameterItem> RebuildFunctionDeclarationParameterListWithAssociatedTypes (FunctionDeclaration decl, List<ParameterItem> pl)
+		{
+			List<ParameterItem> newList = new List<ParameterItem> ();
+			foreach (var parm in pl) {
+				var newParm = new ParameterItem (parm);
+				newParm.TypeSpec = RebuildTypeSpec (OriginalClass as ProtocolDeclaration, parm.TypeSpec);
+				newList.Add (newParm);
+			}
+			return newList;
+		}
+
+		TypeSpec RebuildTypeSpec (ProtocolDeclaration proto, TypeSpec ts)
+		{
+			switch (ts.Kind) {
+			case TypeSpecKind.Named:
+				return RebuildNamedTypeSpec (proto, ts as NamedTypeSpec);
+			case TypeSpecKind.Closure:
+				return RebuildClosureTypeSpec (proto, ts as ClosureTypeSpec);
+			case TypeSpecKind.Tuple:
+				return RebuildTupleTypeSpec (proto, ts as TupleTypeSpec);
+			case TypeSpecKind.ProtocolList:
+				return RebuildProtocolListTypeSpec (proto, ts as ProtocolListTypeSpec);
+			default:
+				throw new ArgumentOutOfRangeException (nameof (ts));
+			}
+		}
+
+		static string kSelfDot = "Self.";
+
+		NamedTypeSpec RebuildNamedTypeSpec (ProtocolDeclaration proto, NamedTypeSpec ts)
+		{
+			var newName = ts.Name;
+			if (ts.Name.StartsWith (kSelfDot, StringComparison.Ordinal)) {
+				var name = ts.Name.Substring (kSelfDot.Length);
+				var assocTypeDecl = proto.AssociatedTypeNamed (name);
+				if (assocTypeDecl != null) {
+					newName = GenericAssociatedTypeName (assocTypeDecl);
+				}
+			}
+			var newGenerics = new List<TypeSpec> ();
+			foreach (var gen in ts.GenericParameters) {
+				newGenerics.Add (RebuildTypeSpec (proto, gen));
+			}
+			if (newName == ts.Name && TSListMatches (ts.GenericParameters, newGenerics))
+				return ts;
+			var newSpec = new NamedTypeSpec (newName, newGenerics.ToArray ());
+			CopyTypeSpecEphemera (ts, newSpec);
+			return newSpec;
+		}
+
+		ProtocolListTypeSpec RebuildProtocolListTypeSpec (ProtocolDeclaration protoDecl, ProtocolListTypeSpec protocolList)
+		{
+			var oldProtocols = new List<TypeSpec> ();
+			var newProtocols = new List<TypeSpec> ();
+			oldProtocols.AddRange (protocolList.Protocols.Keys);
+			foreach (var proto in oldProtocols) {
+				newProtocols.Add (RebuildTypeSpec (protoDecl, proto));
+			}
+			if (TSListMatches (oldProtocols, newProtocols))
+				return protocolList;
+			var newList = new ProtocolListTypeSpec (newProtocols.Select (ts => ts as NamedTypeSpec));
+			CopyTypeSpecEphemera (protocolList, newList);
+			return newList;
+		}
+
+		ClosureTypeSpec RebuildClosureTypeSpec (ProtocolDeclaration proto, ClosureTypeSpec closure)
+		{
+			var newReturn = RebuildTypeSpec (proto, closure.ReturnType);
+			var args = RebuildTypeSpec (proto, closure.Arguments);
+			if (newReturn == closure.ReturnType && args == closure.Arguments)
+				return closure;
+			var newClosure = new ClosureTypeSpec (args, newReturn);
+			CopyTypeSpecEphemera (closure, newClosure);
+			newClosure.Throws = closure.Throws;
+			return newClosure;
+		}
+
+		TupleTypeSpec RebuildTupleTypeSpec (ProtocolDeclaration proto, TupleTypeSpec tuple)
+		{
+			var newElems = new List<TypeSpec> ();
+			foreach (var ts in tuple.Elements) {
+				newElems.Add (RebuildTypeSpec (proto, ts));
+			}
+			if (TSListMatches (tuple.Elements, newElems))
+				return tuple;
+			var newTuple = new TupleTypeSpec (newElems);
+			CopyTypeSpecEphemera (tuple, newTuple);
+			return newTuple;
+		}
+
+		static bool TSListMatches (List<TypeSpec> one, List<TypeSpec> two)
+		{
+			if (one.Count != two.Count)
+				return false;
+			bool allSame = true;
+			for (int i = 0; i < one.Count; i++) {
+				if (one[i] != two[i]) {
+					allSame = false;
+					break;
+				}
+			}
+			return allSame;
+		}
+
+		static void CopyTypeSpecEphemera (TypeSpec from, TypeSpec to)
+		{
+			to.Attributes.AddRange (from.Attributes);
+			to.IsInOut = from.IsInOut;
 		}
 	}
 }

--- a/SwiftReflector/SwiftXmlReflection/AssociatedTypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/AssociatedTypeDeclaration.cs
@@ -10,14 +10,14 @@ namespace SwiftReflector.SwiftXmlReflection {
 	public class AssociatedTypeDeclaration {
 		public AssociatedTypeDeclaration ()
 		{
-			ConformingProtocols = new List<TypeSpec> ();
+			ConformingProtocols = new List<NamedTypeSpec> ();
 		}
 
 		public string Name { get; set; }
 
 		public TypeSpec SuperClass { get; set; }
 		public TypeSpec DefaultType { get; set; }
-		public List<TypeSpec> ConformingProtocols { get; private set; }
+		public List<NamedTypeSpec> ConformingProtocols { get; private set; }
 
 
 		public static AssociatedTypeDeclaration FromXElement (XElement elem)
@@ -39,7 +39,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			
 			if (elem.Element ("conformingprotocols") != null) {
 				var conforming = from conform in elem.Element ("conformingprotocols").Elements ()
-						 select TypeSpecParser.Parse (NameAttribute (conform));
+						 select TypeSpecParser.Parse (NameAttribute (conform)) as NamedTypeSpec;
 				assocType.ConformingProtocols.AddRange (conforming);
 			}
 

--- a/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
@@ -64,6 +64,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 			Inherits = inheritsTypeSpecString;
 		}
 
+		public InheritanceConstraint (string name, TypeSpec inheritsTypeSpecString)
+			: this (name, inheritsTypeSpecString.ToString ())
+		{
+
+		}
+
 		public string Name { get; private set; }
 		string inheritsStr;
 		TypeSpec inheritsSpec;

--- a/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
@@ -141,7 +141,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			var sb = new StringBuilder (ToFullyQualifiedName ());
 			if (ContainsGenericParameters) {
 				sb.Append ("<");
-				for (int i=0; i < Generics.Count; i++) {
+				for (int i = 0; i < Generics.Count; i++) {
 					if (i > 0)
 						sb.Append (", ");
 					sb.Append (Generics [i].Name);
@@ -539,4 +539,3 @@ namespace SwiftReflector.SwiftXmlReflection {
 	}
 
 }
-

--- a/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
@@ -10,6 +10,7 @@ using SwiftReflector.Exceptions;
 using SwiftReflector.Demangling;
 using SwiftReflector.TypeMapping;
 using ObjCRuntime;
+using System.Text;
 
 namespace SwiftReflector.SwiftXmlReflection {
 	public class TypeDeclaration : BaseDeclaration, IXElementConvertible {
@@ -133,6 +134,21 @@ namespace SwiftReflector.SwiftXmlReflection {
 			} else {
 				return base.ToFullyQualifiedName (includeModule);
 			}
+		}
+
+		public string ToFullyQualifiedNameWithGenerics ()
+		{
+			var sb = new StringBuilder (ToFullyQualifiedName ());
+			if (ContainsGenericParameters) {
+				sb.Append ("<");
+				for (int i=0; i < Generics.Count; i++) {
+					if (i > 0)
+						sb.Append (", ");
+					sb.Append (Generics [i].Name);
+				}
+				sb.Append (">");
+			}
+			return sb.ToString ();
 		}
 
 		#region IXElementConvertible implementation

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -200,5 +200,19 @@ public func blindAssocFuncAny{nameSuffix} () -> Any {{
 			TestRunning.TestAndExecute (swiftCode, callingCode, $"{csType}\n", testName: $"CanGetAssociatedTypeFromAny{nameSuffix}");
 		}
 
+
+		[Test]
+		public void SmokeProtocolAssoc ()
+		{
+			var swiftCode = @"
+public protocol Iterator0 {
+	associatedtype Elem
+	func next () -> Elem
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
+		}
 	}
 }


### PR DESCRIPTION
First chunk of code for handling protocols with associated types.

This is...tricky.
What happens is that we get a `ProtocolDeclaration` that has associated types in it. We do a slick transformation to make it look as if it were a class instead.

So given some PAT:
```
public protocol PAT {
    associatedtype Thing
}
```
We make a new generic class  declaration:
```
public class xam_proxy_PAT<ATThing> : PAT {
}
```

The tricky part is that we copy public facing API from the protocol into the class, but any of the associated types when in the position of an argument or a return value gets listed as `Self.Thing` (trivia, you can not name a module/class/struct/enum `Self`). This was a fun chunk of code to write in `OverrideBuilder.cs`. The methods `Rebuild...` do this by looping through all the types and doing a recursive macro substitution that turns `Self.Thing` into `ATThing`. Changes made in the type tree are lazy in that if no change was made in a sub tree and no change was made in a parent, then the parent is returned as is.

Once this is done, this class gets handed off to the normal class wrapping code and treats it as if it were a virtual class that needed wrapping and has the implementation delegated off to a vtable that will be populated by C#.

This is an enormous level of chicanery and I strongly suspect that I will pay for in the long run, but for the time being I think this is actually a reasonable approach to this problem.

Given the protocol:
```
public protocol Iterator0 {
    associatedtype Elem
    func next () -> Elem
}
```
BTfS generates the following swift code:
```
import ProtocolConformanceTests
import XamGlue

internal var 
_vtable: [TypeCacheKey : Iterator0_xam_vtable]  = [TypeCacheKey : Iterator0_xam_vtable]();
internal struct Iterator0_xam_vtable
{
    internal var 
    func0: (@convention(c)(UnsafeRawPointer, UnsafeRawPointer) -> ())?;
}
public class xam_proxy_Iterator0<T0> : Iterator0
{    
    private var 
    _xamarinClassIsInitialized: Bool = false;
    public init()
    {
    }
    public func next() -> T0
    {        
         let vt: Iterator0_xam_vtable = getIterator0_xam_vtable(T0.self)!;
        
         let retval = UnsafeMutablePointer<T0>.allocate(capacity: 1);
        vt.func0!(toIntPtr(value: retval), toIntPtr(value: self));
        
        let actualRetval = retval.move();
        retval.deallocate();
        return actualRetval;
    }
}
public func setIterator0_xam_vtable(_ uvt: UnsafeRawPointer,  _ t0: Any.Type)
    {    
     let vt: UnsafePointer<Iterator0_xam_vtable> = fromIntPtr(ptr: uvt);
    
    _vtable[TypeCacheKey(types: ObjectIdentifier(t0))]  = vt.pointee;
}
internal func getIterator0_xam_vtable(_ t0: Any.Type) -> Iterator0_xam_vtable?
{
    return _vtable[TypeCacheKey(types: ObjectIdentifier(t0))];
}
public func xamarin_xam_proxy_Iterator0Dnext00000000<T0>(retval: 
    UnsafeMutablePointer<T0>, this: xam_proxy_Iterator0<T0>)
    {
    retval.initialize(to: this.next());
}
```

And this wrapper compiles.
I'm stopping this here because this PR is starting to get weighty. This is why in `NewClassCompiler.cs` I put in a chunk of code that explicitly skips doing the C# implementation of the code.

Other details:

- If a type is defined in the module `Self` it gets won't be added to an `SLImportModule` container. This keeps anyone from accidentally doing a `using Self` which is an error.

- In the marshal engine, we pass in the fake class, but it doesn't exist in the type mapper (yet) so we don't ever know the type so in trying to figure out if it's a protocol, I need to put in a null check.

- I changed the types of conforming protocols to `NamedTypeSpec` which makes some of the other code work out better and because these will never be anything but `NamesTypeSpec`.

- I added the call `ToFullyQualifiedNameWithGenerics`. It's possible that I could have made `ToFullyQualifiedName` include the generics, but that call is used in dozens of places and I'm pretty sure that adding in generics there will break a lot of things.

- Added a convenience constructor in `InheritanceConstraint`

The test is just a smoke test for now. 