### PR TITLE
Removed compilation errors in C# wrapping, smoke test passes.

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -272,14 +272,13 @@ namespace SwiftReflector {
 					invoker = new CSIndexExpression (registryCall, false, callParams.ToArray ());
 				}
 			} else {
+				var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
 				if (thisIsInterface && !hasAssociatedTypes) {
-					var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
 					invoker = new CSFunctionCall (
 						$"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self).{methodName}",
 						false, callParams.ToArray ());
 
 				} else {
-					var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
 					var registryCall = isObjC ?
 						$"Runtime.GetNSObject<{thisType.ToString ()}>(self).{methodName}" :
 						$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self).{methodName}";

--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -26,7 +26,7 @@ namespace SwiftReflector {
 		}
 
 		public List<ICodeElement> MarshalFromLambdaReceiverToCSFunc (CSType thisType, string csProxyName, CSParameterList delegateParams,
-			FunctionDeclaration funcDecl, CSType methodType, CSParameterList methodParams, string methodName, bool isObjC)
+			FunctionDeclaration funcDecl, CSType methodType, CSParameterList methodParams, string methodName, bool isObjC, bool hasAssociatedTypes)
 		{
 			bool thisIsInterface = csProxyName != null;
 			bool isIndexer = funcDecl.IsSubscript;
@@ -272,15 +272,17 @@ namespace SwiftReflector {
 					invoker = new CSIndexExpression (registryCall, false, callParams.ToArray ());
 				}
 			} else {
-				if (thisIsInterface) {
+				if (thisIsInterface && !hasAssociatedTypes) {
+					var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
 					invoker = new CSFunctionCall (
-						$"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisType.ToString ()}> (self).{methodName}",
+						$"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self).{methodName}",
 						false, callParams.ToArray ());
 
 				} else {
+					var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
 					var registryCall = isObjC ?
 						$"Runtime.GetNSObject<{thisType.ToString ()}>(self).{methodName}" :
-						$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisType.ToString ()}> (self).{methodName}";
+						$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self).{methodName}";
 					invoker = new CSFunctionCall (registryCall, false, callParams.ToArray ());
 				}
 			}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -201,7 +201,6 @@ public func blindAssocFuncAny{nameSuffix} () -> Any {{
 		}
 
 
-		[Ignore ("Wrapping code is not quite ready yet.")]
 		[Test]
 		public void SmokeProtocolAssoc ()
 		{


### PR DESCRIPTION
Fixed compilation errors in PAT smoke tests.

There were three basic changes:
1. The C# delegate type that goes in the vtable needed to change. The type of the `self` argument was being set to a `SwiftExistentialContainer`, which is correct for a normal protocol, but not here - it should be `IntPtr`.
2. The call to get the matching C# object for the swift object was treating the `self` argument like a protocol/interface instead of a wrapper class.
3. The proxy class name passed into the marshaler was fine for a typical protocol, but in the case of a wrapper, it needs to have a generic type argument.

Smoke test passes and is no longer ignored.