### PR TITLE
Fix for marshaling associated type paths in return values

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -2327,6 +2327,9 @@ namespace SwiftReflector {
 			if (ts is TupleTypeSpec && ((TupleTypeSpec)ts).Elements.Count > 1)
 				return true;
 
+			if (funcDecl.IsProtocolWithAssociatedTypesFullPath (ts as NamedTypeSpec, typeMapper))
+				return true;
+
 			var en = typeMapper.GetEntityForTypeSpec (ts);
 			if (en == null)
 				return false;

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -693,6 +693,8 @@ namespace SwiftReflector.TypeMapping {
 				return null;
 			if (context.IsTypeSpecGenericReference (boundType))
 				return null;
+			if (context.IsProtocolWithAssociatedTypesFullPath (boundType, this))
+				return null;
 			var entity = TypeDatabase.EntityForSwiftName (boundType.Name);
 			return entity.EntityType == EntityType.Scalar  || SwiftType.IsStructScalar (boundType.Name) ? entity : null;
 		}
@@ -704,6 +706,8 @@ namespace SwiftReflector.TypeMapping {
 				return null;
 			if (context.IsTypeSpecGenericReference (boundType))
 				return null;
+			if (context.IsProtocolWithAssociatedTypesFullPath (boundType, this))
+				return null;
 			var entity = TypeDatabase.EntityForSwiftName (boundType.Name);
 			return entity.IsObjCStruct || entity.IsObjCEnum ? entity : null;
 		}
@@ -714,6 +718,8 @@ namespace SwiftReflector.TypeMapping {
 			if (boundType == null)
 				return null;
 			if (context.IsTypeSpecGenericReference (boundType))
+				return null;
+			if (context.IsProtocolWithAssociatedTypesFullPath (boundType, this))
 				return null;
 			var entity = TypeDatabase.EntityForSwiftName (boundType.Name);
 			return entity.IsObjCStruct || entity.IsObjCEnum ? boundType : null;
@@ -1020,6 +1026,8 @@ namespace SwiftReflector.TypeMapping {
 			if (sp is ClosureTypeSpec)
 				return false;
 			if (context.IsTypeSpecGeneric (sp) && context.IsTypeSpecGenericReference (sp))
+				return true;
+			if (context.IsProtocolWithAssociatedTypesFullPath (sp as NamedTypeSpec, this))
 				return true;
 			var en = GetEntityForTypeSpec (sp);
 			if (en == null)

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -428,5 +428,37 @@ public func doSetProp<T> (a: inout T, b:T.Item) where T:Simplest3 {
 			var callingCode = CSCodeBlock.Create (instDecl, doSetProp, printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
 		}
+
+		[Test]
+		public void SimpleProtocolProGetIndexer ()
+		{
+			var swiftCode = @"
+public protocol Simplest4 {
+	associatedtype Item
+	subscript (index: Int) -> Item {
+		get
+	}
+}
+public func doGetIt<T:Simplest4> (a: T, i: Int) -> T.Item {
+	return a[i]
+}
+";
+			var altClass = new CSClass (CSVisibility.Public, "Simple4Impl");
+			altClass.Inheritance.Add (new CSIdentifier ("ISimplest4<SwiftString>"));
+
+			var getBlock = CSCodeBlock.Create (CSReturn.ReturnLine (new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("Got here!"))));
+			var parameters = new CSParameterList (new CSParameter (new CSSimpleType ("nint"), new CSIdentifier ("index")));
+			var thingIndex = new CSProperty (new CSSimpleType ("SwiftString"), CSMethodKind.None,
+				CSVisibility.Public, getBlock, CSVisibility.Public, null, parameters);
+			altClass.Properties.Add (thingIndex);
+
+			var ctor = new CSMethod (CSVisibility.Public, CSMethodKind.None, null, altClass.Name, new CSParameterList (), CSCodeBlock.Create ());
+			altClass.Methods.Add (ctor);
+			var instID = new CSIdentifier ("inst");
+			var instDecl = CSVariableDeclaration.VarLine (instID, new CSFunctionCall ("Simple4Impl", true));
+			var printer = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{instID.Name}[3]"));
+			var callingCode = CSCodeBlock.Create (instDecl, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
This fixes issue [347](https://github.com/xamarin/binding-tools-for-swift/issues/347) when marshaling a return value that is an associated type path

Marshaling was wrong at a number of levels:
- the function `MustBeInOut` in MethodWrapping needed a case for associated type paths
- TypeMapper had a number of functions that needed cases for associated type paths
- finally MarshalEngine needed to handle associated type paths as pointers appropriately

The code for marshaling from C# to swift and back is very similar to the code for handling a pointer to a generic type, but there are enough differences that it would have taken away from the readability of unified code to handle both.