### PR TITLE
Map from PAT->generic

### DIFF
--- a/SwiftReflector/PatToGenericMap.cs
+++ b/SwiftReflector/PatToGenericMap.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SwiftReflector.SwiftXmlReflection;
+
+namespace SwiftReflector {
+	public class PatToGenericMap {
+		const string kGenPrefix = "AV";
+		const int kFormatDigits = 3;
+		static readonly string kGenFormat = $"D{kFormatDigits}";
+		ProtocolDeclaration protocolDecl;
+
+		public PatToGenericMap (ProtocolDeclaration protocolDecl)
+		{
+			Ex.ThrowOnNull (protocolDecl, nameof (protocolDecl));
+			if (!protocolDecl.HasAssociatedTypes)
+				throw new ArgumentException ("ProtocolDeclaration has no associated types", nameof (protocolDecl));
+			this.protocolDecl = protocolDecl;
+		}
+
+		public string GenericTypeNameFor (string associatedTypeName)
+		{
+			var index = AssociatedTypeIndex (associatedTypeName);
+			// why, you may ask, am I using this scheme for naming associated types?
+			// Ordering of the names matters for how the swift type metadata gets passed, so let's use
+			// type names that are (1) horrible so that no one is like to use them (2) will come alphabetically after
+			// the any associated type generic name which are prefixed with 'AT' and and for the generic specifier for
+			// the protocol itself, which will be 'AU'. The digits encode the ordering of the associated type
+			// and (3) encode the original type name so there is some readability in there (4) the prefix is a fixed size.
+
+			// "no one will ever need more than 1000 associated types in a protocol."
+			if (index >= 1000)
+				throw new ArgumentOutOfRangeException (nameof (associatedTypeName), "> 1000 associated types");
+			return $"{kGenPrefix}{index.ToString (kGenFormat)}{associatedTypeName}";
+		}
+
+		public AssociatedTypeDeclaration FromGenericTypeName (string genericName)
+		{
+			Ex.ThrowOnNull (genericName, nameof (genericName));
+
+			// parsing is hard, yo.
+			if (!genericName.StartsWith (kGenPrefix, StringComparison.Ordinal))
+				throw new ArgumentOutOfRangeException (nameof (genericName), $"Expecting generic name '{genericName}' to start with {kGenPrefix}");
+			var minimumLength = kGenPrefix.Length + kFormatDigits + 1;
+			if (genericName.Length < minimumLength)
+				throw new ArgumentOutOfRangeException (nameof (genericName), $"Expecting generic name '{genericName}' to have at least {minimumLength} characters");
+			var indexString = genericName.Substring (kGenPrefix.Length, kFormatDigits);
+			var index = Int32.Parse (indexString);
+			if (index < 0)
+				throw new ArgumentOutOfRangeException (nameof (genericName), $"Expecting a non-negative number in '{genericName}'");
+			if (index >= protocolDecl.AssociatedTypes.Count)
+				throw new ArgumentOutOfRangeException (nameof (genericName), $"Index value {index} from generic name '{genericName}' is out of range of the associated type collection");
+
+			return protocolDecl.AssociatedTypes [index];
+		}
+
+		public string AssociatedTypeNameFromGenericTypeName (string genericName)
+		{
+			return FromGenericTypeName (genericName).Name;
+		}
+
+		int AssociatedTypeIndex (string associatedTypeName)
+		{
+			return protocolDecl.AssociatedTypes.FindIndex (assoc => assoc.Name == associatedTypeName);
+		}
+
+		public List<string> UniqueGenericTypeNamesFor (FunctionDeclaration funcDecl)
+		{
+			HashSet<string> assocTypes = new HashSet<string> ();
+
+			GetUniqueGenericTypeNamesFor (funcDecl.ReturnTypeSpec, assocTypes);
+			foreach (var arg in funcDecl.ParameterLists.Last ()) {
+				GetUniqueGenericTypeNamesFor (arg.TypeSpec, assocTypes);
+			}
+
+			var uniques = assocTypes.ToList ();
+			uniques.Sort ();
+			return uniques;
+		}
+
+		void GetUniqueGenericTypeNamesFor (TypeSpec candidate, HashSet<string> result)
+		{
+			if (TypeSpec.IsNullOrEmptyTuple (candidate))
+				return;
+			switch (candidate.Kind) {
+			case TypeSpecKind.Closure:
+				GetUniqueGenericTypeNamesFor (candidate as ClosureTypeSpec, result);
+				break;
+			case TypeSpecKind.Named:
+				GetUniqueGenericTypeNamesFor (candidate as NamedTypeSpec, result);
+				break;
+			case TypeSpecKind.Tuple:
+				GetUniqueGenericTypeNamesFor (candidate as TupleTypeSpec, result);
+				break;
+			case TypeSpecKind.ProtocolList:
+				GetUniqueGenericTypeNamesFor (candidate as ProtocolListTypeSpec, result);
+				break;
+			default:
+				throw new NotImplementedException ($"Unknown type spec kind {candidate.Kind.ToString ()}");
+			}
+		}
+
+		void GetUniqueGenericTypeNamesFor (ClosureTypeSpec candidate, HashSet<string> result)
+		{
+			GetUniqueGenericTypeNamesFor (candidate.Arguments, result);
+			GetUniqueGenericTypeNamesFor (candidate.ReturnType, result);
+		}
+
+		void GetUniqueGenericTypeNamesFor (NamedTypeSpec candidate, HashSet<string> result)
+		{
+			var assocType = protocolDecl.AssociatedTypeNamed (candidate.Name);
+			if (assocType != null)
+				result.Add (GenericTypeNameFor (assocType.Name));
+			if (candidate.GenericParameters == null)
+				return;
+			foreach (var gen in candidate.GenericParameters) {
+				GetUniqueGenericTypeNamesFor (gen, result);
+			}
+		}
+
+		void GetUniqueGenericTypeNamesFor (TupleTypeSpec candidate, HashSet<string> result)
+		{
+			foreach (var element in candidate.Elements) {
+				GetUniqueGenericTypeNamesFor (element, result);
+			}
+		}
+
+		void GetUniqueGenericTypeNamesFor (ProtocolListTypeSpec candidate, HashSet<string> result)
+		{
+			foreach (var element in candidate.Protocols.Keys) {
+				GetUniqueGenericTypeNamesFor (element, result);
+			}
+		}
+
+
+		public TypeSpec RebuildTypeWithGenericType (TypeSpec type)
+		{
+			bool changed;
+			RebuildTypeWithGenericType (type, out changed);
+			return type;
+		}
+
+		TypeSpec RebuildTypeWithGenericType (TypeSpec type, out bool changed)
+		{
+			if (TypeSpec.IsNullOrEmptyTuple (type)) {
+				changed = false;
+				return type;
+			}
+			switch (type.Kind) {
+			case TypeSpecKind.Closure:
+				return RebuildTypeWithGenericType (type as ClosureTypeSpec, out changed);
+			case TypeSpecKind.Named:
+				return RebuildTypeWithGenericType (type as NamedTypeSpec, out changed);
+			case TypeSpecKind.Tuple:
+				return RebuildTypeWithGenericType (type as TupleTypeSpec, out changed);
+			case TypeSpecKind.ProtocolList:
+				return RebuildTypeWithGenericType (type as ProtocolListTypeSpec, out changed);
+			default:
+				throw new NotImplementedException ($"Unknown type spec kind {type.Kind.ToString ()}");
+			}
+		}
+
+		TypeSpec RebuildTypeWithGenericType (ClosureTypeSpec type, out bool changed)
+		{
+			bool argsChanged, resultChanged;
+			var args = RebuildTypeWithGenericType (type.Arguments, out argsChanged);
+			var result = RebuildTypeWithGenericType (type.ReturnType, out resultChanged);
+			changed = argsChanged || resultChanged;
+			if (changed) {
+				return new ClosureTypeSpec (args, result);
+			}
+			return type;
+		}
+
+		TypeSpec RebuildTypeWithGenericType (NamedTypeSpec type, out bool changed)
+		{
+			bool nameChanged = false, genArgsChanged = false;
+			string newName = null;
+			var assocType = protocolDecl.AssociatedTypeNamed (type.Name);
+			if (assocType != null) {
+				nameChanged = true;
+				newName = GenericTypeNameFor (assocType.Name);
+			}
+			TypeSpec [] newGenParms = type.GenericParameters.ToArray ();
+			if (type.GenericParameters != null) {
+				newGenParms = new TypeSpec [type.GenericParameters.Count];
+				for (int i = 0; i < newGenParms.Length; i++) {
+					bool genChanged;
+					newGenParms [i] = (RebuildTypeWithGenericType (type.GenericParameters [i], out genChanged));
+					genArgsChanged = genArgsChanged || genChanged;
+				}
+			}
+			changed = nameChanged || genArgsChanged;
+			if (changed) {
+				return new NamedTypeSpec (newName, newGenParms);
+			}
+			return type;
+		}
+
+		TypeSpec RebuildTypeWithGenericType (TupleTypeSpec type, out bool changed)
+		{
+			changed = false;
+			var newTupleElems = new TypeSpec [type.Elements.Count];
+			for (int i = 0; i < type.Elements.Count; i++) {
+				bool elemChanged;
+				newTupleElems [i] = RebuildTypeWithGenericType (type.Elements [i], out elemChanged);
+				changed = changed || elemChanged;
+			}
+
+			if (changed) {
+				return new TupleTypeSpec (newTupleElems);
+			}
+			return type;
+		}
+	}
+}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Demangling\Swift5Demangler.cs" />
     <Compile Include="SwiftXmlReflection\AssociatedTypeDeclaration.cs" />
     <Compile Include="ProtocolMethodMatcher.cs" />
