### PR TITLE
Marshaling for generics that implement PATs

### DIFF
--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -1307,7 +1307,6 @@ namespace SwiftReflector {
 
 		CSSimpleType BuildGenericInterfaceFromAssociatedTypes (CSSimpleType interfaceType, ProtocolDeclaration protocol)
 		{
-			
 			return new CSSimpleType (OverrideBuilder.AssociatedTypeProxyClassName (protocol), false, interfaceType.GenericTypes);
 		}
 

--- a/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
@@ -45,6 +45,29 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return true;
 		}
 
+		public bool IsAssociatedTypeProtocolConstrained (TypeMapper mapper)
+		{
+			if (Constraints.Count == 0)
+				return false;
+			foreach (BaseConstraint bc in Constraints) {
+				Entity ent = null;
+				InheritanceConstraint inh = bc as InheritanceConstraint;
+				if (inh != null) {
+					ent = mapper.GetEntityForTypeSpec (inh.InheritsTypeSpec);
+				} else {
+					EqualityConstraint eq = (EqualityConstraint)bc;
+					ent = mapper.GetEntityForTypeSpec (eq.Type2Spec);
+				}
+				if (ent == null)
+					continue; // shouldn't happen
+				if (ent.EntityType != EntityType.Protocol)
+					return false;
+				if (ent.Type is ProtocolDeclaration proto && proto.HasAssociatedTypes)
+					return true;
+			}
+			return false;
+		}
+
 		public bool IsClassConstrained (TypeMapper mapper)
 		{
 			if (Constraints.Count == 0)

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -603,8 +603,15 @@ namespace SwiftReflector.TypeMapping {
 							}
 						} else {
 							var retval = new NetTypeBundle (en.SharpNamespace, en.SharpTypeName, false, spec.IsInOut, en.EntityType);
-							foreach (var gen in spec.GenericParameters) {
-								retval.GenericTypes.Add (MapType (context, gen, isPinvoke));
+							if (en.EntityType == EntityType.Protocol && en.Type is ProtocolDeclaration proto) {
+								foreach (var assoc in proto.AssociatedTypes) {
+									var genMap = new NetTypeBundle (proto, assoc);
+									retval.GenericTypes.Add (genMap);
+								}
+							} else {
+								foreach (var gen in spec.GenericParameters) {
+									retval.GenericTypes.Add (MapType (context, gen, isPinvoke));
+								}
 							}
 							return retval;
 						}

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
@@ -49,6 +49,15 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return proxyAttr.ProxyType;
 		}
 
+		public static T MakeProxy<T> (Type proxyType, T interfaceImpl)
+		{
+			var interfaceType = typeof (T);
+			var ci = proxyType.GetConstructor (new Type [] { interfaceType });
+			if (ci == null)
+				throw new SwiftRuntimeException ($"Type {proxyType.Name} does not have a constructor that takes takes {interfaceType.Name}");
+			return (T)ci.Invoke (new object [] { interfaceImpl });
+		}
+
 		public static BaseProxy MakeProxy (Type interfaceType, object interfaceImpl, EveryProtocol protocol)
 		{
 			var proxyType = ProxyTypeForInterfaceType (interfaceType);

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -334,7 +334,7 @@ public func doPrint<T>(a:T) where T:Simplest0 {
 
 			var instID = new CSIdentifier ("inst");
 			var instDecl = CSVariableDeclaration.VarLine (instID, new CSFunctionCall ("Simple0Impl", true));
-			var doPrint = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoPrint", false, instID);
+			var doPrint = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoPrint<Simple0Impl, SwiftString>", false, instID);
 			var callingCode = CSCodeBlock.Create (instDecl, doPrint);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
 		}


### PR DESCRIPTION
Test still commented out (for now) because this was starting to get big.

Here's what we add:

1. special case for marshaling a type that is a generic constrained to a protocol with associated types
2. type mapper now recognizes PATs and makes the resulting C# type generic on the associated types
3. a new MakeProxy runtime call for a given PAT interface
4. predicates to ask if a generic is PAT constrained

The generated C# code compiles (!). It does not run, but one thing at a time, right?

Now the long part. How do we marshal a generic that is PAT constrained?
1. Make a proxy if needed
2. Hold onto the pre-marshal ref count
3. Make a buffer to hold the proxy's swift object handle
4. Copy into that buffer
5. If the ref count hasn't increased, dispose the proxy

The wrapper for the `doPrint` test code turns into this in C#:

```
public static void DoPrint<T0, ATItem>(T0 a)where T0 : ISimplest0<ATItem>
{
    unsafe {
        var proxy = a is Simplest0Protocol<ATItem> ? (ISimplest0<ATItem>)a : SwiftProtocolTypeAttribute.MakeProxy(typeof(Simplest0Protocol<ATItem>),  (ISimplest0<ATItem>)a);

        var proxyRefCount = StructMarshal.RetainCount((ISwiftObject)proxy);

        var proxyPtr = stackalloc byte[IntPtr.Size];

        var proxyIntPtr = new IntPtr(proxyPtr);
        StructMarshal.Marshaler.ToSwift(proxy, proxyIntPtr);

        NativeMethodsForTopLevelEntities.PIfunc_Xamarin_ProtocolConformanceTestsFdoPrint00000003(proxyIntPtr, StructMarshal.Marshaler.Metatypeof(typeof(T0), new Type[] { typeof(ISimplest0<ATItem>)}),
                    StructMarshal.Marshaler.ProtocolWitnessof(typeof(ISimplest0<ATItem>),  typeof(T0)));

        if (a is Simplest0Protocol<ATItem> && proxyRefCount >= StructMarshal.RetainCount((ISwiftObject)proxy))
        {
            ((ISwiftObject)proxy).Dispose();
        }
    }
}
```

When it runs, there's an entry point that can't be found for getting the type metadata. This is an issue elsewhere in the code and I'll get that in the next PR, so until then the test that exercises this is ignored.