### PR TITLE
[Type-o-Matic] Vision

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -85,6 +85,7 @@ IOS_NAMESPACES= \
 	UserNotifications \
 	UserNotificationsUI \
 	VideoToolbox \
+	Vision \
 	WatchConnectivity \
 	WatchKit \
 	WebKit \


### PR DESCRIPTION
Adds Vision to list of namespaces to include. Does not require any new type name maps.
