### PR TITLE
Made XML imported fool the type system

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
@@ -218,21 +218,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 			var protoDecl = decl as ProtocolDeclaration;
 			if (protoDecl != null) {
+				var addSelf = false;
 				if (elem.Element ("associatedtypes") != null) {
 					var assocElements = from assocElem in elem.Element ("associatedtypes").Elements ()
 							    select AssociatedTypeDeclaration.FromXElement (assocElem);
 					protoDecl.AssociatedTypes.AddRange (assocElements);
-					var selfIndex = protoDecl.AssociatedTypes.FindIndex (at => at.Name == "Self");
-					if (selfIndex > 0) {
-						// if it's present and not at 0, remove it
-						var assoc = protoDecl.AssociatedTypes [selfIndex];
-						protoDecl.AssociatedTypes.RemoveAt (selfIndex);
-						protoDecl.AssociatedTypes.Insert (0, assoc);
-					}
+					addSelf = protoDecl.AssociatedTypes.RemoveAll (at => at.Name == "Self") > 0;
 				}
-				if (protoDecl.HasDynamicSelf) {
-					if (protoDecl.AssociatedTypes.Count == 0 || (protoDecl.AssociatedTypes.Count > 0 && protoDecl.AssociatedTypes [0].Name != "Self"))
-						protoDecl.AssociatedTypes.Insert (0, new AssociatedTypeDeclaration { Name = "Self" });
+				if (protoDecl.HasDynamicSelf || addSelf) {
+					protoDecl.AssociatedTypes.Insert (0, new AssociatedTypeDeclaration { Name = "Self" });
 				}
 			}
 

--- a/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeDeclaration.cs
@@ -222,6 +222,17 @@ namespace SwiftReflector.SwiftXmlReflection {
 					var assocElements = from assocElem in elem.Element ("associatedtypes").Elements ()
 							    select AssociatedTypeDeclaration.FromXElement (assocElem);
 					protoDecl.AssociatedTypes.AddRange (assocElements);
+					var selfIndex = protoDecl.AssociatedTypes.FindIndex (at => at.Name == "Self");
+					if (selfIndex > 0) {
+						// if it's present and not at 0, remove it
+						var assoc = protoDecl.AssociatedTypes [selfIndex];
+						protoDecl.AssociatedTypes.RemoveAt (selfIndex);
+						protoDecl.AssociatedTypes.Insert (0, assoc);
+					}
+				}
+				if (protoDecl.HasDynamicSelf) {
+					if (protoDecl.AssociatedTypes.Count == 0 || (protoDecl.AssociatedTypes.Count > 0 && protoDecl.AssociatedTypes [0].Name != "Self"))
+						protoDecl.AssociatedTypes.Insert (0, new AssociatedTypeDeclaration { Name = "Self" });
 				}
 			}
 

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1400,5 +1400,102 @@ public protocol Simple {
 			Assert.IsNotNull (proto, "no protocol");
 			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
 		}
+
+		[Test]
+		public void SelfIsInAssociatedTypesArg ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami (a: Self)
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
+
+		[Test]
+		public void SelfIsInAssociatedTypesReturn ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami () -> Self
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
+
+		[Test]
+		public void SelfIsInAssociatedTypesTuple ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> (Int, Bool, Self)
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
+
+		[Test]
+		public void SelfIsInAssociatedTypesOptional ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> Self?
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
+
+		[Test]
+		public void SelfIsInAssociatedTypesBoundGeneric ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami() -> UnsafeMutablePointer<Self>
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
+
+
+		[Test]
+		public void SelfIsInAssociatedTypesClosure ()
+		{
+			var code = @"
+public protocol Simple {
+	func whoami(a: ()->Self)
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var proto = module.Protocols.Where (p => p.Name == "Simple").FirstOrDefault ();
+			Assert.IsNotNull (proto, "no protocol");
+			Assert.AreEqual (1, proto.AssociatedTypes.Count, "assoc type count mismatch");
+			Assert.AreEqual ("Self", proto.AssociatedTypes [0].Name);
+		}
 	}
 }


### PR DESCRIPTION
When types get imported from XML, I injected code to ensure that if `Self` is listed as an associated type, it will be the first element and if `Self` is not already in the list and the type contains a usage of dynamic self, then it injects a `Self` associated type as the first element.

The first case is necessary in case we are round-tripping types that, for whatever reason, might have gotten reordered.

Why do I want this first? Because it is going to be easier to track as a special case when needed. This type of test is going to be way faster than `HasDynamicSelf`.

Tests, tests and more tests.