### PR TITLE
Make wrapping work for Associated Type reference

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -341,9 +341,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		public bool HasModule {
-			get {
-				return Name.Contains (".");
+		public bool HasModule (BaseDeclaration context, TypeMapper typeMapper)
+		{
+			if (Name.Contains (".")) {
+				return !context.IsProtocolWithAssociatedTypesFullPath (new NamedTypeSpec (Name), typeMapper);
+			} else {
+				return false;
 			}
 		}
 		public string Module {
@@ -353,7 +356,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 		public string NameWithoutModule {
 			get {
-				return HasModule ? Name.Substring (Name.IndexOf ('.') + 1) : Name;
+				return Name.Contains ('.') ? Name.Substring (Name.IndexOf ('.') + 1) : Name;
 			}
 		}
 	}

--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -356,7 +356,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 		public string NameWithoutModule {
 			get {
-				return Name.Contains ('.') ? Name.Substring (Name.IndexOf ('.') + 1) : Name;
+				return Name.IndexOf ('.') >= 0 ? Name.Substring (Name.IndexOf ('.') + 1) : Name;
 			}
 		}
 	}

--- a/SwiftReflector/TypeMapping/TypeSpecToSLType.cs
+++ b/SwiftReflector/TypeMapping/TypeSpecToSLType.cs
@@ -71,7 +71,7 @@ namespace SwiftReflector.TypeMapping {
 					var genPart = spec.Module;
 					var depthIndex = declContext.GetGenericDepthAndIndex (genPart);
 					var newGenPart = new SLGenericReferenceType (depthIndex.Item1, depthIndex.Item2);
-					retval = new SLSimpleType ($"{newGenPart.ToString ()}.{spec.NameWithoutModule}");
+					retval = new SLSimpleType ($"{newGenPart}.{spec.NameWithoutModule}");
 				} else {
 					retval = new SLSimpleType (spec.NameWithoutModule);
 				}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -399,5 +399,35 @@ public func doSetProp<T, U> (a: inout T, b:U) where T:Simplest2, U==T.Item {
 			var callingCode = CSCodeBlock.Create (instDecl, doSetProp, printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
 		}
+
+		[Test]
+		[Ignore ("work in progress")]
+		public void SimpleProtocolProGetSetAssocTestAltSyntax ()
+		{
+			var swiftCode = @"
+public protocol Simplest3 {
+	associatedtype Item
+	var thing: Item { get set }
+}
+public func doSetProp<T> (a: inout T, b:T.Item) where T:Simplest3 {
+	a.thing = b
+}
+";
+			var altClass = new CSClass (CSVisibility.Public, "Simple3Impl");
+			altClass.Inheritance.Add (new CSIdentifier ("ISimplest3<SwiftString>"));
+			var thingProp = CSProperty.PublicGetSet (new CSSimpleType ("SwiftString"), "Thing");
+			altClass.Properties.Add (thingProp);
+
+			var ctor = new CSMethod (CSVisibility.Public, CSMethodKind.None, null, altClass.Name, new CSParameterList (), CSCodeBlock.Create ());
+			altClass.Methods.Add (ctor);
+
+			var instID = new CSIdentifier ("inst");
+			var instDecl = CSVariableDeclaration.VarLine (instID, new CSFunctionCall ("Simple3Impl", true));
+			var doSetProp = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoSetProp<Simple3Impl, SwiftString>", false, instID,
+				new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("Got here!")));
+			var printer = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{instID.Name}.Thing"));
+			var callingCode = CSCodeBlock.Create (instDecl, doSetProp, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
Swift allows this syntax for getting to an associated type:
```
public func foo<T: SomePAT>(a: T, b: T.SomeElement) { }
```
The problem is that as it comes in `T.SomeElement` which is intended to be "the associated type `SomeElement` relative to `T` which is a PAT is indistinguishable from "the module `T` which contains some type named `SomeElement`. The latter is more common.

The problem first manifested in code to wrap these functions because it saw `T` as a module and tried to add an `import T`, which of course doesn't exist.

My solution is to add the method `IsProtocolWithAssociatedTypesFullPath` and refactor `HasModule` in terms of that.

Past that, the wrapping code needs to take the original `T.SomeElement` and turn it into a generic reference in terms of the wrapper function, which will become (likely) `T0.SomeElement`.

The unit test for this is currently ignored because it trips up further down the line and at that point this PR would start to get ungainly.