### PR TITLE
Added support for dynamic self in get properties.

### DIFF
--- a/Dynamo/Dynamo.SwiftLang/SLClass.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLClass.cs
@@ -9,12 +9,14 @@ namespace Dynamo.SwiftLang {
 	public class SLClass : ICodeElementSet
 	{
 		public SLClass (Visibility vis, SLIdentifier name, IEnumerable<SLFunc> methods = null,
-			bool isStatic = false, bool isSealed = false, NamedType namedType = NamedType.Class)
+			bool isStatic = false, bool isSealed = false, NamedType namedType = NamedType.Class,
+			bool isFinal = false)
 		{
 			// swift hates when you put public on an extension on a public type
 			Visibility = vis == Visibility.Public && namedType == NamedType.Extension ? Visibility.None : vis;
 			IsStatic = isStatic;
 			IsSealed = isSealed;
+			IsFinal = isFinal;
 			NamedType = namedType;
 			Name = Exceptions.ThrowOnNull (name, "name");
 			Inheritance = new SLInheritance ();
@@ -31,14 +33,16 @@ namespace Dynamo.SwiftLang {
 		}
 
 		public SLClass (Visibility vis, string name,
-			IEnumerable<SLFunc> members = null, bool isStatic = false, bool isSealed = false, NamedType namedType = NamedType.Class)
-			: this (vis, new SLIdentifier (name), members, isStatic, isSealed, namedType)
+			IEnumerable<SLFunc> members = null, bool isStatic = false, bool isSealed = false, NamedType namedType = NamedType.Class,
+			bool isFinal = false)
+			: this (vis, new SLIdentifier (name), members, isStatic, isSealed, namedType, isFinal)
 		{
 		}
 
 		public Visibility Visibility { get; private set; }
 		public bool IsStatic { get; private set; }
 		public bool IsSealed { get; private set; }
+		public bool IsFinal { get; private set; }
 		public NamedType NamedType { get; private set; }
 		public SLIdentifier Name { get; private set; }
 		public SLInheritance Inheritance { get; private set; }
@@ -49,6 +53,7 @@ namespace Dynamo.SwiftLang {
 		public SLClasses InnerClasses { get; private set; }
 		public List<SLSubscript> Subscripts { get; private set; }
 		public SLGenericTypeDeclarationCollection Generics { get; private set; }
+
 
 		#region ICodeElem implementation
 
@@ -105,6 +110,8 @@ namespace Dynamo.SwiftLang {
 					decl.Add (new SimpleElememt ("static ", true));
 				if (IsSealed)
 					decl.Add (new SimpleElememt ("sealed ", true));
+				if (IsFinal)
+					decl.Add (new SimpleElememt ("final ", true));
 				decl.Add (IdentifierForNamedType (NamedType));
 				decl.Add (SimpleElememt.Spacer);
 				decl.Add (Name);

--- a/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
@@ -382,7 +382,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 			for (int i = 0; i < newFunc.ParameterLists.Last ().Count; i++) {
 				var arg = newFunc.ParameterLists.Last () [i];
-				if (i == 0 && arg.PublicName == "this")
+				if (skipThisArgument && arg.PublicName == "this")
 					continue;
 				arg.TypeSpec = arg.TypeSpec.ReplaceName (toFind, replaceWith);
 			}

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
@@ -50,8 +50,11 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		}
 
 		public static T MakeProxy<T> (Type proxyType, T interfaceImpl)
-		{
+		{ 
 			var interfaceType = typeof (T);
+			// if it's already the proxy type, don't do the extra work
+			if (proxyType.IsAssignableFrom (interfaceImpl.GetType ()))
+				return interfaceImpl;
 			proxyType = RarefiedProxyType (interfaceImpl, ref interfaceType, proxyType);
 			var ci = proxyType.GetConstructor (new Type [] { interfaceType });
 			if (ci == null)

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftProtocolTypeAttribute.cs
@@ -50,7 +50,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		}
 
 		public static T MakeProxy<T> (Type proxyType, T interfaceImpl)
-		{ 
+		{
 			var interfaceType = typeof (T);
 			// if it's already the proxy type, don't do the extra work
 			if (proxyType.IsAssignableFrom (interfaceImpl.GetType ()))


### PR DESCRIPTION
Like every PR, there should be a narrative around what went on here.

In this case, it really comes down to the changes made to `SwiftProtocolAttribute.MakeProxy<T>`. This is a method that can make a proxy for an existing type type that implements a particular generic interface.  If you have the type:

```
public class Implements : ISomeProto<Type1, Type2>
{
}
```

`MakeProxy` will get passed the BTfS generated proxy type (which is swift friendly) and the instance of Implements cast as `ISomeProto<Type1, Type1>` by building a rarefied version of the proxy that meets the interface. I noted that we very likely would be calling `MakeProxy` with an instance of the proxy itself, thereby making another proxy. This is a leak and will cause proxies all the way down. I put in code to detect this case and short circuit it out. And this is the heart of the change.

Actually, the heart of the change is calling `MakeProxy` inside of `MarshalEngineCSafeSwiftToCSharp`. This code needs take the swift object passed to it, find the swift object associated with it, call its property and marshal the return value back to swift. In this case the implementor of the interface did this:

```
public Foo2 WhoAmI {
    get {
        Console.WriteLine ("got here".);
        return this;
    }
}
```

When the vtable receiver catches this return value, to marshal it back, it needs pass something swift friendly, so we need to guarantee that it's a proxy. `MakeProxy` does this and now it doesn't waste resources.

The rest of the code represent changes to ensure that the right flags are being set for marshaling the property accessor.

There was also a bug in the `MacroReplaceType` method that caused some unit tests to fail. I passed in a flag to allow skipping the `this` parameter, but I was (1) ignoring the flag (2) being more restrictive than I should have been by only checking the 0th argument. That's now fixed.