### PR TITLE
Trivial enum ctors

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSEnum.cs
+++ b/Dynamo/Dynamo.CSLang/CSEnum.cs
@@ -25,6 +25,11 @@ namespace Dynamo.CSLang {
 		public CSType OptionalType { get; private set; }
 		public CSIdentifier Name { get; private set; }
 
+		public CSType ToCSType ()
+		{
+			return new CSSimpleType (Name.Name);
+		}
+
 		#region ICodeElem implementation
 
 		public event EventHandler<WriteEventArgs> Begin = (s, e) => { };

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -1431,6 +1431,7 @@ namespace SwiftReflector {
 
 			ImplementProperties (en, picl, usedPinvokeNames, enumDecl, classContents, null, use, wrapper, false, true, tlf => true, swiftLibraryPath, errors);
 			ImplementMethods (en, picl, usedPinvokeNames, swiftClassName, classContents, enumDecl, use, wrapper, tlf => true, swiftLibraryPath, errors);
+			ImplementTrivialEnumCtors (en, picl, usedPinvokeNames, enumDecl, classContents, use, wrapper, swiftLibraryPath, errors);
 			return en;
 		}
 
@@ -4477,6 +4478,86 @@ namespace SwiftReflector {
 		}
 
 
+		void ImplementTrivialEnumCtors (CSClass en, CSClass picl, List<string> usedPinvokeNames, EnumDeclaration enumDecl,
+							      ClassContents classContents, CSUsingPackages use,
+							      WrappingResult wrapper, string swiftLibraryPath, ErrorHandling errors)
+		{
+			foreach (TLFunction tlf in classContents.Constructors.AllocatingConstructors ()) {
+				FunctionDeclaration funcDecl = null;
+				try {
+					funcDecl = FindFunctionDeclarationForTLFunction (tlf, TypeMapper, enumDecl.Members.OfType<FunctionDeclaration> ());
+					if (funcDecl.Access.IsPrivateOrInternal ())
+						continue;
+				} catch (Exception err) {
+					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 85, $"Unable to find constructor function declaration for enum {enumDecl.ToFullyQualifiedName (true)} from method {tlf.MangledName}: {err.Message}");
+					errors.Add (ex);
+					continue;
+				}
+				if (funcDecl == null) {
+					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 86, $"Unable to find constructor function declaration for struct {enumDecl.ToFullyQualifiedName (true)} from method {tlf.MangledName}");
+					errors.Add (ex);
+					continue;
+				}
+				var recastCtor = RecastEnumCtorAsStaticFactory (enumDecl, funcDecl);
+				var isOptional = IsOptional (funcDecl.ReturnTypeSpec);
+				var optionalSuffix = isOptional ? "Optional" : "";
+
+				var homonymSuffix = Homonyms.HomonymSuffix (funcDecl, enumDecl.Members.OfType<FunctionDeclaration> (), TypeMapper);
+				var libraryPath = PInvokeName (wrapper.ModuleLibPath, swiftLibraryPath);
+				var classType = tlf.Class;
+				var consName = "Init" + optionalSuffix + homonymSuffix;
+				var pinvokeConsName = PICTorName (classType.ClassName) + optionalSuffix + homonymSuffix;
+				var csReturnType = TypeMapper.MapType (funcDecl, funcDecl.ReturnTypeSpec, isPinvoke: false, isReturnValue: true).ToCSType (use);
+
+				pinvokeConsName = Uniqueify (pinvokeConsName, usedPinvokeNames);
+				usedPinvokeNames.Add (pinvokeConsName);
+
+				var pinvokeConsRef = PIClassName (classType.ClassName) + "." + pinvokeConsName;
+
+				var wrapperFunction = FindWrapperForConstructor (classContents, funcDecl, tlf, wrapper);
+				if (wrapperFunction == null) {
+					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 87, $"Unable to find matching constructor declaration for {tlf.MangledName} in enum {enumDecl.ToFullyQualifiedName ()}, skipping.");
+					errors.Add (ex);
+					continue;
+				}
+				var wrapperFunc = FindEquivalentFunctionDeclarationForWrapperFunction (wrapperFunction, TypeMapper, wrapper);
+				if (wrapperFunc == null) {
+					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 88, $"Unable to find FunctionDeclaration for wrapper function {wrapperFunction.MangledName} in enum {enumDecl.ToFullyQualifiedName ()}, skipping.");
+					errors.Add (ex);
+					continue;
+				}
+				try {
+					var piConstructor = TLFCompiler.CompileMethod (wrapperFunc, use,
+						libraryPath, wrapperFunction.MangledName, pinvokeConsName, true, true, false);
+
+					var publicCons = TLFCompiler.CompileMethod (recastCtor, use, libraryPath, wrapperFunction.MangledName,
+						consName, isPinvoke: false, isFinal: true, isStatic: true);
+					var piCCTorName = PICCTorName (classType.ClassName);
+
+					var swiftCons = tlf.Signature as SwiftConstructorType;
+
+					var localIdents = new List<String> {
+						publicCons.Name.Name,
+						piConstructor.Name.Name,
+						piCCTorName,
+						kThisName
+					};
+
+					var engine = new MarshalEngine (use, localIdents, TypeMapper, wrapper.Module.SwiftCompilerVersion);
+
+					publicCons.Body.AddRange (engine.MarshalFunctionCall (wrapperFunc, false, pinvokeConsRef,
+						publicCons.Parameters, enumDecl, funcDecl.ReturnTypeSpec, csReturnType, swiftInstanceType: null,
+						instanceType: null, includeCastToReturnType: true, wrapper, includeIntermediateCastToLong: true));
+
+					en.Methods.Add (publicCons);
+					picl.Methods.Add (piConstructor);
+				} catch (Exception err) {
+					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 88, err, $"Exception thrown marshaling to swift in enum constructor {recastCtor}");
+				}
+			}
+		}
+
+
 		void ImplementMethods (CSClass cl, CSClass picl, List<string> usedPinvokeNames, SwiftClassName piClassName, ClassContents contents,
 		                       TypeDeclaration typeDecl, CSUsingPackages use, WrappingResult wrapper, Func<TLFunction, bool> funcFilter,
 		                       string swiftLibraryPath, ErrorHandling errors)
