### PR TITLE
Now generating top level functions to wrap PAT calls

### DIFF
--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -648,8 +648,6 @@ namespace SwiftReflector {
 					if (originalFunction.IsGetter) {
 						body.Add (SLReturn.ReturnLine (propExpr));
 					} else {
-						// note for future Steve - you need to add an argument for newValue
-						// if it's a setter.
 						body.Add (new SLLine (new SLBinding (propExpr, parameters [1].PrivateName ?? parameters [1].PublicName)));
 					}
 				}

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -574,7 +574,7 @@ namespace SwiftReflector {
 
 			var newFunc = new FunctionDeclaration ();
 
-			newFunc.Name = AssociatedTypeStaticWrapperName (modelFunc.Name);
+			newFunc.Name = AssociatedTypeStaticWrapperName (OriginalClass as ProtocolDeclaration, modelFunc.Name);
 			newFunc.Module = OverriddenClass.Module;
 			newFunc.ParameterLists.Add (instanceList);
 			newFunc.ParameterLists.Add (newParamList);
@@ -1692,10 +1692,11 @@ namespace SwiftReflector {
 			to.IsInOut = from.IsInOut;
 		}
 
-		public static string AssociatedTypeStaticWrapperName (string funcName)
+		public static string AssociatedTypeStaticWrapperName (ProtocolDeclaration proto, string funcName)
 		{
 			Ex.ThrowOnNull (funcName, nameof (funcName));
-			return "xamarin_static_wrapper_" + funcName;
+			string prefix = proto.ToFullyQualifiedName ().Replace ('.', '_');
+			return $"xamarin_static_wrapper_{prefix}_{funcName}";
 		}
 	}
 }

--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -260,6 +260,21 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 			return sb.ToString ();
 		}
+
+		public virtual string ToFullyQualifiedNameWithGenerics ()
+		{
+			var sb = new StringBuilder (ToFullyQualifiedName ());
+			if (ContainsGenericParameters) {
+				sb.Append ("<");
+				for (int i = 0; i < Generics.Count; i++) {
+					if (i > 0)
+						sb.Append (", ");
+					sb.Append (Generics [i].Name);
+				}
+				sb.Append (">");
+			}
+			return sb.ToString ();
+		}
 	}
 
 }

--- a/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
@@ -136,21 +136,6 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		public string ToFullyQualifiedNameWithGenerics ()
-		{
-			var sb = new StringBuilder (ToFullyQualifiedName ());
-			if (ContainsGenericParameters) {
-				sb.Append ("<");
-				for (int i = 0; i < Generics.Count; i++) {
-					if (i > 0)
-						sb.Append (", ");
-					sb.Append (Generics [i].Name);
-				}
-				sb.Append (">");
-			}
-			return sb.ToString ();
-		}
-
 		#region IXElementConvertible implementation
 
 		public XElement ToXElement ()


### PR DESCRIPTION
We need a way to invoke PAT which is an arbitrary PAT and not one that we know about.

So given the PAT:
```
public protocol Iterator0 {
    associatedtype Elem
    func next () -> Elem
}
```

We now write the following top-level function:
```
public func xamarin_static_wrapper_ProtocolConformanceTests_Iterator0_next<T0, T1>(this: inout T0) -> T1 where T0 : ProtocolConformanceTests.Iterator0, T1 == T0.Elem
{
    return this.next();
}
```

It was quite a ride to get here. The bulk of the work gets done in OverrideBuilder, which normally writes code like this, so this seemed like a good place for it.
Writing this code revealed a number of bugs related to static methods which were fixed in MethodWrapping - primarily they were a result of assuming which argument list to use instead of using `Last ()`.

MethodWrapping already had code to handle turning a `GenericDeclaration` into an `SLGenericDeclaration`, so I repacked those methods and made them public since I needed them in other places.

Removed a couple places that said we don't handle equality constraints because we do. Kinda.
