### PR TITLE
[Type-o-Matic] CoreAudioKit

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -34,6 +34,7 @@ IOS_NAMESPACES= \
 	Compression \
 	Contacts \
 	ContactsUI \
+	CoreAudioKit \
 	CoreGraphics \
 	DeviceCheck \
 	EventKit \


### PR DESCRIPTION
Adds CoreAudioKit to list of namespaces to include. Does not require any new type name maps.
