### PR TITLE
Fixed signature of trivial enum property

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -4937,9 +4937,12 @@ namespace SwiftReflector {
 			if (prop.TLFGetter != null) {
 				var marshaler = new MarshalEngine (use, useLocals, TypeMapper, wrapper.Module.SwiftCompilerVersion);
 
-				var getter = TLFCompiler.CompileMethod (getterWrapperFunc, use, null, null, getterName, false, false, true);
-				var thisParm = getter.Parameters [0];
-				getter.Parameters [0] = new CSParameter (thisParm.CSType, thisParm.Name, CSParameterKind.This);
+				var wrapperGetter = TLFCompiler.CompileMethod (getterWrapperFunc, use, null, null, getterName, false, false, true);
+
+				var getter = TLFCompiler.CompileMethod (propDecl.GetGetter (), use, null, null, getterName, false, false, true);
+
+				var thisParm = wrapperGetter.Parameters.Last ();
+				getter.Parameters.Add (new CSParameter (thisParm.CSType, thisParm.Name, CSParameterKind.This));
 
 				getter.Body.AddRange (marshaler.MarshalFunctionCall (getterWrapperFunc, false, piGetterRef, getter.Parameters,
 					propDecl.GetGetter (), propDecl.GetGetter ().ReturnTypeSpec, getter.Type, null, null, false, wrapper));

--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Dynamo.CSLang;
+using NUnit.Framework;
+using SwiftReflector;
+using tomwiftytest;
+
+namespace SwiftReflector {
+	[TestFixture]
+	public class EnumTests {
+		[Test]
+		public void PropOnTrivialEnum ()
+		{
+			var swiftCode = @"
+public enum Rocks {
+    case igneous, sedimentary, metamorphic
+    public var Rocks: String { return ""Pile Of Rocks"" }
+}
+";
+
+
+			// Console.WriteLine (Rocks.Igneous.GetRocks ());
+
+			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ("Rocks.Igneous.Rocks", false));
+			var callingCode = CSCodeBlock.Create (printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Pile Of Rocks\n");
+		}
+	}
+}

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -113,6 +113,7 @@
     <Compile Include="SwiftReflector\ProtocolConformanceTests.cs" />
     <Compile Include="SwiftReflector\DynamicSelfTests.cs" />
     <Compile Include="SwiftReflector\ProtowitnessTest.cs" />
+    <Compile Include="SwiftReflector\EnumTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Corrected the signature of trivial enum property fixing [issue 142](https://github.com/xamarin/binding-tools-for-swift/issues/142)

This is an exploration in how you can make life easier for your future self. In the issue above, past Steve went to the trouble of including the swift code that triggered the issue and present Steve is very happy about that.

Now, here's what was going on. Given this swift code:
```
public enum Rocks {
    case igneous, sedimentary, metamorphic
    public var Rocks: String { return ""Pile Of Rocks"" }
}
```

BTfS was generating an extension method on the C# enum `Rocks` that had this signature:
```
public static void Rocks (this SwiftString retval, Rocks this0)
{
}
```
which is totally wrong. The reason is that we have two functions representing the method: The actual swift getter (which we can't call) and a wrapper that we can call. We were using only the getter wrapper before which has this following signature:
```
func Rocks (retval: UnsafeMutablePointer<String>, this: Rocks)
```
What we really want to do is use the getter signature (`func Rocks () -> String`) for generating the signature of the function. This gives us this C# signature:
```
public static SwiftString Rocks ()
{
}
```
Which is close, but we need the `this` parameter. We get that by also generating the signature for the wrapper function to get the type of the `this` parameter.  I could type map the swift type to the C#, but there can be issues and special cases in the mapping and `CompileMethod` already handles those. The last parameter is the instance, so we grab that and inject it into the the parameter list.

Test as per usual.
