### PR TITLE
PAT Subscript getter

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -271,7 +271,7 @@ namespace SwiftReflector {
 
 
 			var invoker = isIndexer ? (CSBaseExpression)new CSIndexExpression (registryCall, false, callParams.ToArray ()) :
-				new CSFunctionCall (registryCall, false, callParams.ToArray ());
+				new CSFunctionCall ($"{registryCall}.{methodName}", false, callParams.ToArray ());
 
 			var tryBlock = funcDecl.HasThrows ? new CSCodeBlock () : null;
 			var catchBlock = funcDecl.HasThrows ? new CSCodeBlock () : null;

--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -266,7 +266,7 @@ namespace SwiftReflector {
 			if (thisIsInterface && !hasAssociatedTypes) {
 				registryCall = $"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self)";
 			} else {
-				registryCall = isObjC ? $"Runtime.GetNSObject<{thisTypeName}> (self)" : $"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self)");
+				registryCall = isObjC ? $"Runtime.GetNSObject<{thisTypeName}> (self)" : $"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self)";
 			}
 
 

--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -272,30 +272,6 @@ namespace SwiftReflector {
 
 			var invoker = isIndexer ? (CSBaseExpression)new CSIndexExpression (registryCall, false, callParams.ToArray ()) :
 				new CSFunctionCall (registryCall, false, callParams.ToArray ());
-			//if (isIndexer) {
-			//	if (thisIsInterface && !hasAssociatedTypes) {
-			//		invoker = new CSIndexExpression (
-			//			$"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self)",
-			//			false, callParams.ToArray ());
-			//	} else {
-			//		var registryCall = isObjC ?
-			//			$"Runtime.GetNSObject<{thisTypeName}> (self)" :
-			//			$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self)";
-			//		invoker = new CSIndexExpression (registryCall, false, callParams.ToArray ());
-			//	}
-			//} else {
-			//	if (thisIsInterface && !hasAssociatedTypes) {
-			//		invoker = new CSFunctionCall (
-			//			$"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (self).{methodName}",
-			//			false, callParams.ToArray ());
-
-			//	} else {
-			//		var registryCall = isObjC ?
-			//			$"Runtime.GetNSObject<{thisType.ToString ()}>(self).{methodName}" :
-			//			$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self).{methodName}";
-			//		invoker = new CSFunctionCall (registryCall, false, callParams.ToArray ());
-			//	}
-			//}
 
 			var tryBlock = funcDecl.HasThrows ? new CSCodeBlock () : null;
 			var catchBlock = funcDecl.HasThrows ? new CSCodeBlock () : null;

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -677,10 +677,15 @@ namespace SwiftReflector {
 				elseblock.Add (SLReturn.ReturnLine (new SLSubscriptExpr (SLIdentifier.Super,
 					getParams.Select (nameTypePair => nameTypePair.PrivateName))));
 				var ifelse = new SLIfElse (condition, ifblock, elseblock);
-				if (isProtocol)
-					getBlock = ifblock;
-				else
+				if (isProtocol) {
+					if (getBlock.Count == 0) {
+						getBlock = ifblock;
+					} else {
+						getBlock.AddRange (ifblock);
+					}
+				} else {
 					getBlock.And (ifelse);
+				}
 			}
 			SLCodeBlock setBlock = null;
 
@@ -719,10 +724,16 @@ namespace SwiftReflector {
 				                                                                  getParams.Select (nameTypePair => nameTypePair.PrivateName)), new SLIdentifier ("newValue")));
 				elseblock.Add (superAssign);
 				var ifelse = new SLIfElse (condition, ifblock, elseblock);
-				if (isProtocol)
-					setBlock = ifblock;
-				else
+				if (isProtocol) {
+					if (setBlock.Count == 0) {
+						setBlock = ifblock;
+					} else {
+						setBlock.AddRange (ifblock);
+					}
+
+				} else {
 					setBlock.And (ifelse);
+				}
 			}
 			SLType returnType = null;
 			if (getter.IsTypeSpecGeneric (getter.ReturnTypeSpec)) {

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -247,9 +247,25 @@ public protocol Iterator2 {
 		public void SmokeProtocolAssocFuncArg ()
 		{
 			var swiftCode = @"
-public protocol Iterator2 {
+public protocol Iterator3 {
 	associatedtype Elem
 	func ident (a:Elem)
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+		}
+
+		[Test]
+		public void SomeProtocolAssocSubscriptGet ()
+		{
+			var swiftCode = @"
+public protocol Iterator4 {
+	associatedtype Elem
+	subscript (index: Int) -> Elem {
+		get
+	}
 }
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));


### PR DESCRIPTION
Added support for wrapper subscript getters in protocols with associated types.

This should look a lot like previous PRs. I've had to:
- ensure there was a generic rename
- made sure that static receivers marshal the instance to the right place
- using the right name for the pinvoke class
- various little clean ups

Tests as per usual