### PR TITLE
Get-Set property support

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -18,6 +18,8 @@ namespace SwiftReflector {
 		List<string> identifiersUsed;
 		TypeMapper typeMapper;
 
+		public Func<int, int, string> GenericRenamer { get; set; }
+
 		public MarshalEngineCSafeSwiftToCSharp (CSUsingPackages use, List<string> identifiersUsed, TypeMapper typeMapper)
 		{
 			this.use = use;
@@ -564,6 +566,7 @@ namespace SwiftReflector {
 					// someVal gets passed in
 					var depthIndex = funcDecl.GetGenericDepthAndIndex (funcDecl.ParameterLists [1] [0].TypeSpec);
 					var genRef = new CSGenericReferenceType (depthIndex.Item1, depthIndex.Item2);
+					genRef.ReferenceNamer = GenericRenamer;
 					use.AddIfNotPresent (typeof (StructMarshal));
 					string valMarshalName = MarshalEngine.Uniqueify (delegateParams [1].Name + "Temp", identifiersUsed);
 					var valMarshalId = new CSIdentifier (valMarshalName);

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -2612,9 +2612,12 @@ namespace SwiftReflector {
 				target.Add (ifElse);
 			}
 
+			var renamer = protocolDecl.HasAssociatedTypes ? MakeAssociatedTypeNamer (protocolDecl) : null;
+
 			var recvr = ImplementVirtualPropertyStaticReceiver (new CSSimpleType (iface.Name.Name),
 			                                                    proxyClass.ToCSType ().ToString (), etterDelegateDecl, use,
-			                                                    etterFunc, wrapperProp, null, vtable.Name, isObjC, protocolDecl.HasAssociatedTypes);
+			                                                    etterFunc, wrapperProp, null, vtable.Name, isObjC, protocolDecl.HasAssociatedTypes,
+									    renamer);
 			proxyClass.Methods.Add (recvr);
 
 			vtableAssignments.Add (CSAssignment.Assign (String.Format ("{0}.{1}",
@@ -2853,7 +2856,7 @@ namespace SwiftReflector {
 
 		CSMethod ImplementVirtualPropertyStaticReceiver (CSType thisType, string csProxyName, CSDelegateTypeDecl delType,
 		                                               CSUsingPackages use, FunctionDeclaration funcDecl, CSProperty prop, CSMethod protoListMethod,
-							       CSIdentifier vtableName, bool isObjC, bool hasAssociatedTypes)
+							       CSIdentifier vtableName, bool isObjC, bool hasAssociatedTypes, Func<int, int, string> genericRenamer = null)
 		{
 			var returnType = funcDecl.IsGetter ? delType.Type : CSSimpleType.Void;
 			CSParameterList pl = delType.Parameters;
@@ -2869,6 +2872,7 @@ namespace SwiftReflector {
 				recvrName = "xamVtable_recv_" + (funcDecl.IsGetter ? "get_" : "set_") + protoListMethod.Name.Name;
 			} else {
 				var marshaler = new MarshalEngineCSafeSwiftToCSharp (use, usedIDs, TypeMapper);
+				marshaler.GenericRenamer = genericRenamer;
 
 				var bodyContents = marshaler.MarshalFromLambdaReceiverToCSProp (prop, thisType, csProxyName,
 												delType.Parameters,

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -893,10 +893,15 @@ namespace SwiftReflector {
 				elseblock.Add (superAssign);
 				var ifelse = new SLIfElse (condition, ifblock, elseblock);
 
-				if (isProtocol)
-					setBlock = ifblock;
-				else
+				if (isProtocol) {
+					if (setBlock.Count == 0)
+						setBlock = ifblock;
+					else {
+						setBlock.AddRange (ifblock);
+					}
+				} else {
 					setBlock.And (ifelse);
+				}
 			}
 			SLType returnType = null;
 			if (getter.IsTypeSpecGeneric (getter.ReturnTypeSpec)) {

--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -153,9 +153,10 @@ namespace SwiftReflector {
 			var csParams = new CSParameterList ();
 			for (int i = 0; i < args.Count; i++) {
 				var arg = args [i];
+				var argIsGeneric = func.IsTypeSpecGeneric (func.ParameterLists.Last () [i].TypeSpec);
 				CSParameter csParam = null;
 				var parmType = func.ParameterLists.Last () [i].TypeSpec;
-				if (arg.Type.Entity == EntityType.Tuple || IsObjCStruct (parmType)) {
+				if (arg.Type.Entity == EntityType.Tuple || (!argIsGeneric && IsObjCStruct (parmType))) {
 					csParam = new CSParameter (CSSimpleType.IntPtr, new CSIdentifier (arg.Name), CSParameterKind.None, null);
 				} else {
 					csParam = new CSParameter (arg.Type.ToCSType (packs), new CSIdentifier (arg.Name),

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -228,5 +228,19 @@ public protocol Iterator1 {
 			var callingCode = CSCodeBlock.Create (printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
 		}
+
+		[Test]
+		public void SmokeProtocolAssocGetSetProp ()
+		{
+			var swiftCode = @"
+public protocol Iterator2 {
+	associatedtype Elem
+	var item: Elem { get set }
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
This was a straightforward change since most of the support already existed for get only properties.

Changes needed:
- `MarshalEngineCSafeSwiftToCSharp` needed a `GenericRenamer` for the setter value
- That renames had to find its way from the property code into the marshaler
- The implementation of the swift wrapper needed to have a code path for the setter parallel to the setter which keeps the `if/else` structure if there code there (which is the binding for the vtable)
- Type mapping issue in the category of "how did this line of code not get hit yet?", trying to map a generic type will fail. The predicate `IsObjCStruct` has to hit the type mapper, but it doesn't have enough context to determine if the type is generic or not.