### PR TITLE
Now executing PAT code.

### DIFF
--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -254,7 +254,12 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			if (attr == null) {
 				throw new SwiftRuntimeException ($"Interface type {t.Name} is missing the {typeof (SwiftProtocolTypeAttribute).Name} attribute.");
 			}
-			var pi = attr.ProxyType.GetProperty ("ProtocolWitnessTable", BindingFlags.Static | BindingFlags.Public);
+			var proxyType = attr.ProxyType;
+			if (proxyType.ContainsGenericParameters) {
+				var generics = t.GenericTypeArguments;
+				proxyType = proxyType.MakeGenericType (generics);
+			}
+			var pi = proxyType.GetProperty ("ProtocolWitnessTable", BindingFlags.Static | BindingFlags.Public);
 			if (pi == null)
 				throw new SwiftRuntimeException ($"Unable to find ProtocolWitnessTable property in proxy {attr.ProxyType.Name}");
 			return (IntPtr)pi.GetValue (null);

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -306,7 +306,6 @@ public protocol Iterator6 {
 		}
 
 		[Test]
-		[Ignore ("Signature is right, marshaling isn't")]
 		public void SimplestProtocolAssocTest ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
This changes gets a very basic test with a Protocol with associated types as built in C#.
Here's the swift code:
```
public protocol Simplest0 {
	associatedtype Item
	func printAndGetIt () -> Item
}
public func doPrint<T>(a:T) where T:Simplest0 {
	let _ = a.printAndGetIt ()
}
```
Up to this point, we wrote the protocol proxy in swift and a C# wrapper, but it didn't execute. The issues preventing that are fixed in this.
- the proxy needed a `ProtocolWitnessTable` property, however the implementation as it was was incorrect since it used the type metadata from `EveryProtocol`. Now the accessor uses `GetMetatype` from the associated type proxy in that case, but `EveryProtocol` otherwise.
- In calling a generic function with a protocol constraint, we have to add hidden arguments to the pinvoke: the type metadata for the generic argument and the protocol witness table for the protocol conformance. This does not work for PATs because we're not passing in the generic value. We're passing in a proxy onto the generic value and the type metadata needs to be for that type. In the code that does this, I'm really narrowing down the circumstances as "must be exactly one inheritance constraint, must be a protocol, must have associated types". Getting the correct proxy type is tricky and I'm doing a greasy trick where I map to the interface type which has correct generics and shove the generics into the name of the proxy type.
- generic classes have been calling the vtable initializer incorrectly. The vtable initializer signature is supposed to have a type argument for every generic parameter. Now it does.
- runtime `ProtocolWitnessof` for protocols with associated types is different because the type stored in the attribute is a non-specific generic proxy. At runtime we need to rarefy that type and we have the components to do that from the proxy type.

Tests pass.