### PR TITLE
[Type-o-Matic] CoreTelephony

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -46,6 +46,7 @@ IOS_NAMESPACES= \
 	CoreMotion \
 	CoreNFC \
 	CoreSpotlight \
+	CoreTelephony \
 	DeviceCheck \
 	EventKit \
 	EventKitUI \


### PR DESCRIPTION
Adds CoreTelephony to list of namespaces to include. Does not require any new type name maps.
