### PR TITLE
Added predicate for dynamic self

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
@@ -51,7 +51,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 
 		public bool HasDynamicSelf {
-			// you could cache this, but this type is not mutable, so that would be bad
+			// you shouldn't cache this. This type is mutable, so that would be bad
 			get => SearchForDynamicSelf ();
 		}
 

--- a/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
@@ -82,30 +82,36 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		bool SearchForDynamicSelf (PropertyDeclaration propDecl)
 		{
-			var types = new List<TypeSpec> ();
-			types.Add (propDecl.TypeSpec);
-			return SearchForDynamicSelf (types);
+			return SearchForDynamicSelf (propDecl.TypeSpec);
 		}
 
 		bool SearchForDynamicSelf (List<TypeSpec> types)
 		{
 			foreach (var type in types) {
-				if (type is NamedTypeSpec ns) {
-					if (SearchForDynamicSelf (ns))
-						return true;
-				} else if (type is TupleTypeSpec tuple) {
-					if (SearchForDynamicSelf (tuple.Elements))
-						return true;
-				} else if (type is ClosureTypeSpec closure) {
-					var moreTypes = new List<TypeSpec> ();
-					moreTypes.Add (closure.Arguments);
-					if (!TypeSpec.IsNullOrEmptyTuple (closure.ReturnType))
-						moreTypes.Add (closure.ReturnType);
-					if (SearchForDynamicSelf (moreTypes))
-						return true;
-				}
-				// don't care about protocol list
+				if (SearchForDynamicSelf (type))
+					return true;
 			}
+			return false;
+		}
+
+		bool SearchForDynamicSelf (TypeSpec type)
+		{
+			if (type is NamedTypeSpec ns) {
+				if (SearchForDynamicSelf (ns))
+					return true;
+			} else if (type is TupleTypeSpec tuple) {
+				if (SearchForDynamicSelf (tuple.Elements))
+					return true;
+			} else if (type is ClosureTypeSpec closure) {
+				if (SearchForDynamicSelf (closure.Arguments)) {
+					return true;
+				}
+				if (!TypeSpec.IsNullOrEmptyTuple (closure.ReturnType) &&
+					SearchForDynamicSelf (closure.ReturnType)) {
+					return true;
+				}
+			}
+			// don't care about protocol list
 			return false;
 		}
 

--- a/SwiftVersion.mk
+++ b/SwiftVersion.mk
@@ -2,4 +2,4 @@
 SWIFT_BRANCH=swift-5.0-branch-tomswifty
 SWIFT_SCHEME=swift-5.0-branch
 # this hash should be the most recent in the above branch
-SWIFT_HASH=872054a463ffb15b7a45a5c2cdab643d0c04424b
+SWIFT_HASH=f645a99fa62555b4f6a34e8c4bd91bd0c2585660

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1307,5 +1307,98 @@ private var x: T
 			Assert.AreEqual ("Public SomeModule.Foo.printIt<T, U> (a: U) -> ()", output);
 		}
 
+		[Test]
+		public void DetectsSelfEasy ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> Self
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
+
+		[Test]
+		public void DetectsSelfEasy1 ()
+		{
+			var code = @"
+public protocol NoSelf {
+	func whoami (a: NoSelf)
+}
+public protocol Simple {
+	associatedtype Thing
+	func whoami(a: Self) -> Thing
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
+
+		[Test]
+		public void DetectsSelfInTuple ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> (Int, Bool, Self)
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
+
+		[Test]
+		public void DetectsSelfInOptional ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> Self?
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
+
+		[Test]
+		public void DetectsSelfInBoundGeneric ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> UnsafeMutablePointer<Self>
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
+
+		[Test]
+		public void DetectsSelfInClosure ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami(a: (Self)->()) -> ()
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
+		}
 	}
 }


### PR DESCRIPTION
We need the ability to detect if a protocol contains the type `Self` which is the dynamic self type.

To do this, I added code in `ProtocolDeclaration` to search through all the members for it as a type. This ends up being recursive to search through tuples, closures, etc.

In the process, I discovered an issue with the reflector in that if a protocol comes through as a parameter type, it always is listed as `Self` which is incorrect - it should be the full name of the protocol. The problem is that if the type really was `Self` it needs to stay self. So how do distinguish between the two cases?

In the reflector, I added a call to `existentialTypeSupported` which returns `true` if and only if a type can be represented by an existential type. If a type has `Self` or an associated type, it can't be an existential type, so if `existentialTypeSupported` returns false means that the `Self` is appropriate.

Tests as per usual.