### PR TITLE
[Type-o-Matic] CoreLocation

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -40,6 +40,7 @@ IOS_NAMESPACES= \
 	CoreFoundation \
 	CoreGraphics \
 	CoreImage \
+	CoreLocation \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \


### PR DESCRIPTION
Adds CoreLocation to list of namespaces to include. Does not require any new type name maps.