+    <Compile Include="PatToGenericMap.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
This is code that will be needed in an upcoming change.
Given the following PAT:
```
public protocol Foo {
    associatedtype Elem
    func next() -> Elem
}
```
I will need to generate a method in a proxy class like this:
```
public class ProxyClass {
    public static func <AU, AVElem> xamWrap_next(this: AU) -> AVElem where AU: Foo, AVElem == AU.Elem {
        return AU.Elem
    }
}
```

So I need a map that can go between associated types of a PAT and generic types in a static wrapper.
In the example above the map is:
`AVElem` <-> `Foo.Elem`

In addition to the map functionality, I added two related functions. The first is that given a function declaration, find all the unique uses of associated types. This will let me do the generic declaration between the angle brackets. Swift is really persnickety when you declare a generic type and then don't use it in the signature of the function - it's an error, so this is one of those classes CS 200 problems:
Given a tree of symbols, make a list of the unique uses of that symbol - that's the function `UniqueGenericTypeNamesFor`.

And finally there is a related task, which is: given a TypeSpec, rebuild it substituting the mapped generic type for every associated type.

Both of these tasks have the same structure which is effectively structural recursion (but you know, without the language support): based on the node type branch off to code for handling that node.

As an added stunt, in the rebuild process I put in some code to mark each node as having changed or not in the process. This will same some memory and not rebuild an entire type if it isn't necessary.

No tests yet.