### PR TITLE
Added test and a few fixes for Dynamic Self in subscripts

### DIFF
--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -892,15 +892,6 @@ namespace SwiftReflector {
 				returnType = typeMapper.OverrideTypeSpecMapper.MapType (getter, Imports, getter.ReturnTypeSpec.ReplaceName ("Self", SubstituteForSelf), true);
 			}
 
-
-			//if (getter.IsTypeSpecGeneric (getter.ReturnTypeSpec)) {
-			//	var ns = (NamedTypeSpec)getter.ReturnTypeSpec;
-			//	var depthIndex = getter.GetGenericDepthAndIndex (ns.Name);
-			//	returnType = new SLGenericReferenceType (depthIndex.Item1, depthIndex.Item2);
-			//} else {
-			//	returnType = typeMapper.OverrideTypeSpecMapper.MapType (getter, Imports, getter.ReturnTypeSpec, true);
-			//}
-
 			return new SLSubscript (Visibility.Public, isProtocol ? FunctionKind.None : FunctionKind.Override, returnType,
 			                        new SLParameterList (getParams), getBlock, setBlock);
 		}

--- a/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
@@ -359,7 +359,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		public override bool HasDynamicSelfInReturnOnly {
 			get {
-				if (IsProperty)
+				if (IsProperty && !IsSubscript)
 					return false;
 				if (TypeSpec.IsNullOrEmptyTuple (ReturnTypeSpec) || !ReturnTypeSpec.HasDynamicSelf)
 					return false;


### PR DESCRIPTION
I hate checking in incomplete work, but I'm at a dead-end here.
I added a unit test for dynamic self in protocol subscripts and fixed a few minor issues, but the wrapping code triggers a crasher in the swift compiler.

This feature can wait until the next time we update the compiler. I opened an issue [here](https://github.com/xamarin/binding-tools-for-swift/issues/374) to remember to return to this in the future.

The changes made:

1 - made sure that the code that implements the protocol uses the correct "substitute for self" in subscripts.
2 - fixed an incorrect case in `HasDynamicSelfInReturnOnly` in `FunctionDeclaration`.