### PR TITLE
[Type-o-Matic] CoreNFC

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -44,6 +44,7 @@ IOS_NAMESPACES= \
 	CoreMedia \
 	CoreML \
 	CoreMotion \
+	CoreNFC \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \


### PR DESCRIPTION
Adds CoreNFC to list of namespaces to include. Does not require any new type name maps.