### PR TITLE
Handle dynamic self in returns

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/ParameterItem.cs
+++ b/SwiftReflector/SwiftXmlReflection/ParameterItem.cs
@@ -130,8 +130,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 
 			for (int i = 0; i < pl1.Count; i++) {
-				ParameterItem p1 = RecastAsReference (pl1 [i]);
-				ParameterItem p2 = RecastAsReference (pl2 [i]);
+				var p1 = SubstituteSelfFromParent (fn1, pl1 [i]);
+				var p2 = SubstituteSelfFromParent (fn2, pl2 [i]);
+				p1 = RecastAsReference (p1);
+				p2 = RecastAsReference (p2);
+
+
 				// Names invariant means TYPE names not parameter names
 				if (!ParameterNamesMatch (p1, p2)) {
 					// we give a pass on matching "self".
@@ -163,6 +167,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 				}
 			}
 			return true;
+		}
+
+		static ParameterItem SubstituteSelfFromParent (FunctionDeclaration func, ParameterItem p)
+		{
+			if (func.Parent == null || !p.TypeSpec.HasDynamicSelf)
+				return p;
+			p = new ParameterItem (p);
+			p.TypeSpec = p.TypeSpec.ReplaceName ("Self", func.Parent.ToFullyQualifiedNameWithGenerics ());
+			return p;
 		}
 
 		static ParameterItem RecastAsReference (ParameterItem p)

--- a/SwiftReflector/TypeMapping/NetTypeBundle.cs
+++ b/SwiftReflector/TypeMapping/NetTypeBundle.cs
@@ -71,6 +71,15 @@ namespace SwiftReflector.TypeMapping {
 			IsReference = isReference;
 		}
 
+		public NetTypeBundle (string selfRepresentation, bool isReference)
+		{
+			GenericIndex = -1;
+			Type = FullName = Ex.ThrowOnNull (selfRepresentation, nameof (selfRepresentation));
+			NameSpace = String.Empty;
+			IsReference = isReference;
+			IsSelf = true;
+		}
+
 		static NetTypeBundle ntbVoid = new NetTypeBundle ("", kNoType, false, false, EntityType.None);
 
 		public static NetTypeBundle Void { get { return ntbVoid; } }
@@ -82,6 +91,7 @@ namespace SwiftReflector.TypeMapping {
 			}
 		}
 
+		public bool IsSelf { get; private set; }
 		public bool IsVoid { get; private set; }
 		public string Type { get; private set; }
 		public string NameSpace { get; private set; }
@@ -189,7 +199,7 @@ namespace SwiftReflector.TypeMapping {
 					genref.InterfaceConstraints.AddRange (this.GenericConstraints.Select (ntb => ntb.ToCSType (use)));
 				}
 				return genref;
-			} else if (IsAssociatedType) {
+			} else if (IsAssociatedType || IsSelf) {
 				return new CSSimpleType (Type, false);
 			}
 

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -572,6 +572,12 @@ namespace SwiftReflector.TypeMapping {
 						var assocType = context.AssociatedTypeDeclarationFromNamedTypeSpec (named);
 						return new NetTypeBundle (context.AsProtocolOrParentAsProtocol (), assocType, named.IsInOut);
 					}
+				} else if (named.Name == "Self") {
+					if (isPinvoke) {
+						return new NetTypeBundle ("System", "IntPtr", false, named.IsInOut, EntityType.None);
+					} else {
+						return new NetTypeBundle (NewClassCompiler.kGenericSelfName, named.IsInOut);
+					}
 				} else {
 					Entity en = TypeDatabase.EntityForSwiftName (named.Name);
 					if (en != null) {
@@ -623,6 +629,10 @@ namespace SwiftReflector.TypeMapping {
 						} else {
 							var retval = new NetTypeBundle (en.SharpNamespace, en.SharpTypeName, false, spec.IsInOut, en.EntityType);
 							if (en.EntityType == EntityType.Protocol && en.Type is ProtocolDeclaration proto) {
+								if (proto.HasDynamicSelf) {
+									var genMap = new NetTypeBundle (NewClassCompiler.kGenericSelfName, spec.IsInOut);
+									retval.GenericTypes.Add (genMap);
+								}
 								foreach (var assoc in proto.AssociatedTypes) {
 									var genMap = new NetTypeBundle (proto, assoc, spec.IsInOut);
 									retval.GenericTypes.Add (genMap);

--- a/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
@@ -12,7 +12,6 @@ namespace SwiftReflector {
 	[Parallelizable (ParallelScope.All)]
 	[RunWithLeaks]
 	public class DynamicSelfTests {
-		[Ignore ("Still smoking")]
 		[Test]
 		public void SmokeTestSimplest ()
 		{


### PR DESCRIPTION
This is a smoke test - it writes swift wrappers and C# bindings and both compile correctly.
Does it run? 🤷 That's for another day.

How does this work? ALL THE SPECIAL CASES.
- made a change to the code that matches wrappers to original functions to understand about self. This gets done by substituting the parent protocol type for Self.
- marshaling code needed to know about self. This code will fail with Self in arguments. That's OK, that's more special cases for another day
- made a new type of `NetTypeBundle` to understand dynamic self (and wishing that C# had discriminated unions)
- made the type mapper understand dynamic sel

Smoke test now passes.