### PR TITLE
Start to accept dynamic self

### DIFF
--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -52,6 +52,7 @@ namespace SwiftReflector {
 		Tuple,
 		Closure,
 		ProtocolList,
+		DynamicSelf,
 	}
 
 	public enum MemberNesting {

--- a/SwiftReflector/MarshalEngineSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineSwiftToCSharp.cs
@@ -201,7 +201,7 @@ namespace SwiftReflector {
 							}
 						} else {
 							var entity = typeMapper.GetEntityForTypeSpec (func.ReturnTypeSpec);
-							if (func.ReturnTypeSpec is NamedTypeSpec && entity == null)
+							if (func.ReturnTypeSpec is NamedTypeSpec && entity == null && !func.ReturnTypeSpec.IsDynamicSelf)
 								throw new NotImplementedException ($"Function {func.ToFullyQualifiedName (true)} has an unknown return type {func.ReturnTypeSpec.ToString ()}");
 							if (entity?.EntityType == EntityType.TrivialEnum) {
 								imports.AddIfNotPresent (entity.Type.Module.Name);
@@ -263,7 +263,7 @@ namespace SwiftReflector {
 									// retval.deallocate()
 									// return actualRetval
 									string allocCallSite = String.Format ("UnsafeMutablePointer<{0}>.allocate", func.ReturnTypeName);
-									if (namedReturn != null)
+									if (namedReturn != null && !namedReturn.IsDynamicSelf)
 										imports.AddIfNotPresent (namedReturn.Module);
 									string retvalName = MarshalEngine.Uniqueify ("retval", identifiersUsed);
 									identifiersUsed.Add (retvalName);
@@ -457,7 +457,7 @@ namespace SwiftReflector {
 
 		bool NamedSpecIsClass (NamedTypeSpec spec)
 		{
-			return spec != null && typeMapper.GetEntityTypeForSwiftClassName (spec.Name) == EntityType.Class;
+			return spec != null && !spec.IsDynamicSelf && typeMapper.GetEntityTypeForSwiftClassName (spec.Name) == EntityType.Class;
 		}
 
 		SLFuncType ToMarshaledClosureType (BaseDeclaration declContext, ClosureTypeSpec closure)

--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -283,6 +283,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return theSpec;
 		}
 
+		public bool IsDynamicSelf {
+			get {
+				return this is NamedTypeSpec ns && ns.Name == "Self";
+			}
+		}
+
 		public abstract bool HasDynamicSelf {
 			get;
 		}

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -142,7 +142,7 @@ namespace SwiftReflector.TypeMapping {
 			if (spec == null)
 				return null;
 			var ns = spec as NamedTypeSpec;
-			if (ns == null)
+			if (ns == null || spec.IsDynamicSelf)
 				return null;
 			return GetEntityForSwiftClassName (ns.Name);
 		}
@@ -153,6 +153,8 @@ namespace SwiftReflector.TypeMapping {
 				return EntityType.None;
 
 			if (spec is NamedTypeSpec) {
+				if (spec.IsDynamicSelf)
+					return EntityType.DynamicSelf;
 				var ent = GetEntityForTypeSpec (spec);
 				return ent != null ? ent.EntityType : EntityType.None;
 			}
@@ -1028,6 +1030,8 @@ namespace SwiftReflector.TypeMapping {
 			if (context.IsTypeSpecGeneric (sp) && context.IsTypeSpecGenericReference (sp))
 				return true;
 			if (context.IsProtocolWithAssociatedTypesFullPath (sp as NamedTypeSpec, this))
+				return true;
+			if (sp.IsDynamicSelf)
 				return true;
 			var en = GetEntityForTypeSpec (sp);
 			if (en == null)

--- a/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Dynamo.CSLang;
+using NUnit.Framework;
+using SwiftReflector;
+using tomwiftytest;
+
+namespace SwiftReflector {
+	[TestFixture]
+	[Parallelizable (ParallelScope.All)]
+	[RunWithLeaks]
+	public class DynamicSelfTests {
+		[Ignore ("Still smoking")]
+		[Test]
+		public void SmokeTestSimplest ()
+		{
+			var swiftCode = @"
+public protocol Identity0 {
+	func whoAmI () -> Self
+}
+";
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("Got here."));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", platform: PlatformName.macOS);
+
+		}
+	}
+}

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -111,6 +111,7 @@
     <Compile Include="SwiftReflector\SwiftTypeAttributeNameTests.cs" />
     <Compile Include="SwiftReflector\SwiftTypeRegistryTests.cs" />
     <Compile Include="SwiftReflector\ProtocolConformanceTests.cs" />
+    <Compile Include="SwiftReflector\DynamicSelfTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Added the entity type `DynamicSelf`, started going through NREs when trying to wrap a simple protocol that returns `Self`.

As part of this, I added `IsDynamicSelf` to `TypeSpec` which returns true if and only if the type is `Self`, as opposed to `HasDynamicSelf` which returns true if the type is `Self` or contains a type that is `Self`.

At this point, the wrappers get written, but aren't correct yet. The next step is out of the scope of these changes, so I'll do that next.

Test is currently ignored.