### PR TITLE
Added code for doing declarations of PATs

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -1728,7 +1728,7 @@ namespace SwiftReflector {
 
 			string ifaceName = InterfaceNameForProtocol (swiftClassName, TypeMapper);
 			string className = CSProxyNameForProtocol (swiftClassName, TypeMapper);
-			string classNameSuffix = "";
+			string classNameSuffix = String.Empty;
 
 			if (protocolDecl.HasAssociatedTypes) {
 				// generates <, , ,>
@@ -6219,4 +6219,3 @@ namespace SwiftReflector {
 		}
 	}
 }
-

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -222,6 +222,21 @@ namespace SwiftReflector {
 				decl.Generics.Add (genDecl);
 			}
 			decl.Inheritance.Add (new Inheritance (OriginalClass.ToFullyQualifiedName (), InheritanceKind.Class));
+
+			// default constructor with no arguments.
+			var ctor = new FunctionDeclaration ();
+			ctor.Parent = OverriddenClass;
+			ctor.Name = FunctionDeclaration.kConstructorName;
+			ctor.ParameterLists.Add (new List<ParameterItem> ());
+			ctor.ParameterLists.Add (new List<ParameterItem> ());
+			var instanceParm = new ParameterItem ();
+			instanceParm.PublicName = instanceParm.PrivateName = "self";
+			var instanceTypeName = decl.ToFullyQualifiedNameWithGenerics ();
+			instanceParm.TypeName = instanceTypeName;
+			ctor.ParameterLists [0].Add (instanceParm);
+			ctor.ReturnTypeName = instanceTypeName;
+			decl.Members.Add (ctor);
+
 			return decl.MakeUnrooted () as ClassDeclaration;
 		}
 
@@ -1366,7 +1381,7 @@ namespace SwiftReflector {
 			return new SLBinaryExpr (BinaryOp.And, kClassIsInitialized, new SLBinaryExpr (BinaryOp.NotEqual, vtExpr, SLConstant.Nil));
 		}
 
-		static string GenericAssociatedTypeName (AssociatedTypeDeclaration at)
+		public static string GenericAssociatedTypeName (AssociatedTypeDeclaration at)
 		{
 			return $"AT{at.Name}";
 		}


### PR DESCRIPTION
This next step in the Protocol with Associated Types evolution: turns the PAT into a generic interface declaration.

Keeping the PR's smaller, there is no actual code generated for the wrappers and no members of the interface yet.

I also added in a constructor into the phony `ClassDeclaration` to ensure that that is available by wrapping code.

There is support for constraints in the class/interface declaration, but that's not tested yet.
The existing smoke test exercises all of this code. No smoke.