### PR TITLE
Execute dynamic self in unit test

### DIFF
--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -84,7 +84,7 @@ namespace SwiftReflector {
 				} else {
 					swiftParms = setter.ParameterLists [1].Skip (1).ToList ();
 				}
-				var args = typeMap.MapParameterList (getter, swiftParms, false, false, null, null);
+				var args = typeMap.MapParameterList (getter, swiftParms, false, false, null, null, packs);
 				args.ForEach (a => AddUsingBlock (packs, a.Type));
 
 				var csParams =
@@ -140,7 +140,7 @@ namespace SwiftReflector {
 		{
 			bool returnIsGeneric = func.IsTypeSpecGeneric (func.ReturnTypeSpec);
 			var returnIsSelf = !TypeSpec.IsNullOrEmptyTuple (func.ReturnTypeSpec) && func.ReturnTypeSpec.IsDynamicSelf;
-			var args = typeMap.MapParameterList (func, func.ParameterLists.Last (), objectsAreIntPtrs, true, null, null);
+			var args = typeMap.MapParameterList (func, func.ParameterLists.Last (), objectsAreIntPtrs, true, null, null, packs);
 			RemapSwiftClosureRepresensation (args);
 			var returnType = returnIsGeneric || returnIsSelf ? null : typeMap.MapType (func, func.ReturnTypeSpec, objectsAreIntPtrs, true);
 			delegateName = delegateName ?? typeMap.SanitizeIdentifier (func.Name);
@@ -210,7 +210,7 @@ namespace SwiftReflector {
 			isStatic = isStatic || func.IsExtension;
 			var extraProtoArgs = new CSGenericTypeDeclarationCollection ();
 			var extraProtoConstraints = new CSGenericConstraintCollection ();
-			var args = typeMap.MapParameterList (func, func.ParameterLists.Last (), isPinvoke, false, extraProtoArgs, extraProtoConstraints);
+			var args = typeMap.MapParameterList (func, func.ParameterLists.Last (), isPinvoke, false, extraProtoArgs, extraProtoConstraints, packs);
 			if (isPinvoke && func.ParameterLists.Count > 1) {
 				var metaTypeBundle = new NetTypeBundle ("SwiftRuntimeLibrary", "SwiftMetatype", false, false, EntityType.None);
 				NetParam p = new NetParam ("metaClass", metaTypeBundle);

--- a/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
@@ -25,5 +25,50 @@ public protocol Identity0 {
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", platform: PlatformName.macOS);
 
 		}
+
+		[Test]
+		public void TestSimplest ()
+		{
+			var swiftCode = @"
+public protocol Identity1 {
+	func whoAmI () -> Self
+}
+
+public func getName (a: Identity1) -> String {
+	let o = a.whoAmI
+	let t = type(of: o)
+	return String(describing: t)
+}
+";
+
+			// public class Foo : Identity1<Foo>
+			// {
+			//    public Foo () { }
+			//    public Foo WhoAmI () {
+			//        return this;
+			//    }
+			// }
+
+			var auxClass = new CSClass (CSVisibility.Public, "Foo");
+			auxClass.Inheritance.Add (new CSIdentifier ("IIdentity1<Foo>"));
+
+			var ctor = new CSMethod (CSVisibility.Public, CSMethodKind.None, null, auxClass.Name,
+				new CSParameterList (), new CSCodeBlock ());
+			var whoAmI = new CSMethod (CSVisibility.Public, CSMethodKind.None, new CSSimpleType (auxClass.Name.Name),
+				new CSIdentifier ("WhoAmI"), new CSParameterList (),
+				CSCodeBlock.Create (CSReturn.ReturnLine (CSIdentifier.This)));
+
+			auxClass.Constructors.Add (ctor);
+			auxClass.Methods.Add (whoAmI);
+
+			var instName = new CSIdentifier ("inst");
+			var nameName = new CSIdentifier ("name");
+			var instDecl = CSVariableDeclaration.VarLine (instName, new CSFunctionCall (auxClass.Name, new Dynamo.CommaListElementCollection<CSBaseExpression> (), true));
+			var nameDecl = CSVariableDeclaration.VarLine (nameName, new CSFunctionCall ("TopLevelEntities.GetName", false, instName));
+			var printer = CSFunctionCall.ConsoleWriteLine (nameName);
+			var callingCode = CSCodeBlock.Create (instDecl, nameDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "() -> Identity1\n", otherClass: auxClass, platform: PlatformName.macOS);
+		}
 	}
 }


### PR DESCRIPTION
The goal this PR was to execute code in C# that implements an interface using dynamic self only in a return.

There were three issues that came to light from this test:

1. The C# code for the top level function did not compile because of an incorrect function signature. The generic parameter for `TSelf` needed to get added into the function signature. Fortunately, there is a code path to do that in `TypeMapper.cs` for generics with constraints, so the code there just detects this special case and injects `TSelf` and its constraint.
2. There was a runtime error when making the proxy. Necessarily, in `SwiftProtocolAttribute`, the type of the proxy is unbound, eg, `FooProxy<,,,>`, but the proxy that gets created needs to have concrete types, so find the interface via reflection and extract the types from it and inject them into the proxy type and use this to make the proxy.
3. The vtable setter pinvoke and the corresponding C# implementation was incorrectly trying to pass metadata types into swift. This isn't correct behavior, so the code the generates the vtable setter and the pinvoke declaration needed to only add `SwiftMetatype` arguments if it was a real generic type, as opposed to this case, which is an `EveryProtocol` in swift which has no generics.