### PR TITLE
[Type-o-Matic] CoreBluetooth

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -35,6 +35,7 @@ IOS_NAMESPACES= \
 	Contacts \
 	ContactsUI \
 	CoreAudioKit \
+	CoreBluetooth \
 	CoreGraphics \
 	DeviceCheck \
 	EventKit \


### PR DESCRIPTION
Adds CoreBluetooth to list of namespaces to include. Does not require any new type name maps.
