### PR TITLE
Added Associated Type support in Get properties

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -433,7 +433,7 @@ namespace SwiftReflector {
 
 
 		public List<ICodeElement> MarshalFromLambdaReceiverToCSProp (CSProperty prop, CSType thisType, string csProxyName, CSParameterList delegateParams,
-			FunctionDeclaration funcDecl, CSType methodType, bool isObjC)
+			FunctionDeclaration funcDecl, CSType methodType, bool isObjC, bool hasAssociatedTypes)
 		{
 			bool forProtocol = csProxyName != null;
 			bool needsReturn = funcDecl.IsGetter;
@@ -463,12 +463,13 @@ namespace SwiftReflector {
 
 
 			CSIdentifier csharpCall = null;
-			if (forProtocol) {
-				csharpCall = new CSIdentifier ($"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisType.ToString()}> (self).{prop.Name.Name}");
+			var thisTypeName = hasAssociatedTypes ? csProxyName : thisType.ToString ();
+			if (forProtocol && !hasAssociatedTypes) {
+				csharpCall = new CSIdentifier ($"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self).{prop.Name.Name}");
 			} else {
 				var call = isObjC ?
-					$"ObjCRuntime.Runtime.GetNSObject<{thisType.ToString ()}> (self).{prop.Name.Name}" :
-					$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject<{thisType.ToString ()}> (self).{prop.Name.Name}";
+					$"ObjCRuntime.Runtime.GetNSObject<{thisTypeName}> (self).{prop.Name.Name}" :
+					$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject<{thisTypeName}> (self).{prop.Name.Name}";
 
 				csharpCall = new CSIdentifier (call);
 			}

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -2570,6 +2570,9 @@ namespace SwiftReflector {
 
 			if (wrapperProp == null) {
 				wrapperProp = TLFCompiler.CompileProperty (use, propName, etterFunc, setter, CSMethodKind.None);
+				if (protocolDecl.HasAssociatedTypes) {
+					SubstituteAssociatedTypeNamer (protocolDecl, wrapperProp);
+				}
 
 				var ifaceProp = new CSProperty (wrapperProp.PropType, CSMethodKind.None,
 				                              new CSIdentifier (propName),
@@ -6328,6 +6331,12 @@ namespace SwiftReflector {
 			SubstituteAssociatedTypeNamer (namer, publicMethod.Type);
 			foreach (var parm in publicMethod.Parameters)
 				SubstituteAssociatedTypeNamer (namer, parm.CSType);
+		}
+
+		void SubstituteAssociatedTypeNamer (ProtocolDeclaration protocolDecl, CSProperty publicProperty)
+		{
+			var namer = MakeAssociatedTypeNamer (protocolDecl);
+			SubstituteAssociatedTypeNamer (namer, publicProperty.PropType);
 		}
 
 		void SubstituteAssociatedTypeNamer (Func<int, int, string> namer, CSType ty)

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -255,7 +255,10 @@ namespace SwiftReflector {
 			dtor.ReturnTypeName = "()";
 			decl.Members.Add (dtor);
 
-			return decl.MakeUnrooted () as ClassDeclaration;
+			decl = decl.MakeUnrooted () as ClassDeclaration;
+			foreach (var member in decl.Members)
+				member.Parent = decl;
+			return decl;
 		}
 
 		void CopyConstructors ()
@@ -837,7 +840,11 @@ namespace SwiftReflector {
 				var ifelse = new SLIfElse (condition, ifblock, elseblock);
 
 				if (isProtocol) {
-					getBlock = ifblock;
+					if (getBlock.Count == 0)
+						getBlock = ifblock;
+					else {
+						getBlock.AddRange (ifblock);
+					}
 				} else {
 					getBlock.And (ifelse);
 				}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -214,5 +214,19 @@ public protocol Iterator0 {
 			var callingCode = CSCodeBlock.Create (printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
 		}
+
+		[Test]
+		public void SmokeProtocolAssocGetProp ()
+		{
+			var swiftCode = @"
+public protocol Iterator1 {
+	associatedtype Elem
+	var next:Elem { get }
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
Added Associated Types support in get properties.

This is only a smoke test - the code doesn't get executed (yet).

For the most part, the work was similar to methods:
- flag when a protocol has associated types
- use the correct method in the static receiver
- use the generic renamer to get the associated type names in the generics

One other things that came up - the way that I handle the wrapper for associated types is that I write a synthetic `ClassDeclaration` and copy all the protocol methods and properties into it. That done, it can get passed to `MethodWrapping` to get turned into a set of functions that we can pinvoke into.
The problem I was having was that every member of the class points to the parent, but when I was looking for the a matching wrapper, I wasn't finding it, and sure enough, the wrapper class didn't have any properties in it.
The problem was that when I called `MakeUnrooted` on the synthetic class, its members lost their parentage. I put in a hack patch instead of fixing `MakeUnrooted` because I'm worried about code that might depend on that behavior. Issue for that is [here](https://github.com/xamarin/binding-tools-for-swift/issues/313).