### PR TITLE
Arguments with my self

### DIFF
--- a/SwiftReflector/MarshalEngineSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineSwiftToCSharp.cs
@@ -354,6 +354,10 @@ namespace SwiftReflector {
 
 		SLBaseExpr MarshalNamedTypeSpec (BaseDeclaration declContext, string name, NamedTypeSpec spec)
 		{
+			if (spec.IsDynamicSelf) {
+				return MarshalDynamicSelf (declContext, name);
+			}
+
 			if (typeMapper.GetEntityForTypeSpec (spec) == null)
 				throw new NotImplementedException ($"Unknown type {name}:{spec.ToString ()} in context {declContext.ToFullyQualifiedName (true)}");
 			bool isClass = NamedSpecIsClass (spec);
@@ -424,6 +428,12 @@ namespace SwiftReflector {
 			postMarshalCode.Add (ptrDealloc);
 			return new SLFunctionCall ("toIntPtr", false, true,
 						   new SLArgument (new SLIdentifier ("value"), localPtr, true));
+		}
+
+		SLBaseExpr MarshalDynamicSelf (BaseDeclaration declContext, string name)
+		{
+			return new SLFunctionCall ("toIntPtr", false, true,
+						   new SLArgument (new SLIdentifier ("value"), new SLIdentifier ("self"), true));
 		}
 
 		SLBaseExpr MarshalProtocolListTypeSpec (BaseDeclaration declContext, string name, ProtocolListTypeSpec protocols)

--- a/SwiftReflector/PatToGenericMap.cs
+++ b/SwiftReflector/PatToGenericMap.cs
@@ -17,7 +17,7 @@ namespace SwiftReflector {
 		public PatToGenericMap (ProtocolDeclaration protocolDecl)
 		{
 			Ex.ThrowOnNull (protocolDecl, nameof (protocolDecl));
-			if (!protocolDecl.HasAssociatedTypes)
+			if (!(protocolDecl.HasAssociatedTypes || (protocolDecl.HasDynamicSelf && ! protocolDecl.HasDynamicSelfInReturnOnly)))
 				throw new ArgumentException ("ProtocolDeclaration has no associated types", nameof (protocolDecl));
 			this.protocolDecl = protocolDecl;
 			AddAssocTypesToNameMap (this.protocolDecl);
@@ -27,6 +27,9 @@ namespace SwiftReflector {
 		{
 			for (int i = 0; i < decl.AssociatedTypes.Count; i++) {
 				nameIndexMap.Add (OverrideBuilder.GenericAssociatedTypeName (decl.AssociatedTypes [i]), i);
+			}
+			if (decl.HasDynamicSelf) {
+				nameIndexMap.Add (OverrideBuilder.GenericAssociatedTypeName ("Self"), decl.AssociatedTypes.Count);
 			}
 		}
 
@@ -60,6 +63,10 @@ namespace SwiftReflector {
 			var index = Int32.Parse (indexString);
 			if (index < 0)
 				throw new ArgumentOutOfRangeException (nameof (genericName), $"Expecting a non-negative number in '{genericName}'");
+
+			if (index == protocolDecl.AssociatedTypes.Count && protocolDecl.HasDynamicSelf)
+				return new AssociatedTypeDeclaration () { Name = "Self" };
+
 			if (index >= protocolDecl.AssociatedTypes.Count)
 				throw new ArgumentOutOfRangeException (nameof (genericName), $"Index value {index} from generic name '{genericName}' is out of range of the associated type collection");
 

--- a/SwiftReflector/PatToGenericMap.cs
+++ b/SwiftReflector/PatToGenericMap.cs
@@ -17,7 +17,7 @@ namespace SwiftReflector {
 		public PatToGenericMap (ProtocolDeclaration protocolDecl)
 		{
 			Ex.ThrowOnNull (protocolDecl, nameof (protocolDecl));
-			if (!(protocolDecl.HasAssociatedTypes || (protocolDecl.HasDynamicSelf && ! protocolDecl.HasDynamicSelfInReturnOnly)))
+			if (!(protocolDecl.HasAssociatedTypes || (protocolDecl.HasDynamicSelf && !protocolDecl.HasDynamicSelfInReturnOnly)))
 				throw new ArgumentException ("ProtocolDeclaration has no associated types", nameof (protocolDecl));
 			this.protocolDecl = protocolDecl;
 			AddAssocTypesToNameMap (this.protocolDecl);

--- a/SwiftReflector/ProtocolMethodMatcher.cs
+++ b/SwiftReflector/ProtocolMethodMatcher.cs
@@ -149,8 +149,7 @@ namespace SwiftReflector {
 
 		public static ClassDeclaration FindWrapperClass (WrappingResult wrapper, ProtocolDeclaration protocol)
 		{
-			var className = protocol.HasAssociatedTypes || protocol.HasDynamicSelfInArguments ? OverrideBuilder.AssociatedTypeProxyClassName (protocol) :
-				OverrideBuilder.ProxyClassName (protocol);
+			var className = protocol.IsExistential ? OverrideBuilder.ProxyClassName (protocol) : OverrideBuilder.AssociatedTypeProxyClassName (protocol);
 			var theClass = wrapper.Module.Classes.FirstOrDefault (cl => cl.Name == className);
 			return wrapper.FunctionReferenceCodeMap.OriginalOrReflectedClassFor (theClass) as ClassDeclaration;
 		}

--- a/SwiftReflector/ProtocolMethodMatcher.cs
+++ b/SwiftReflector/ProtocolMethodMatcher.cs
@@ -149,7 +149,7 @@ namespace SwiftReflector {
 
 		public static ClassDeclaration FindWrapperClass (WrappingResult wrapper, ProtocolDeclaration protocol)
 		{
-			var className = protocol.HasAssociatedTypes ? OverrideBuilder.AssociatedTypeProxyClassName (protocol) :
+			var className = protocol.HasAssociatedTypes || protocol.HasDynamicSelfInArguments ? OverrideBuilder.AssociatedTypeProxyClassName (protocol) :
 				OverrideBuilder.ProxyClassName (protocol);
 			var theClass = wrapper.Module.Classes.FirstOrDefault (cl => cl.Name == className);
 			return wrapper.FunctionReferenceCodeMap.OriginalOrReflectedClassFor (theClass) as ClassDeclaration;

--- a/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Xml.Linq;
 using SwiftReflector.IOUtils;
 
@@ -53,6 +54,17 @@ namespace SwiftReflector.SwiftXmlReflection {
 				return pieces [1];
 			}
 			return null;
+		}
+
+		public static BaseConstraint CopyOf (BaseConstraint baseConstraint)
+		{
+			if (baseConstraint is InheritanceConstraint inh) {
+				return new InheritanceConstraint (inh.Name, inh.Inherits);
+
+			} else if (baseConstraint is EqualityConstraint eq) {
+				return new EqualityConstraint (eq.Type1, eq.Type2);
+			}
+			throw new NotImplementedException ($"Unknown constraint type {baseConstraint.GetType ().Name}");
 		}
 	}
 

--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -99,6 +99,11 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return ThisOrParentProtocol (this);
 		}
 
+		public BaseDeclaration AsTypeDeclaration ()
+		{
+			return ThisOrParentTypeDeclaration (this);
+		}
+
 		static ProtocolDeclaration ThisOrParentProtocol (BaseDeclaration self)
 		{
 			if (self == null)
@@ -111,6 +116,20 @@ namespace SwiftReflector.SwiftXmlReflection {
 			} while (self != null);
 			return null;
 		}
+
+		static TypeDeclaration ThisOrParentTypeDeclaration (BaseDeclaration self)
+		{
+			if (self == null)
+				return null;
+
+			do {
+				if (self is TypeDeclaration decl)
+					return decl;
+				self = self.Parent;
+			} while (self != null);
+			return null;
+		}
+
 
 		public bool IsProtocolWithAssociatedTypesFullPath (NamedTypeSpec named, TypeMapper typeMap)
 		{
@@ -275,7 +294,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 								// Find the entity in the database
 								var entity = typeMap.TypeDatabase.EntityForSwiftName (inheritance.Inherits);
 								// Is it a protocol and it has associated types
-								if (entity != null && entity.Type is ProtocolDeclaration proto && proto.HasAssociatedTypes)
+								if (entity != null && entity.Type is ProtocolDeclaration proto && (proto.HasAssociatedTypes || proto.HasDynamicSelfInArguments))
 									result = new GenericReferenceAssociatedTypeProtocol () {
 										GenericPart = spec,
 										Protocol = proto

--- a/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
@@ -20,6 +20,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 			Name = name;
 		}
 
+		public GenericDeclaration (GenericDeclaration other)
+			: this ()
+		{
+			Name = other.Name;
+			foreach (var constraint in other.Constraints) {
+				Constraints.Add (BaseConstraint.CopyOf (constraint));
+			}
+		}
+
 
 		public string Name { get; set; }
 		public List<BaseConstraint> Constraints { get; private set; }
@@ -62,7 +71,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 					continue; // shouldn't happen
 				if (ent.EntityType != EntityType.Protocol)
 					return false;
-				if (ent.Type is ProtocolDeclaration proto && proto.HasAssociatedTypes)
+				if (ent.Type is ProtocolDeclaration proto && (proto.HasAssociatedTypes || proto.HasDynamicSelfInArguments))
 					return true;
 			}
 			return false;

--- a/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
@@ -71,7 +71,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 					continue; // shouldn't happen
 				if (ent.EntityType != EntityType.Protocol)
 					return false;
-				if (ent.Type is ProtocolDeclaration proto && (proto.HasAssociatedTypes || proto.HasDynamicSelfInArguments))
+				if (ent.Type is ProtocolDeclaration proto && !proto.IsExistential)
 					return true;
 			}
 			return false;

--- a/SwiftReflector/SwiftXmlReflection/Member.cs
+++ b/SwiftReflector/SwiftXmlReflection/Member.cs
@@ -40,6 +40,10 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public abstract bool HasDynamicSelfInReturnOnly {
 			get;
 		}
+
+		public abstract bool HasDynamicSelfInArguments {
+			get;
+		}
 	}
 }
 

--- a/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
@@ -158,6 +158,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		public override bool HasDynamicSelf => this.TypeSpec.HasDynamicSelf;
 		public override bool HasDynamicSelfInReturnOnly => false;
-		}
+		public override bool HasDynamicSelfInArguments => HasDynamicSelf;
+	}
 }
 

--- a/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ProtocolDeclaration.cs
@@ -56,7 +56,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 
 		public bool HasDynamicSelfInReturnOnly {
-			get => Members.All (m => m.HasDynamicSelfInReturnOnly) || HasAssociatedTypes;
+			get => Members.Any (m => m.HasDynamicSelfInReturnOnly) && !HasDynamicSelfInArguments;
+		}
+
+		public bool HasDynamicSelfInArguments {
+			get => Members.Any (m => m.HasDynamicSelfInArguments);
+		}
+
+		public bool IsExistential {
+			get => !(HasAssociatedTypes || HasDynamicSelfInArguments);
 		}
 	}
 }

