### PR TITLE
[Type-o-Matic] CoreML

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -41,6 +41,7 @@ IOS_NAMESPACES= \
 	CoreGraphics \
 	CoreImage \
 	CoreLocation \
+	CoreML \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \


### PR DESCRIPTION
Adds CoreML to list of namespaces to include. Does not require any new type name maps.
