### PR TITLE
[Type-o-Matic] Twitter fix

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -12,7 +12,7 @@ namespace SwiftReflector.Importing {
 			"OpenTK",
 	    		"CoreMidi",
 			"Registrar",
-	    		"Twitter",
+	    		"Twitter", // not compatible with Swift
 			"CoreAnimation",
 			"CoreServices",
 	    		"System",

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -104,7 +104,6 @@ IOS_NAMESPACES= \
 	SpriteKit \
 	StoreKit \
 	SystemConfiguration \
-	Twitter \
 	UIKit \
 	UserNotifications \
 	UserNotificationsUI \


### PR DESCRIPTION
Removed mistaken inclusion of Twitter namespace in `IOS_NAMESPACES`, and added comment explaining why namespace is excluded.