### PR TITLE
[Type-o-Matic] CoreMotion

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -43,6 +43,7 @@ IOS_NAMESPACES= \
 	CoreLocation \
 	CoreMedia \
 	CoreML \
+	CoreMotion \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \


### PR DESCRIPTION
Adds CoreMotion to list of namespaces to include. Does not require any new type name maps.
