### PR TITLE
Added code to support access to implicit arguments.

### DIFF
--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -25,6 +25,8 @@ bindingmetadata.macos.swift:
 
 generate-swift-bindings: bindingmetadata.iphone.swift bindingmetadata.macos.swift
 
+CFILES:=$(wildcard *.c)
+
 #
 # Define a template that can compile the swift glue code for each architecture
 #
@@ -38,26 +40,29 @@ $(3)_SDK:=$$(shell xcrun --sdk $(2) --show-sdk-path)
 ## debug
 $(3)_DEBUG_OUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)
 $(3)_DEBUG_COUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)/ofiles
+$(3)_DEBUG_OBJFILES:=$$(foreach cfile,$(CFILES),$$($(3)_DEBUG_COUTPUTDIR)/$$(cfile:.c=.o))
+
 $$($(3)_DEBUG_COUTPUTDIR)/%.o : %.c
 	$$(Q) mkdir -p $$($(3)_DEBUG_COUTPUTDIR)
-	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Debug/$$(@F)]) clang -x c -arch $$($(3)_ARCH) -std=gnu11 -O0 -fasm-blocks -c $$< -o $$($(3)_DEBUG_COUTPUTDIR)/$$<.o
+	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Debug/$$(@F)]) clang -x c -arch $$($(3)_ARCH) -std=gnu11 -O0 -fasm-blocks -c $$< -o $$@
 