@@ -5340,7 +5421,13 @@ namespace SwiftReflector {
 			var bft = constructorToWrap.Signature as SwiftBaseFunctionType;
 			if (bft == null)
 				throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 36, "Yikes! Expected a SwiftBaseFunctionType but got " + constructorToWrap.Signature.GetType ());
-			int skipCount = constructorToWrap.Signature.ReturnType.IsClass ? 0 : 1;
+
+			var isTrivialEnum = false;
+			if (constructorToWrap.Signature.ReturnType.IsEnum) {
+				var entity = TypeMapper.GetEntityForTypeSpec (funcDecl.ReturnTypeSpec);
+				isTrivialEnum = entity?.EntityType == EntityType.TrivialEnum;
+			}
+			int skipCount = constructorToWrap.Signature.ReturnType.IsClass || isTrivialEnum ? 0 : 1;
 			return allwrappers.FirstOrDefault (tlf => ParametersMatchExceptSkippingFirstN (tlf.Signature,
 				constructorToWrap.Signature, skipCount, TypeMapper));
 		}
@@ -6423,6 +6510,22 @@ namespace SwiftReflector {
 						SubstituteAssociatedTypeNamer (namer, genSubType);
 				}
 			} else throw new NotImplementedException ($"Unknown type {ty.GetType ().Name} ({ty.ToString ()})");
+		}
+
+		static FunctionDeclaration RecastEnumCtorAsStaticFactory (EnumDeclaration enumDecl, FunctionDeclaration funcDecl)
+		{
+			var copy = new FunctionDeclaration (funcDecl);
+			copy.IsStatic = true;
+			if (copy.ParameterLists.Count > 0)
+				copy.ParameterLists.RemoveAt (0);
+			copy.Name = "init";
+
+			return copy;
+		}
+
+		static bool IsOptional (TypeSpec spec)
+		{
+			return spec is NamedTypeSpec namedSpec && namedSpec.ContainsGenericParameters && namedSpec.Name == "Swift.Optional";
 		}
 	}
 }

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -4553,6 +4553,7 @@ namespace SwiftReflector {
 					picl.Methods.Add (piConstructor);
 				} catch (Exception err) {
 					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 88, err, $"Exception thrown marshaling to swift in enum constructor {recastCtor}");
+					errors.Add (ex);
 				}
 			}
 		}

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -158,6 +158,11 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				return true;
 			}
 #endif
+			if (t.IsEnum) {
+				if (TryGetNominalMetadata (t, out mt))
+					return true;
+			}
+
 			if (t.IsDelegate ()) {
 				mt = DelegateMetatype (t);
 			}
@@ -384,7 +389,16 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			}
 		}
 
