### PR TITLE
[Type-o-Matic] Fixed duplicate EKWeekday declaration

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -196,6 +196,7 @@ namespace SwiftReflector.Importing {
 			"CoreVideo.CVPixelFormatType", // not an enum
 			// EventKit
 			"EventKit.EKCalendarEventAvailability", // not an enum
+			"EventKit.EKDay", // changed to EKWeekday
 			// Foundation
 			"Foundation.NSFileType",
 	    		"Foundation.NSUserDefaultsType",
@@ -515,7 +516,6 @@ namespace SwiftReflector.Importing {
 			// CoreVideo
 			{ "CoreVideo.CVPixelBufferLock", "CVPixelBufferLockFlags" },
 			// EventKit
-			{ "EventKit.EKDay", "EKWeekday" },
 			{ "EventKit.EKErrorCode", "EKError.Code" },
 	    		// Foundation
 			{ "Foundation.NSBundle", "Bundle" },


### PR DESCRIPTION
Originally the `EKDay` enum had been mapped to the `EKWeekday` enum - however the `EKWeekday` enum already existed, so this was a duplicate binding. So this change just skips the `EKDay` enum, which is an artifact of Objective-C and not used in Swift.