### PR TITLE
Setter with dynamic self working.

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -556,7 +556,6 @@ namespace SwiftReflector {
 						// code generated:
 						// var obj = SwiftObjectRegistry.Registry.CSObjectForSwiftObject<thisTypeName> (delegateParams [1].Name);
 						// callSite = (TSelf)(obj.xamarinImpl ?? obj)
-						// double cast (TSelf)(IIdentity4<TSelf>)
 						var proxObjName = MarshalEngine.Uniqueify ("proxyObj", identifiersUsed);
 						identifiersUsed.Add (proxObjName);
 						var proxyObjId = new CSIdentifier (proxObjName);


### PR DESCRIPTION
This is nice because the PR changes very little - in this case the set code for marshaling from a vtable setter to C#.

What does this mean?
A swift proxy for the protocol needs to call a C# implementation for a property setter. It does this by looking marshaling the types to something that C# can receive through a C function pointer. In this case, the proxy object's instance gets passed as a raw pointer and the dynamic self is also marshaled as a raw pointer.

In C#, the receiver needs to turn this pointers back into C# objects. For the both the self and the property value, these get marshaled as C# proxy objects. The property value C# proxy is assumed to be a wrapper around the real type, so we grab it's `xamarinImpl` member which should be cartable to `TSelf`. As protection against future code, I put in a null-coalescing operator for `xamarinImpl` since there will be a future case where it's null (proxy wraps a swift type, not a C# type).

Test as per usual.