### PR TITLE
Added common base class for proxied swift protocols with associated types

### DIFF
--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -274,6 +274,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftAssociatedTypeDescriptor.cs">
       <Link>SwiftMarshal\SwiftAssociatedTypeDescriptor.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\BaseAssociatedTypeProxy.cs">
+      <Link>BaseAssociatedTypeProxy.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -279,6 +279,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftAssociatedTypeDescriptor.cs">
       <Link>SwiftMarshal\SwiftAssociatedTypeDescriptor.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\BaseAssociatedTypeProxy.cs">
+      <Link>BaseAssociatedTypeProxy.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="make --directory=../SwiftRuntimeLibrary create-pinvokes-ios configuration=$(Configuration)" />

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -83,12 +83,9 @@ namespace SwiftRuntimeLibrary {
 				}
 			}
 
-			protected byte [] SwiftData {
-				get; set;
-			}
-			protected SwiftMetatype ProxiedMetatype {
-				get; set;
-			}
+			protected byte [] SwiftData { get; set; }
+
+			protected SwiftMetatype ProxiedMetatype { get; set; }
 		}
 	}
 }

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -42,8 +42,7 @@ namespace SwiftRuntimeLibrary {
 
 			protected virtual void Dispose (bool disposing)
 			{
-				if ((object_flags & SwiftObjectFlags.Disposed) !=
-				    SwiftObjectFlags.Disposed) {
+				if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
 					if (disposing) {
 						DisposeManagedResources ();
 					}

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -8,9 +8,9 @@ namespace SwiftRuntimeLibrary {
 	namespace ClassWrapTests {
 		[SwiftNativeObject ()]
 		public class BaseAssociatedTypeProxy : ISwiftObject {
-			protected IntPtr handle;
-			protected SwiftMetatype class_handle;
-			protected SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
+			IntPtr handle;
+			SwiftMetatype class_handle;
+			SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
 
 			protected BaseAssociatedTypeProxy (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
 			{

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using SwiftRuntimeLibrary.SwiftMarshal;
+
+namespace SwiftRuntimeLibrary {
+	namespace ClassWrapTests {
+		[SwiftNativeObject ()]
+		public class BaseAssociatedTypeProxy : ISwiftObject {
+			protected IntPtr handle;
+			protected SwiftMetatype class_handle;
+			protected SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
+
+			protected BaseAssociatedTypeProxy (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
+			{
+				if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
+					object_flags |= SwiftObjectFlags.IsDirectBinding;
+				}
+				class_handle = classHandle;
+				SwiftObject = handle;
+				if (IsCSObjectProxy)
+					registry.Add (this);
+			}
+
+			protected BaseAssociatedTypeProxy (byte [] swiftTypeData, SwiftMetatype mt)
+			{
+				if (swiftTypeData == null)
+					throw new ArgumentNullException (nameof (swiftTypeData));
+				var length = swiftTypeData.Length;
+				StructMarshal.Marshaler.RetainNominalData (mt, swiftTypeData);
+				SwiftData = new byte [length];
+				Array.Copy (swiftTypeData, SwiftData, length);
+				ProxiedMetatype = mt;
+			}
+
+			public void Dispose ()
+			{
+				Dispose (true);
+				GC.SuppressFinalize (this);
+			}
+
+			protected virtual void Dispose (bool disposing)
+			{
+				if ((object_flags & SwiftObjectFlags.Disposed) !=
+				    SwiftObjectFlags.Disposed) {
+					if (disposing) {
+						DisposeManagedResources ();
+					}
+					if (IsCSObjectProxy)
+						SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
+					DisposeUnmanagedResources ();
+					object_flags |= SwiftObjectFlags.Disposed;
+				}
+			}
+
+			protected virtual void DisposeManagedResources ()
+			{
+			}
+
+			protected virtual void DisposeUnmanagedResources ()
+			{
+				if (IsCSObjectProxy) {
+					SwiftCore.Release (SwiftObject);
+				} else {
+					StructMarshal.Marshaler.ReleaseNominalData (ProxiedMetatype, SwiftData);
+				}
+			}
+
+			~BaseAssociatedTypeProxy ()
+			{
+				Dispose (false);
+			}
+
+			protected bool IsCSObjectProxy => handle != IntPtr.Zero;
+
+			public IntPtr SwiftObject {
+				get {
+					return handle;
+				}
+				private set {
+					handle = value;
+				}
+			}
+
+			protected byte [] SwiftData {
+				get; set;
+			}
+			protected SwiftMetatype ProxiedMetatype {
+				get; set;
+			}
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftValueWitnessTable.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftValueWitnessTable.cs
@@ -78,7 +78,12 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			// mov        rsi, qword [rsi+0x88]  ; get the 17th pointer into the value witness table which is the size field
 			//
 			var meta = StructMarshal.Marshaler.Metatypeof (t);
-			var backPtr = meta.handle - IntPtr.Size;
+			return FromType (meta);
+		}
+
+		public static SwiftValueWitnessTable FromType (SwiftMetatype mt)
+		{
+			var backPtr = mt.handle - IntPtr.Size;
 			var witPtr = Marshal.ReadIntPtr (backPtr);
 #if DEBUG
 			//Console.WriteLine ("Value witness table for " + t.Name);

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -115,6 +115,7 @@
     <Compile Include="SwiftMarshal\SwiftProtocolConformanceDescriptor.cs" />
     <Compile Include="SwiftMarshal\SwiftProtocolWitnessTable.cs" />
     <Compile Include="SwiftMarshal\SwiftAssociatedTypeDescriptor.cs" />
+    <Compile Include="BaseAssociatedTypeProxy.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
All proxy types for protocols with associated types will have a lot of common code in them.
It made sense to put into a common base class.

I made this class by first running a unit test on a swift class type to generate all the C# goo, then personalized it for this.

Proxied types can be either a CS type that maps onto a swift implementation or a swift implementation that may not exist in C#.
If it exists in C#, the actual C# binding will get used. If it doesn't exist in C#, we will get a buffer of opaque data that represents the type and a `SwiftMetatype` struct.

To handle this, I put in a `SwiftData` member, but as I don't see it being needed publicly, I've made it protected. I modified the dispose code to check to see if `SwiftObject` is valid and if so, we do a normal dispose. If not, we use do a release on the nominal data.

We didn't have quite the right APIs for making that happen, so I refactored `RetainSwiftNominalData` and `ReleaseSwiftNominalData` to work on what we will have to throw at it. This included refactoring the code to get the value witness table.

The value witness table is a set of function pointers for being able to manipulate swift value types without really knowing anything about them. This includes (effectively) being able to do retain and release. If we have a `SwiftMetadata` object, we can get the value witness table by stepping back one pointer from the `SwiftMetadata` object which gives us a pointer to the value witness table.

This will fail on types that aren't nominal types (tuples, closures) which should never ever get passed to this because as far as I know you can't make tuples or closures implement protocols of any kind.