### PR TITLE
[Type-o-Matic] IdentityLookupUI

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -9,7 +9,6 @@ namespace SwiftReflector.Importing {
 
 		static partial void ModulesToSkipIOS (ref HashSet<string> result) { result = iOSModulesToSkip; }
 		static HashSet<string> iOSModulesToSkip = new HashSet<string> () {
-			"IdentityLookupUI",
 			"OpenTK",
 	    		"CoreMidi",
 			"Registrar",

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -51,6 +51,7 @@ IOS_NAMESPACES= \
 	HomeKit \
 	iAd \
 	IdentityLookup \
+	IdentityLookupUI \
 	ImageIO \
 	Intents \
 	IntentsUI \


### PR DESCRIPTION
Adds IdentityLookupUI to list of namespaces to include. Does not require any new type name maps.