-
+		bool TryGetNominalMetadata (Type t, out SwiftMetatype mt)
+		{
+			try {
+				mt = GetNominalMetatype (t);
+				return true;
+			} catch {
+				mt = default (SwiftMetatype);
+				return false;
+			}
+		}
 
 		SwiftMetatype SwiftStructMetatype (Type t)
 		{

--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -28,5 +28,55 @@ public enum Rocks {
 
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Pile Of Rocks\n");
 		}
+
+		[Test]
+		public void TrivialEnumCtor ()
+		{
+			var swiftCode = @"
+public enum TheForce {
+    case `do`, doNot
+    public init (yoda: Bool) {
+        self = yoda ? .do : .doNot // there is no try
+    }
+}
+";
+
+			// var force = TheForceExtensions.Init (true);
+			// Console.WriteLine (force);
+
+			var forceID = new CSIdentifier ("force");
+			var forceDecl = CSVariableDeclaration.VarLine (forceID, new CSFunctionCall ("TheForceExtensions.Init", false, CSConstant.Val (true)));
+			var printer = CSFunctionCall.ConsoleWriteLine (forceID);
+
+			var callingCode = CSCodeBlock.Create (forceDecl, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Do\n");
+		}
+
+		[Test]
+		public void TrivialOptionalEnumCtor ()
+		{
+			var swiftCode = @"
+public enum SomeForce {
+	case `do`, doNot
+	public init? (a: Int32) {
+		if a == 0 {
+			self = .do
+		} else if a == 1 {
+			self = .doNot
+		}
+		return nil
+	}
+}
+";
+			// var force = SomeForceExtensions.InitOptional (2);
+			// Console.WriteLine (force.HasValue);
+
+			var forceID = new CSIdentifier ("force");
+			var forceDecl = CSVariableDeclaration.VarLine (forceID, new CSFunctionCall ("SomeForceExtensions.InitOptional", false, CSConstant.Val (7)));
+			var printer = CSFunctionCall.ConsoleWriteLine (forceID.Dot (new CSIdentifier ("HasValue")));
+
+			var callingCode = CSCodeBlock.Create (forceDecl, printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n");
+		}
 	}
 }


### PR DESCRIPTION
Added constructor support for trivial enum ctors, fixing issue [141](https://github.com/xamarin/binding-tools-for-swift/issues/141)

I classify enums into several categories since enums in swift are really discriminated unions. Trivial enums are those that are just homogenous integral cases. These map directly onto C# enums, but because we're talking swift here, there are special cases. You can write methods and constructors on these types. Methods are easy-is - BTfS turns them into extension methods. Constructors? Well, I hadn't considered that initially.

Let's think about what a constructor is from a semantic point of view: it's a static function that takes 0 or more arguments are returns an instance of the type. And given that this is swift, it could also return an optional of that type. Now swift is slightly more complicated than that because constructors also take another argument, which is the type metadata for that type. This argument is *always* ignored unless the type is generic and trivial enums will always be non-generic.

Let's consider the signature of two constructors:
```
public enum TheForce {
    public init (does: Bool) { }
    public init? (does: Int) {}
}
```
The first is really `static TheForce.init (Bool) -> TheForce` and the second is `static TheForce.init(Int) -> TheForce?`.

Seeing this transformation is the key to having these in C#. What I do is the take the `FunctionDeclaration` for the ctor and do the following:
1 - Make it static
2 - Remove the first parameter list (this contains the metadata argument)
3 - Change the name (`.ctor`) to `init`

Side note: early on in dismantling what swift generated, I noted that types had 2 varieties of constructor, one which called the other and destructors. I called them call `.ctor` and `.dtor`. I later learned that these are an allocator and an initializer.

The above transformation happens in `RecastEnumCtorAsStaticFactory`. The result gets put into the same class as any extension methods for the trivial enum and will either get named `Init` or `InitOptional`, but they're just static methods, not actual extensions.

Now comes a traditional engineering tradeoff: where to do this work? There is code already for handling constructors for structs which is very similar. I could just use that code and add in special cases for this or I could copy/paste it, change the issue and risk propagating bugs by poor factoring. Putting in the special case code into the struct handling makes that code more fragile and harder to maintain. As far as I'm concerned, this is a lose-lose proposition. I chose the code duplication. This code loops through all the TopLevelFunction ctors, finds the corresponding `FunctionDeclaration`, recasts it as static, finds wrappers, writes the pinvoke, writes the function declaration and then injects the marshaling code.

In writing all of this I got the main case working, but optional constructors failed. I had intended to do those in another PR, but I was also getting dozens of new failures in existing tests. Why? Because every trivial enum in swift has an implicit constructor that takes in `Int` to build it from the raw value but unless you have up to 64 bits worth of cases, then there are raw values that don't generate correct cases, so the constructor could fail. Any test I had written with a trivial enum was now generating a (broken) optional initializer.

Optional initializers were failing for two reasons:
1 - Typically the return of a ctor is put into a passed in reference since we can't guarantee that the swift and C# calling conventions match - except for heap allocated types and trivial enums. I had missed the trivial enum case in exactly 1 spot in `FindWrapperForConstructor`. Now fixed.
2 - We have never asked the `StructMarshal.Metatypeof` a trivial enum. How do I know this? Because we were getting an exception trying to do that. The type metadata exists and we have a handle to it. We were just missing the code to get it. However, this fix is more subtle than it appears. Most of the code to get a SwiftMetatype object is the same: "is it a foo? If so get it's `SwiftMetatype`. We know definitively that if, say, the object implements `ISwiftObject` there is precisely one way to get it's type metadata. Not so with enums. An enum may be either a swift enum or it may be an ObjC enum. So I adopt the `TryGet` pattern in C# for a swift trivial enum. Turns out that it's pretty much the same as the code for any other value type, just without an exception. I could have rewritten all of that code to be better factored for both but chose to call the value type code from the trivial enum code and swallow the exception. Again, engineering trade-off. If the enum isn't a swift enum, it will fall through (eventually) to the code that picks up the ObjC metadata.

Tests as per usual.