### PR TITLE
Added constructors etc.

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -42,6 +42,8 @@ namespace SwiftReflector {
 		{
 			Ex.ThrowOnNull (modules, nameof (modules));
 			Ex.ThrowOnNull (modname, nameof (modname));
+			if (modname == wrappingModule.Name)
+				return;
 			modules.AddIfNotPresent (modname);
 			uniqueModuleReferences.Add (modname);
 		}

--- a/SwiftReflector/ProtocolMethodMatcher.cs
+++ b/SwiftReflector/ProtocolMethodMatcher.cs
@@ -144,7 +144,13 @@ namespace SwiftReflector {
 
 		ClassDeclaration FindWrapperClass ()
 		{
-			var className = OverrideBuilder.ProxyPrefix + protocol.Name;
+			return FindWrapperClass (wrapper, protocol);
+		}
+
+		public static ClassDeclaration FindWrapperClass (WrappingResult wrapper, ProtocolDeclaration protocol)
+		{
+			var className = protocol.HasAssociatedTypes ? OverrideBuilder.AssociatedTypeProxyClassName (protocol) :
+				OverrideBuilder.ProxyClassName (protocol);
 			var theClass = wrapper.Module.Classes.FirstOrDefault (cl => cl.Name == className);
 			return wrapper.FunctionReferenceCodeMap.OriginalOrReflectedClassFor (theClass) as ClassDeclaration;
 		}


### PR DESCRIPTION
This PR adds constructors and the rest of the necessary trappings to make the wrapper class act like a swift object.

OverrideBuilder - had a number of issues in defining the wrapper class in swift.
1 - it needed a _public_ constructor
2 - it needed a destructor
3 - the parent needed to be set (it was being set to null)
4 - the type needed to be added to database earlier rather than later
5 - added a better name for the associated type wrapper

MethodWrapping:
1 - when code is marshaled, we automatically look at the namespace of any type and add a swift `using` statement for it if it's not already there. Because we were wrapping a type in the wrapping namespace (don't think about it too hard), we were adding a using for it. This is a redundancy, not an error, but it creates a problem later because in addition to adding the using, we keep a list of all modules referenced so that the swift code can be compiled and linked. When we try to find the wrapper module to link to, we find that it isn't there (it doesn't exist) and we fail with an error. Now we ignore a `using` on the wrapping module.

MethodMatcher:
1 - I needed a public hook to map a protocol to its wrapper, so I made it public and made the code properly use the associated type wrapper name

NewClassCompiler:
1 - Generic classes can't have an inner struct defining a vtable since we can't use `[MonoPinvokeCallback()]` on a member in an inner struct of a generic type. The vtable is now an internal class.
2 - `CompileInterfaceAndProxy` changed significantly. I get the (possible) wrapper class declaration earlier in the method, make the naming conditional on whether the protocol has associated types or not, name the pinvoke class conditional on that too. All of this was necessary in order to:
3 - Add the standard constructors
4 - Add the metadata accessor (still incorrectly named class constructor)
5 - Implement `ISwiftObject`
6 - Implement `IDispoable`
7 - Add the metadata fields

Test is still ignored because the output code is not quite ready yet, however the errors are the same as they were before, which means that none of the new code is generating errors.
