### PR TITLE
Add support for demangling associated type paths.

### DIFF
--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -768,27 +768,47 @@ namespace SwiftReflector {
 	}
 
 	public class SwiftGenericArgReferenceType : SwiftType {
-		public SwiftGenericArgReferenceType (int depth, int index, bool isReference, SwiftName name = null)
+		public SwiftGenericArgReferenceType (int depth, int index, bool isReference, SwiftName name = null, List<string> associatedTypePath = null)
 		    : base (CoreCompoundType.GenericReference, isReference, name)
 		{
 			Depth = depth;
 			Index = index;
+			AssociatedTypePath = new List<string> ();
+			if (associatedTypePath != null)
+				AssociatedTypePath.AddRange (associatedTypePath);
 		}
 
 		public int Depth { get; private set; }
 		public int Index { get; private set; }
+		public List<string> AssociatedTypePath { get; private set; }
+		public bool HasAssociatedTypePath => AssociatedTypePath.Count > 0;
 
 		protected override bool LLEquals (SwiftType other)
 		{
 			var art = other as SwiftGenericArgReferenceType;
 			if (art == null)
 				return false;
-			return Depth == art.Depth && Index == art.Index;
+			if (Depth != art.Depth || Index != art.Index)
+				return false;
+			if (AssociatedTypePath.Count != art.AssociatedTypePath.Count)
+				return false;
+			return AssociatedTypePath.SequenceEqual (art.AssociatedTypePath);
 		}
+
 		public override string ToString()
 		{
 			var name = Name != null ? Name.Name + ": " : "";
-			return name + $"({Depth},{Index})";
+			if (HasAssociatedTypePath) {
+				var path = AssociatedTypePath.InterleaveStrings (".");
+				return name + $"({Depth},{Index}){(char)('A' + Depth)}{Index}.{path}";
+			} else {
+				return name + $"({Depth},{Index})";
+			}
+		}
+
+		public SwiftGenericArgReferenceType WithAssociatedTypePath (List<string> associatedTypePath)
+		{
+			return new SwiftGenericArgReferenceType (Depth, Index, IsReference, Name, associatedTypePath);
 		}
 	}
 

--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -805,11 +805,6 @@ namespace SwiftReflector {
 				return name + $"({Depth},{Index})";
 			}
 		}
-
-		public SwiftGenericArgReferenceType WithAssociatedTypePath (List<string> associatedTypePath)
-		{
-			return new SwiftGenericArgReferenceType (Depth, Index, IsReference, Name, associatedTypePath);
-		}
 	}
 
 	public class SwiftBoundGenericType : SwiftType {

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1386,6 +1386,33 @@ namespace SwiftReflector.Demangling {
 			Assert.AreEqual ("font", tlf.Name.Name);
 		}
 
+		[Test]
+		public void TestPATReference ()
+		{
+			var tld = Decomposer.Decompose ("_$s24ProtocolConformanceTests9doSetProp1a1byxz_4ItemQztAA9Simplest3RzlF", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLFunction;
+			Assert.IsNotNull (tlf, "not a function");
+			var arg2 = tlf.Signature.GetParameter (1) as SwiftGenericArgReferenceType;
+			Assert.IsNotNull (arg2, "Not an SLGenericReference");
+			Assert.IsTrue (arg2.HasAssociatedTypePath, "No associated type path");
+			Assert.AreEqual (1, arg2.AssociatedTypePath.Count, "wrong number of assoc type path elements");
+			Assert.AreEqual ("Item", arg2.AssociatedTypePath [0], "Mismatch in assoc type name");
+		}
 
+		[Test]
+		public void TestPATPathReference ()
+		{
+			var tld = Decomposer.Decompose ("_$s15BadAssociations7doPrint1a1byx_5Thing_4NameQZtAA13PrintableItemRzlF", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLFunction;
+			Assert.IsNotNull (tlf, "not a function");
+			var arg2 = tlf.Signature.GetParameter (1) as SwiftGenericArgReferenceType;
+			Assert.IsNotNull (arg2, "Not an SLGenericReference");
+			Assert.IsTrue (arg2.HasAssociatedTypePath, "No associated type path");
+			Assert.AreEqual (2, arg2.AssociatedTypePath.Count, "wrong number of assoc type path elements");
+			Assert.AreEqual ("Thing", arg2.AssociatedTypePath [0], "Mismatch in assoc type name 0");
+			Assert.AreEqual ("Name", arg2.AssociatedTypePath [1], "Mismatch in assoc type name 1");
+		}
 	}
 }


### PR DESCRIPTION
Fixes issue [343](https://github.com/xamarin/binding-tools-for-swift/issues/343)

How did I find this?
I had a test that had a function in the form `func foo<T>(a: T, b: T.AssocType)`. The function was coming through with the second argument being a generic reference with depth 0 and index 0, but no associated type reference.

How did I fix it?
I added an associated type path to `SwiftGenericArgReferenceType` as a list of strings, added an optional constructor argument, added extra logic for `Equals` and `ToString`.
Then I changed the reduction rule for `DependentMemberType` to go to a chunk of code to do the conversion properly. The demangle engine puts together a multi nested type with the head buried on the inside. We use head recursion in that routine via `ConvertFirstChildToSwiftType` followed by appending the associated type name. This naturally undoes the structure of tree into a list.

How did I test it?
I wrote swift code that included a single element path to an associated type, compiled it with Xcode then pulled out the mangled signature for the function. Test initially failed, then I did the fix and the test passed.
I then wrote code that included a compound element path to an associate type, compiled it, etc, etc.