-$$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_DEBUG_COUTPUTDIR)/*.o
+$$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_DEBUG_OBJFILES)
 	$(Q) mkdir -p $$(dir $$@)
-	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Debug])   $(UNPACKAGED_SWIFTC) -g -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_DEBUG_COUTPUTDIR)/*.o
+	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Debug])   $(UNPACKAGED_SWIFTC) -g -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_DEBUG_OBJFILES)
 	$$(Q) install_name_tool -delete_rpath $(realpath $(UNPACKAGED_SWIFTLIB)/$(2)) $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
 ## release
 $(3)_RELEASE_OUTPUTDIR=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)
 $(3)_RELEASE_COUTPUTDIR:=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)/ofiles
+$(3)_RELEASE_OBJFILES:=$$(foreach cfile,$(CFILES),$$($(3)_DEBUG_COUTPUTDIR)/$$(cfile:.c=.o))
 $$($(3)_RELEASE_COUTPUTDIR)/%.o : %.c
 	$$(Q) mkdir -p $$($(3)_RELEASE_COUTPUTDIR)
-	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Release/$$(@F)])clang -x c -arch $$($(3)_ARCH) -DCPU_ARCH=$$($(3)_ARCH) -std=gnu11 -Os -fasm-blocks -c $$< -o $$($(3)_RELEASE_COUTPUTDIR)/$$<.o
+	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Release/$$(@F)])clang -x c -arch $$($(3)_ARCH) -DCPU_ARCH=$$($(3)_ARCH) -std=gnu11 -Os -fasm-blocks -c $$< -o $$@
 
-$$($(3)_RELEASE_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_RELEASE_COUTPUTDIR)/*.o
+$$($(3)_RELEASE_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_RELEASE_OBJFILES)
 	$(Q) mkdir -p $$(dir $$@)
-	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Release]) $(UNPACKAGED_SWIFTC) -O -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_RELEASE_COUTPUTDIR)/*.o
+	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Release]) $(UNPACKAGED_SWIFTC) -O -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_RELEASE_OBJFILES)
 	$$(Q) install_name_tool -delete_rpath $(realpath $(UNPACKAGED_SWIFTLIB)/$(2)) $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 endef

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -52,8 +52,8 @@ $$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_DEB
 $(3)_RELEASE_OUTPUTDIR=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)
 $(3)_RELEASE_COUTPUTDIR:=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)/ofiles
 $$($(3)_RELEASE_COUTPUTDIR)/%.o : %.c
-	mkdir -p $$($(3)_RELEASE_COUTPUTDIR)
-	clang -x c -arch $$($(3)_ARCH) -DCPU_ARCH=$$($(3)_ARCH) -std=gnu11 -Os -fasm-blocks -c $$< -o $$($(3)_RELEASE_COUTPUTDIR)/$$<.o
+	$$(Q) mkdir -p $$($(3)_RELEASE_COUTPUTDIR)
+	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Release/$$(@F)])clang -x c -arch $$($(3)_ARCH) -DCPU_ARCH=$$($(3)_ARCH) -std=gnu11 -Os -fasm-blocks -c $$< -o $$($(3)_RELEASE_COUTPUTDIR)/$$<.o
 
 $$($(3)_RELEASE_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_RELEASE_COUTPUTDIR)/*.o
 	$(Q) mkdir -p $$(dir $$@)

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -39,8 +39,8 @@ $(3)_SDK:=$$(shell xcrun --sdk $(2) --show-sdk-path)
 $(3)_DEBUG_OUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)
 $(3)_DEBUG_COUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)/ofiles
 $$($(3)_DEBUG_COUTPUTDIR)/%.o : %.c
-	mkdir -p $$($(3)_DEBUG_COUTPUTDIR)
-	clang -x c -arch $$($(3)_ARCH) -std=gnu11 -O0 -fasm-blocks -c $$< -o $$($(3)_DEBUG_COUTPUTDIR)/$$<.o
+	$$(Q) mkdir -p $$($(3)_DEBUG_COUTPUTDIR)
+	$$(call Q_2,CLANG [$(1)/$$($(3)_ARCH)/Debug/$$(@F)]) clang -x c -arch $$($(3)_ARCH) -std=gnu11 -O0 -fasm-blocks -c $$< -o $$($(3)_DEBUG_COUTPUTDIR)/$$<.o
 
 $$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_DEBUG_COUTPUTDIR)/*.o
 	$(Q) mkdir -p $$(dir $$@)

--- a/swiftglue/Makefile
+++ b/swiftglue/Makefile
@@ -37,17 +37,27 @@ $(3)_SDK:=$$(shell xcrun --sdk $(2) --show-sdk-path)
 
 ## debug
 $(3)_DEBUG_OUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)
-$$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift)
+$(3)_DEBUG_COUTPUTDIR:=$(BINDIR)/Debug/$(1)/$$($(3)_ARCH)/ofiles
+$$($(3)_DEBUG_COUTPUTDIR)/%.o : %.c
+	mkdir -p $$($(3)_DEBUG_COUTPUTDIR)
+	clang -x c -arch $$($(3)_ARCH) -std=gnu11 -O0 -fasm-blocks -c $$< -o $$($(3)_DEBUG_COUTPUTDIR)/$$<.o
+
+$$($(3)_DEBUG_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_DEBUG_COUTPUTDIR)/*.o
 	$(Q) mkdir -p $$(dir $$@)
-	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Debug])   $(UNPACKAGED_SWIFTC) -g -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -module-name $(MODULENAME) -o $$@.tmp *.swift
+	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Debug])   $(UNPACKAGED_SWIFTC) -g -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_DEBUG_COUTPUTDIR)/*.o
 	$$(Q) install_name_tool -delete_rpath $(realpath $(UNPACKAGED_SWIFTLIB)/$(2)) $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
 ## release
 $(3)_RELEASE_OUTPUTDIR=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)
-$$($(3)_RELEASE_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift)
+$(3)_RELEASE_COUTPUTDIR:=$(BINDIR)/Release/$(1)/$$($(3)_ARCH)/ofiles
+$$($(3)_RELEASE_COUTPUTDIR)/%.o : %.c
+	mkdir -p $$($(3)_RELEASE_COUTPUTDIR)
+	clang -x c -arch $$($(3)_ARCH) -DCPU_ARCH=$$($(3)_ARCH) -std=gnu11 -Os -fasm-blocks -c $$< -o $$($(3)_RELEASE_COUTPUTDIR)/$$<.o
+
+$$($(3)_RELEASE_OUTPUTDIR)/$(MODULENAME): Makefile $(wildcard *.swift) $$($(3)_RELEASE_COUTPUTDIR)/*.o
 	$(Q) mkdir -p $$(dir $$@)
-	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Release]) $(UNPACKAGED_SWIFTC) -O -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -module-name $(MODULENAME) -o $$@.tmp *.swift
+	$$(call Q_2,SWIFTC [$(1)/$$($(3)_ARCH)/Release]) $(UNPACKAGED_SWIFTC) -O -sdk $$($(3)_SDK) -target $(3) -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker $(MODULENAME) -Xlinker -install_name -Xlinker @rpath/$(MODULENAME).framework/$(MODULENAME) -I . -module-name $(MODULENAME) -o $$@.tmp *.swift $$($(3)_RELEASE_COUTPUTDIR)/*.o
 	$$(Q) install_name_tool -delete_rpath $(realpath $(UNPACKAGED_SWIFTLIB)/$(2)) $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 endef

--- a/swiftglue/module.map
+++ b/swiftglue/module.map
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+module RegisterAccess [system] {
+header "registeraccess.h"
+export *
+}

--- a/swiftglue/registeraccess.c
+++ b/swiftglue/registeraccess.c
@@ -14,72 +14,26 @@
 // I don't imagine that we'll need the extensions since all we're doing is
 // register juggling
 
-void swiftAsmArg0 ()
+// Yes, the signature here doesn't match the declaration in registeraccess.h
+// This is a feature, not a bug.
+void *swiftAsmArg0 (void *arg0)
 {
-#if __x86_64
-	__asm("mov %rdi, %rax");
-#elif __arm64
-	__asm("mov x0, x0");
-#elif __arm
-	__asm("mov r0, r0");
-#elif i386
-	asm {
-		mov eax, dword ptr [ebp + 12]
-	}
-#else
-#error("Unknown CPU type for register access");
-#endif
+	return arg0;
 }
 
-void swiftAsmArg1 ()
+void *swiftAsmArg1 (void *arg0, void *arg1)
 {
-#if __x86_64
-	__asm("mov %rsi, %rax");
-#elif __arm64
-	__asm("mov x0, x1");
-#elif __arm
-	__asm("mov r0, r1");
-#elif i386
-	asm {
-		mov eax, dword ptr [ebp + 16]
-	}
-#else
-#error("Unknown CPU type for register access");
-#endif
+	return arg1;
 }
 
-void swiftAsmArg2 ()
+void *swiftAsmArg2 (void *arg0, void *arg1, void *arg2)
 {
-#if __x86_64
-	__asm("mov %rdx, %rax");
-#elif __arm64
-	__asm("mov x0, x2");
-#elif __arm
-	__asm("mov r0, r2");
-#elif i386
-	asm {
-		mov eax, dword ptr [ebp + 20]
-	}
-#else
-#error("Unknown CPU type for register access");
-#endif
+	return arg2;
 }
 
-void swiftAsmArg3 ()
+void *swiftAsmArg3 (void *arg0, void *arg1, void *arg2, void *arg3)
 {
-#if __x86_64
-	__asm("mov %rcx, %rax");
-#elif __arm64
-	__asm("mov x0, x3");
-#elif __arm
-	__asm("mov r0, r3");
-#elif i386
-	asm {
-		mov eax, dword ptr [ebp + 24]
-	}
-#else
-#error("Unknown CPU type for register access");
-#endif
+	return arg3;
 }
 
 void swiftSelfArg ()

--- a/swiftglue/registeraccess.c
+++ b/swiftglue/registeraccess.c
@@ -36,19 +36,18 @@ void *swiftAsmArg3 (void *arg0, void *arg1, void *arg2, void *arg3)
 	return arg3;
 }
 
+#if __x86_64 || __arm64
 void swiftSelfArg ()
 {
 #if __x86_64
 	__asm("mov %r13, %rax");
 #elif __arm64
 	__asm("mov x0, x20");
-#elif __arm
-	__asm("mov r0, r0");
-#elif i386
-	asm {
-		mov eax, dword ptr [ebp + 12]
-	}
-#else
-#error("Unknown CPU type for register access");
 #endif
 }
+#else
+void *swiftSelfArg(void *self)
+{
+	return self;
+}
+#endif

--- a/swiftglue/registeraccess.c
+++ b/swiftglue/registeraccess.c
@@ -24,7 +24,7 @@ void swiftAsmArg0 ()
 	__asm("mov r0, r0");
 #elif i386
 	asm {
-		mov eax, dword ptr [ebp + 8]
+		mov eax, dword ptr [ebp + 12]
 	}
 #else
 #error("Unknown CPU type for register access");
@@ -41,7 +41,7 @@ void swiftAsmArg1 ()
 	__asm("mov r0, r1");
 #elif i386
 	asm {
-		mov eax, dword ptr [ebp + 12]
+		mov eax, dword ptr [ebp + 16]
 	}
 #else
 #error("Unknown CPU type for register access");
@@ -58,7 +58,7 @@ void swiftAsmArg2 ()
 	__asm("mov r0, r2");
 #elif i386
 	asm {
-		mov eax, dword ptr [ebp + 16]
+		mov eax, dword ptr [ebp + 20]
 	}
 #else
 #error("Unknown CPU type for register access");
@@ -75,7 +75,7 @@ void swiftAsmArg3 ()
 	__asm("mov r0, r3");
 #elif i386
 	asm {
-		mov eax, dword ptr [ebp + 20]
+		mov eax, dword ptr [ebp + 24]
 	}
 #else
 #error("Unknown CPU type for register access");
@@ -92,7 +92,7 @@ void swiftSelfArg ()
 	__asm("mov r0, r0");
 #elif i386
 	asm {
-		mov eax, dword ptr [ebp + 8]
+		mov eax, dword ptr [ebp + 12]
 	}
 #else
 #error("Unknown CPU type for register access");

--- a/swiftglue/registeraccess.c
+++ b/swiftglue/registeraccess.c
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// These are accessors for each supported CPU to get the register arguments.
+// These are used because swift puts implicit arguments in registers including
+// type metadata and protocol witness tables.
+
+// supported CPUs:
+// __x86_64
+// __arm64
+// __arm
+// i386
+// we could probably further distinguish armv7, armv7k, and armv7s, but
+// I don't imagine that we'll need the extensions since all we're doing is
+// register juggling
+
+void swiftAsmArg0 ()
+{
+#if __x86_64
+	__asm("mov %rdi, %rax");
+#elif __arm64
+	__asm("mov x0, x0");
+#elif __arm
+	__asm("mov r0, r0");
+#elif i386
+	asm {
+		mov eax, dword ptr [ebp + 8]
+	}
+#else
+#error("Unknown CPU type for register access");
+#endif
+}
+
+void swiftAsmArg1 ()
+{
+#if __x86_64
+	__asm("mov %rsi, %rax");
+#elif __arm64
+	__asm("mov x0, x1");
+#elif __arm
+	__asm("mov r0, r1");
+#elif i386
+	asm {
+		mov eax, dword ptr [ebp + 12]
+	}
+#else
+#error("Unknown CPU type for register access");
+#endif
+}
+
+void swiftAsmArg2 ()
+{
+#if __x86_64
+	__asm("mov %rdx, %rax");
+#elif __arm64
+	__asm("mov x0, x2");
+#elif __arm
+	__asm("mov r0, r2");
+#elif i386
+	asm {
+		mov eax, dword ptr [ebp + 16]
+	}
+#else
+#error("Unknown CPU type for register access");
+#endif
+}
+
+void swiftAsmArg3 ()
+{
+#if __x86_64
+	__asm("mov %rcx, %rax");
+#elif __arm64
+	__asm("mov x0, x3");
+#elif __arm
+	__asm("mov r0, r3");
+#elif i386
+	asm {
+		mov eax, dword ptr [ebp + 20]
+	}
+#else
+#error("Unknown CPU type for register access");
+#endif
+}
+
+void swiftSelfArg ()
+{
+#if __x86_64
+	__asm("mov %r13, %rax");
+#elif __arm64
+	__asm("mov x0, x20");
+#elif __arm
+	__asm("mov r0, r0");
+#elif i386
+	asm {
+		mov eax, dword ptr [ebp + 8]
+	}
+#else
+#error("Unknown CPU type for register access");
+#endif
+}

--- a/swiftglue/registeraccess.h
+++ b/swiftglue/registeraccess.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+//  registeraccess.h
+//
+
+#ifndef CGLUE_EXPORT
+#if defined(__cplusplus)
+#define CGLUE_EXPORT extern "C"
+#else
+#define CGLUE_EXPORT extern
+#endif
+#endif
+
+CGLUE_EXPORT const void * swiftAsmArg0 ();
+CGLUE_EXPORT const void * swiftAsmArg1 ();
+CGLUE_EXPORT const void * swiftAsmArg2 ();
+CGLUE_EXPORT const void * swiftAsmArg3 ();
+CGLUE_EXPORT const void * swiftAsmArg4 ();
+CGLUE_EXPORT const void * swiftAsmArg5 ();
+CGLUE_EXPORT const void * swiftSelfArg ();
+//#import <registeraccess.h>
+

--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -31,11 +31,13 @@ namespace tomwiftytest {
 		public const string kSwiftCustomDirectoryRel = "../../../../apple/build/Ninja-ReleaseAssert/swift-macosx-x86_64";
 #if DEBUG
 		public const string kSwiftRuntimeGlueDirectoryRel = "../../../../swiftglue/bin/Debug/mac/FinalProduct/XamGlue.framework";
+		public const string kSwiftRuntimeSourceDirectoryRel = "../../../../swiftglue/";
 #endif
 		public static string kSwiftDeviceTestRoot = PosixHelpers.RealPath (Path.Combine (GetTestDirectory (), "../../devicetests"));
 		public static string kLeakCheckBinary = PosixHelpers.RealPath (Path.Combine (GetTestDirectory (), "..", "..", "..", "..", "leaktest", "bin", "Debug", "leaktest"));
 		public static string kSwiftRuntimeGlueDirectory = PosixHelpers.RealPath (SOM_PATH is null ? Path.Combine (GetTestDirectory (), kSwiftRuntimeGlueDirectoryRel) : FindPathFromEnvVariable ("lib/SwiftInterop/mac/XamGlue.framework"));
 		public static string kSwiftCustomDirectory = PosixHelpers.RealPath (SOM_PATH ?? Path.Combine (GetTestDirectory (), kSwiftCustomDirectoryRel));
+		public static string kXamGlueSourceDirectory = PosixHelpers.RealPath (SOM_PATH ?? Path.Combine (GetTestDirectory (), kSwiftRuntimeSourceDirectoryRel));
 
 		static string kSwiftCustomBin = PosixHelpers.RealPath (SOM_PATH is null ? Path.Combine (kSwiftCustomDirectory, "bin/") : FindPathFromEnvVariable ("bin/swift/bin/")) + "/";
 		static string kSwiftCustomLib = PosixHelpers.RealPath (SOM_PATH is null ? Path.Combine (kSwiftCustomDirectory, "lib/swift/macosx/") : FindPathFromEnvVariable ("bin/swift/lib/swift/macosx/"));

--- a/tests/tom-swifty-test/SwiftReflector/ProtowitnessTest.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtowitnessTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using tomwiftytest;
+using Dynamo.CSLang;
+
+namespace SwiftReflector {
+	[TestFixture]
+	[Parallelizable (ParallelScope.All)]
+	[RunWithLeaks]
+	public class ProtowitnessTest {
+
+		[Test]
+		public void VerifyProtoAccess ()
+		{
+			var swiftCode = @"
+import RegisterAccess
+
+public protocol Ageist {
+	func getAge () -> Int
+}
+
+public class AgeImp : Ageist {
+	public init () { }
+	public func getAge () -> Int {
+		return 42
+	}
+}
+
+@inline(never)
+public func protoWitness<T: Ageist> (of: T) -> UnsafeRawPointer?
+{
+    return RegisterAccess.swiftAsmArg2()
+}
+
+public func myWitness<T: Ageist> (x: T) -> UnsafeRawPointer {
+	return protoWitness(of: x)!
+}
+";
+			// var proto = new AgeImp ();
+			// var witnessPtr = StructMarshal.Marshaler.ProtocolWitnessof (typeof (IAgeist), typeof(AgeImp));
+			// var gottenWitness = TopLevelEntities.ProtoWitness<AgeImp>(proto);
+			// Console.Writeline(witnessPtr == gottenWitness.Pointer);
+
+			var protoId = new CSIdentifier ("proto");
+			var witnessPtrId = new CSIdentifier ("witnessPtr");
+			var gottenWitnessId = new CSIdentifier ("gottenWitness");
+
+			var protoDecl = CSVariableDeclaration.VarLine (protoId, new CSFunctionCall ("AgeImp", true));
+			var witnessDecl = CSVariableDeclaration.VarLine (witnessPtrId, new CSFunctionCall ("StructMarshal.Marshaler.ProtocolWitnessof", false,
+				new CSSimpleType ("IAgeist").Typeof (), new CSSimpleType ("AgeImp").Typeof ()));
+			var gottenDecl = CSVariableDeclaration.VarLine (gottenWitnessId, new CSFunctionCall ("TopLevelEntities.MyWitness<AgeImp>", false, protoId));
+			var printer = CSFunctionCall.ConsoleWriteLine (witnessPtrId == gottenWitnessId.Dot (new CSIdentifier ("Pointer")));
+
+			var callingCode = CSCodeBlock.Create (protoDecl, witnessDecl, gottenDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", platform: PlatformName.macOS);
+
+		}
+	}
+}

--- a/tests/tom-swifty-test/SwiftReflector/Utils.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Utils.cs
@@ -41,6 +41,8 @@ namespace SwiftReflector {
 			{
 				includeDirectories = new string [] { provider.DirectoryPath };
 				libraryDirectories.Add (provider.DirectoryPath);
+				File.Copy (Path.Combine (Compiler.kXamGlueSourceDirectory, "module.map"), Path.Combine (provider.DirectoryPath, "module.map"));
+				File.Copy (Path.Combine (Compiler.kXamGlueSourceDirectory, "registeraccess.h"), Path.Combine (provider.DirectoryPath, "registeraccess.h"));
 			}
 
 			SwiftCompilerOptions options = new SwiftCompilerOptions (moduleName, includeDirectories, libraryDirectories.ToArray (), new string [] { "XamGlue" });

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -112,6 +112,7 @@
     <Compile Include="SwiftReflector\SwiftTypeRegistryTests.cs" />
     <Compile Include="SwiftReflector\ProtocolConformanceTests.cs" />
     <Compile Include="SwiftReflector\DynamicSelfTests.cs" />
+    <Compile Include="SwiftReflector\ProtowitnessTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
We have a challenge in working with swift that there are times when swift has implicit arguments to functions. Here's an example:
```
public protocol AProto {
    func x ()
}
public func doX<T: AProto> (x: T) {
    x.x()
}
```

In `doX` there appears to be only 1 argument, but in reality there are three: `x`, the type metadata for `T` and the protocol witness table for `T` with respect to `AProto`.

There are times when we will need to access the protocol witness table in order to pass that to C#, but because it's implicit, we're out of luck doing that in swift. Or are we?

If we write a function like this in swift:
```
@inline(never)
public func protocolWitness<T: AProto>(of: T) -> UnsafeRawPointer
{
    return RegisterAccess.swiftAsmArg2()!
}
```
We can get that argument. How do we do this? We do the terrible things that C lets you do. In this case, we write a function `swiftAsmArg2()` which looks like it takes no arguments and returns `const void *`. In reality, what it does is access the caller's arguments instead. This happens in two ways. The first way is that if the CPU ABI dictates using register passing, we write code to stuff the register argument into the return register. If the CPU supports stack passed arguments, we reach past our own stack frame to get the arguments.

How do we know that this is safe-ish? If we embed a call to the C inside a swift function like `protocolWitnessOf` above which has no local variables, then the arguments registers and stack is untouched. This is true in debug and it is true in release.

How does swift import the C code? We create a file called `module.map` that declares that all the global declarations in a given header file will end up in the module `RegisterAccess`. This means that to compile against our code, we need to ship the `module.map` file as well as `registeraccess.h`.

There are implementations for armv7*, i386, x64, and arm64.

There is a test - stunt testing!
I define a protocol, implement it on a class, then write a `protocolWitness` function that returns a given protocol witness table for an implementor of a protocol. I call this with the C# binding to the implementation and compare the return value to `StructMarshal.Marshaler.ProtocolWitnessof`. The value that comes back matches in a correct case.