### PR TITLE
Property setter with PAT

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -6313,7 +6313,7 @@ namespace SwiftReflector {
 			return CSAttribute.FromAttr (typeof (SwiftTypeNameAttribute), argList);
 		}
 
-		Func<int, int, string> MakeAssociatedTypeNamer (ProtocolDeclaration protocolDecl)
+		public static Func<int, int, string> MakeAssociatedTypeNamer (ProtocolDeclaration protocolDecl)
 		{
 			return (depth, index) => {
 				if (depth != 0)

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -171,6 +171,7 @@
     <Compile Include="SwiftXmlReflection\AssociatedTypeDeclaration.cs" />
     <Compile Include="ProtocolMethodMatcher.cs" />
     <Compile Include="PatToGenericMap.cs" />
+    <Compile Include="SwiftXmlReflection\GenericReferenceAssociatedTypeProtocol.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/SwiftXmlReflection/GenericReferenceAssociatedTypeProtocol.cs
+++ b/SwiftReflector/SwiftXmlReflection/GenericReferenceAssociatedTypeProtocol.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace SwiftReflector.SwiftXmlReflection {
+	public class GenericReferenceAssociatedTypeProtocol {
+		public NamedTypeSpec GenericPart { get; set; }
+		public ProtocolDeclaration Protocol { get; set; }
+	}
+}

--- a/SwiftReflector/TypeMapping/NetTypeBundle.cs
+++ b/SwiftReflector/TypeMapping/NetTypeBundle.cs
@@ -60,7 +60,7 @@ namespace SwiftReflector.TypeMapping {
 			GenericIndex = index;
 		}
 
-		public NetTypeBundle (ProtocolDeclaration proto, AssociatedTypeDeclaration assoc)
+		public NetTypeBundle (ProtocolDeclaration proto, AssociatedTypeDeclaration assoc, bool isReference)
 		{
 			GenericIndex = -1;
 			AssociatedTypeProtocol = proto;
@@ -68,6 +68,7 @@ namespace SwiftReflector.TypeMapping {
 			Type = OverrideBuilder.GenericAssociatedTypeName (assoc);
 			FullName = Type;
 			NameSpace = String.Empty;
+			IsReference = isReference;
 		}
 
 		static NetTypeBundle ntbVoid = new NetTypeBundle ("", kNoType, false, false, EntityType.None);


### PR DESCRIPTION
Test added for property setter with PAT.
This turned up a number of issues, most of which I addressed.
1. In consistent naming of associated types as generics. Modified `ReworkGenericTypeFromWrapperFunc` to get the right name if its that type
2. Predicates/tools for finding if a `TypeSpec` in the form 'T.Assoc` is an associated type and not a type `Assoc` in module `T`. I had neolithic versions of these tools but I decided that they needed to live in `BaseDeclaration`.
3. TypeMapper has some issues with whether or not to use the `inout` property.
4. Most importantly, in previous work I had _thought_ that when you have a function of the form `public func foo<T, U>(a: T, b: U) where T:SomeProto0, U:SomeProto1 { }` got transformed into a function of the form `public func foo<T, U>(a: T, b: T, at: T.type, ap: T.ProtocolWitness, bt: T.type, bp: T.ProtocolWitness)`. This is not the case. It's type objects first, protocol witness tables second, not interleaved.

New test.