### PR TITLE
Added a test for PATs as args, fixed NRE

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -6293,8 +6293,10 @@ namespace SwiftReflector {
 			if (ty is CSGenericReferenceType genType) {
 				genType.ReferenceNamer = namer;
 			} else if (ty is CSSimpleType simpleType) {
-				foreach (var genSubType in simpleType.GenericTypes)
-					SubstituteAssociatedTypeNamer (namer, genSubType);
+				if (simpleType.GenericTypes != null) {
+					foreach (var genSubType in simpleType.GenericTypes)
+						SubstituteAssociatedTypeNamer (namer, genSubType);
+				}
 			} else throw new NotImplementedException ($"Unknown type {ty.GetType ().Name} ({ty.ToString ()})");
 		}
 	}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -242,5 +242,19 @@ public protocol Iterator2 {
 			var callingCode = CSCodeBlock.Create (printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
 		}
+
+		[Test]
+		public void SmokeProtocolAssocFuncArg ()
+		{
+			var swiftCode = @"
+public protocol Iterator2 {
+	associatedtype Elem
+	func ident (a:Elem)
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
 	}
 }

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -588,7 +588,7 @@ public class FilmStrip<T: Interpolatable> where T.ValueType == T {
 	    		// associated type
 			// equality constraint
 	    		// skipping FilmString (due to previous errors)
-			TestRunning.TestAndExecute (swiftCode, callingCode, "No smoke\n", expectedErrorCount: 2, platform:PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "No smoke\n", expectedErrorCount: 1, platform:PlatformName.macOS);
 		}
 
 		[Test]


### PR DESCRIPTION
Put in a test for PATs as args. This caused an NRE which is now fixed.
In the process, this also removed an error in the equality constraint tests, so I dropped the error count in that to 1 instead of 2.