### PR TITLE
Fix type mapping and marshaling for generic reference associated types

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -114,11 +114,27 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		public bool IsProtocolWithAssociatedTypesFullPath (NamedTypeSpec named, TypeMapper typeMap)
 		{
+			if (named == null)
+				return false;
 			return OwningProtocolFromGenericWithFullPath (named, typeMap) != null;
 		}
 
 		public ProtocolDeclaration OwningProtocolFromGenericWithFullPath (NamedTypeSpec named, TypeMapper typeMap)
 		{
+			AssociatedTypeDeclaration assoc = null;
+			return OwningProtocolAndAssociateTypeFromGenericWithFullPath (named, typeMap, out assoc);
+		}
+
+		public AssociatedTypeDeclaration AssociatedTypeDeclarationFromGenericWithFullPath (NamedTypeSpec named, TypeMapper typeMap)
+		{
+			AssociatedTypeDeclaration assoc = null;
+			OwningProtocolAndAssociateTypeFromGenericWithFullPath (named, typeMap, out assoc);
+			return assoc;
+		}
+
+		ProtocolDeclaration OwningProtocolAndAssociateTypeFromGenericWithFullPath (NamedTypeSpec named, TypeMapper typeMap, out AssociatedTypeDeclaration assoc)
+		{
+			assoc = null;
 			if (named.Name.Contains (".")) {
 				var parts = named.Name.Split ('.');
 				if (IsTypeSpecGeneric (parts [0])) {
@@ -142,7 +158,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 					if (entity.EntityType != EntityType.Protocol)
 						return null; // Also can't happen
 					var protocol = entity.Type as ProtocolDeclaration;
-					if (protocol != null && protocol.HasAssociatedTypes && protocol.AssociatedTypeNamed (parts [1]) != null) {
+					if (protocol != null && protocol.HasAssociatedTypes && (assoc = protocol.AssociatedTypeNamed (parts [1])) != null) {
 						return protocol;
 					}
 				}

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -417,7 +417,7 @@ namespace SwiftReflector.TypeMapping {
 
 		NetTypeBundle RecastToReference (BaseDeclaration typeContext, NetTypeBundle netBundle, TypeSpec theElem, bool structsAndEnumsAreAlwaysRefs)
 		{
-			if (typeContext.IsTypeSpecGenericReference (theElem))
+			if (typeContext.IsTypeSpecGenericReference (theElem) || typeContext.IsProtocolWithAssociatedTypesFullPath (theElem as NamedTypeSpec, this))
 				return netBundle;
 			if (theElem is ClosureTypeSpec)
 				return netBundle;
@@ -538,8 +538,15 @@ namespace SwiftReflector.TypeMapping {
 				if (IsScalar (named.Name)) {
 					return ToScalar (named.Name, spec.IsInOut);
 				}
-
-				if (context.IsEqualityConstrainedByAssociatedType (named, this)) {
+				if (context.IsProtocolWithAssociatedTypesFullPath (named, this)) {
+					if (isPinvoke) {
+						return new NetTypeBundle ("System", "IntPtr", false, false, EntityType.None);
+					} else {
+						var assocType = context.AssociatedTypeDeclarationFromGenericWithFullPath (named, this);
+						var owningProtocol = context.OwningProtocolFromGenericWithFullPath (named, this);
+						return new NetTypeBundle (owningProtocol, assocType, false);
+					}
+				} else if (context.IsEqualityConstrainedByAssociatedType (named, this)) {
 					if (isPinvoke) {
 						return new NetTypeBundle ("System", "IntPtr", false, false, EntityType.None);
 					} else {

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -401,7 +401,6 @@ public func doSetProp<T, U> (a: inout T, b:U) where T:Simplest2, U==T.Item {
 		}
 
 		[Test]
-		[Ignore ("work in progress")]
 		public void SimpleProtocolProGetSetAssocTestAltSyntax ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Fixes issue [336](https://github.com/xamarin/binding-tools-for-swift/issues/336)

In the exciting conclusion, we now (partially) support the syntax `T.AssocType` where `T` is a generic reference that is constrained to a PAT.

Here's what going on in this fix:
When mapping from a swift type to the corresponding C# type, we identify this case and map it as if it were a generic constrained to that type. It is essentially a generic - a somewhat specific generic - but a generic nonetheless).

In marshaling code, we treat it as if it were a generic reference. There were some modifications made to the marshaling code to not put in generic constraints (there are none) and not try to look up the `swiftType` as a generic reference (it contains one, but is not one), otherwise it marshals just fine as is.

Test now passes.