--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -276,8 +276,11 @@ namespace SwiftReflector {
 									// need to add extra generics:
 									// AT0, ...
 									// need to add the constraint T : ISwiftProto<AT0, AT1, AT2, ...>
-									var assocTypeNames = proto.Protocol.AssociatedTypes.Select (assoc => OverrideBuilder.GenericAssociatedTypeName (assoc));
+									var assocTypeNames = proto.Protocol.AssociatedTypes.Select (assoc => OverrideBuilder.GenericAssociatedTypeName (assoc)).ToList ();
 									retval.GenericParameters.AddRange (assocTypeNames.Select (name => new CSGenericTypeDeclaration (new CSIdentifier (name))));
+									if (proto.Protocol.HasDynamicSelf) {
+										assocTypeNames.Insert (0, genTypeId.Name);
+									}
 									var genParts = assocTypeNames.Select (name => new CSSimpleType (name)).ToArray ();
 									var genType = new CSSimpleType ($"I{proto.Protocol.Name}", false, genParts);
 									var genRef = new CSIdentifier (CSGenericReferenceType.DefaultNamer (depthIndex.Item1, depthIndex.Item2));

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -541,7 +541,8 @@ namespace SwiftReflector.TypeMapping {
 			}
 		}
 
-		public NetTypeBundle MapType (BaseDeclaration context, TypeSpec spec, bool isPinvoke, bool isReturnValue = false)
+		public NetTypeBundle MapType (BaseDeclaration context, TypeSpec spec, bool isPinvoke, bool isReturnValue = false,
+			Tuple<int, int> selfDepthIndex = null)
 		{
 			if (IsCompoundProtocolListType (spec) && !isPinvoke)
 				throw new NotImplementedException ("Check for a protocol list type first because you need to promote the method to a generic");
@@ -641,8 +642,11 @@ namespace SwiftReflector.TypeMapping {
 							var retval = new NetTypeBundle (en.SharpNamespace, en.SharpTypeName, false, spec.IsInOut, en.EntityType);
 							if (en.EntityType == EntityType.Protocol && en.Type is ProtocolDeclaration proto) {
 								if (proto.HasDynamicSelf) {
-									var genMap = new NetTypeBundle (NewClassCompiler.kGenericSelfName, spec.IsInOut);
-									retval.GenericTypes.Add (genMap);
+									if (selfDepthIndex != null) {
+										retval.GenericTypes.Add (new NetTypeBundle (selfDepthIndex.Item1, selfDepthIndex.Item2));
+									} else {
+										retval.GenericTypes.Add (new NetTypeBundle (NewClassCompiler.kGenericSelfName, spec.IsInOut));
+									}
 								}
 								foreach (var assoc in proto.AssociatedTypes) {
 									var genMap = new NetTypeBundle (proto, assoc, spec.IsInOut);


### PR DESCRIPTION
In this PR we add the ability to handle dynamic self in parameters in protocols.

To begin with, let's define a couple of the things. A swift type is existential if and only if it contains no associated types and it contains no usage of dynamic self in arguments. In other words an existential type is a type that can be used directly such as in a variable declaration, return type or a method parameter:
```
public protocol SomeType {
    func Duplicate () -> SomeType
}

public func foo (a: SomeType) -> SomeType {
  let b:SomeType = a.Duplicate ()
  return b
}
```
A non-existential type can only be used as either a generic constraint or as part of a `some` clause.
```
public protocol OtherType {
    func IsFriend (f: Self) -> Bool
}
public func foo<T:OtherType> (a: T) { }
```
So step 1 was to add the predicate `IsExistential` to `ProtocolDeclaration` which requires the creation of `HasDynamicSelfInArguments` in `Member`.

Then this had to get filtered up into the code to get used. We can treat the type pretty much the same as a protocol with associated types, so `OverrideBuilder` gets the brunt of that. Now things get funny. When we build the swift wrapper for this type, we can't put `Self` into the arguments because that's a syntax error. The problem is that when it comes time to wrap the method, we don't know that the arguments may have Self in them, so I flag that and macro replace the wrapper type with `Self` in the arguments.

The other stunt change is in the type mapper which goes from a swift type to a C# type (more or less). The problem is that we have `Self` going in, but this is a non-existential type, so when mapped into C# it has to be the generic that gets used in the actual declaration. To understand this, let's back up and show what the C# interface looks like for `OtherType`:

```
public interface IOtherType<TSelf> where TSelf : IOtherType<TSelf> {
    bool IsFriend (TSelf f);
}

public class TopLevelEntities {
    static void foo<T> (a: T) where T: IOtherType<T> { }
}
```
The type mapper would make the constraint (and all usages) of `IOtherType` be `IOtherType<TSelf>` because it doesn't know the context in which the interface is being used. I added an optional parameter that contains the depth and index of the generic that is constrained to that so that the type mapper can then use it as a generic reference to embed into the interface. And this works and should also work in the case of having multiple arguments of `IOtherType` but with different `TSelf` types.

Tests pass.