### PR TITLE
Added support for using common proxy base class.

### DIFF
--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -5,86 +5,84 @@ using System;
 using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
-	namespace ClassWrapTests {
-		[SwiftNativeObject ()]
-		public class BaseAssociatedTypeProxy : ISwiftObject {
-			IntPtr handle;
-			SwiftMetatype class_handle;
-			SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
+	[SwiftNativeObject ()]
+	public class BaseAssociatedTypeProxy : ISwiftObject {
+		IntPtr handle;
+		SwiftMetatype class_handle;
+		SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
 
-			protected BaseAssociatedTypeProxy (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
-			{
-				if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
-					object_flags |= SwiftObjectFlags.IsDirectBinding;
-				}
-				class_handle = classHandle;
-				SwiftObject = handle;
-				if (IsCSObjectProxy)
-					registry.Add (this);
+		protected BaseAssociatedTypeProxy (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
+		{
+			if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
+				object_flags |= SwiftObjectFlags.IsDirectBinding;
 			}
-
-			protected BaseAssociatedTypeProxy (byte [] swiftTypeData, SwiftMetatype mt)
-			{
-				if (swiftTypeData == null)
-					throw new ArgumentNullException (nameof (swiftTypeData));
-				var length = swiftTypeData.Length;
-				StructMarshal.Marshaler.RetainNominalData (mt, swiftTypeData);
-				SwiftData = new byte [length];
-				Array.Copy (swiftTypeData, SwiftData, length);
-				ProxiedMetatype = mt;
-			}
-
-			public void Dispose ()
-			{
-				Dispose (true);
-				GC.SuppressFinalize (this);
-			}
-
-			protected virtual void Dispose (bool disposing)
-			{
-				if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
-					if (disposing) {
-						DisposeManagedResources ();
-					}
-					if (IsCSObjectProxy)
-						SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
-					DisposeUnmanagedResources ();
-					object_flags |= SwiftObjectFlags.Disposed;
-				}
-			}
-
-			protected virtual void DisposeManagedResources ()
-			{
-			}
-
-			protected virtual void DisposeUnmanagedResources ()
-			{
-				if (IsCSObjectProxy) {
-					SwiftCore.Release (SwiftObject);
-				} else {
-					StructMarshal.Marshaler.ReleaseNominalData (ProxiedMetatype, SwiftData);
-				}
-			}
-
-			~BaseAssociatedTypeProxy ()
-			{
-				Dispose (false);
-			}
-
-			protected bool IsCSObjectProxy => handle != IntPtr.Zero;
-
-			public IntPtr SwiftObject {
-				get {
-					return handle;
-				}
-				private set {
-					handle = value;
-				}
-			}
-
-			protected byte [] SwiftData { get; set; }
-
-			protected SwiftMetatype ProxiedMetatype { get; set; }
+			class_handle = classHandle;
+			SwiftObject = handle;
+			if (IsCSObjectProxy)
+				registry.Add (this);
 		}
+
+		protected BaseAssociatedTypeProxy (byte [] swiftTypeData, SwiftMetatype mt)
+		{
+			if (swiftTypeData == null)
+				throw new ArgumentNullException (nameof (swiftTypeData));
+			var length = swiftTypeData.Length;
+			StructMarshal.Marshaler.RetainNominalData (mt, swiftTypeData);
+			SwiftData = new byte [length];
+			Array.Copy (swiftTypeData, SwiftData, length);
+			ProxiedMetatype = mt;
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
+				if (disposing) {
+					DisposeManagedResources ();
+				}
+				if (IsCSObjectProxy)
+					SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
+				DisposeUnmanagedResources ();
+				object_flags |= SwiftObjectFlags.Disposed;
+			}
+		}
+
+		protected virtual void DisposeManagedResources ()
+		{
+		}
+
+		protected virtual void DisposeUnmanagedResources ()
+		{
+			if (IsCSObjectProxy) {
+				SwiftCore.Release (SwiftObject);
+			} else {
+				StructMarshal.Marshaler.ReleaseNominalData (ProxiedMetatype, SwiftData);
+			}
+		}
+
+		~BaseAssociatedTypeProxy ()
+		{
+			Dispose (false);
+		}
+
+		protected bool IsCSObjectProxy => handle != IntPtr.Zero;
+
+		public IntPtr SwiftObject {
+			get {
+				return handle;
+			}
+			private set {
+				handle = value;
+			}
+		}
+
+		protected byte [] SwiftData { get; set; }
+
+		protected SwiftMetatype ProxiedMetatype { get; set; }
 	}
 }


### PR DESCRIPTION
Now that we're using a common base class for the PAT proxy, I removed the `ISwiftObject` inheritance and implementation and added inheritance to `BaseAssociatedTypeProxy`.
To do this I had to:
- remove the namespace in the proxy class left over from when it was made from a test (oops)
- remove `ISwiftObject` inheritance and implementation
- remove `IDisposable` implementation
- remove mono touch fields
- Add `BaseAssociatedTypeProxy` inheritance
- tweak the constructor implementation to call `base` instead of `this`.

Existing tests pass, refactor successful.
