### PR TITLE
[Type-o-Matic] Add explanations for skipped namespaces

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -9,16 +9,15 @@ namespace SwiftReflector.Importing {
 
 		static partial void ModulesToSkipIOS (ref HashSet<string> result) { result = iOSModulesToSkip; }
 		static HashSet<string> iOSModulesToSkip = new HashSet<string> () {
-			"OpenTK",
-	    		"CoreMidi",
-			"Registrar",
+			"OpenTK", // not a namespace
+	    		"CoreMidi", // not a namespace
+			"Registrar", // not a namespace
 	    		"Twitter", // not compatible with Swift
-			"CoreAnimation",
-			"CoreServices",
-	    		"System",
-			"System.Drawing",
-	    		"Xamarin.Utils",
-			"ObjCRuntime",
+			"CoreAnimation", // not a namespace
+	    		"System", // not a namespace
+			"System.Drawing", // not a namespace
+	    		"Xamarin.Utils", // .NET only
+			"ObjCRuntime", // .NET only
 	    		"VideoSubscriberAccount", // tvOS only
 		};
 

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -45,6 +45,7 @@ IOS_NAMESPACES= \
 	CoreML \
 	CoreMotion \
 	CoreNFC \
+	CoreServices \
 	CoreSpotlight \
 	CoreTelephony \
 	CoreText \
@@ -95,6 +96,7 @@ IOS_NAMESPACES= \
 	Photos \
 	PhotosUI \
 	QuickLook \
+	Registrar \
 	ReplayKit \
 	SafariServices \
 	SceneKit \


### PR DESCRIPTION
Adds explanations for why each skipped namespace is skipped, and adds namespaces that do not need to be skipped.