### PR TITLE
Added AEXML

### DIFF
--- a/tests/3rd-party/AEXML/Makefile
+++ b/tests/3rd-party/AEXML/Makefile
@@ -1,0 +1,33 @@
+TOP=../../..
+
+# Define values specific to this test / repository
+REPO=https://github.com/tadija/AEXML
+NAME:=$(shell basename $(REPO))
+# Modify the hash if the latest won't compile (for instance if it requires Swift 4.2 / Xcode 10)
+HASH=8623e73b193386909566a9ca20203e33a09af142
+
+# The following variables can be used to customize the build:
+#
+# The path to the Xcode project (unless the default 'repository/$NAME.xcodeproj' isn't right)
+# XCODEPROJECT=/path/to/xcodeproject
+#
+# The Xcode project's scheme to build (unless the default '$NAME' isn't right).
+# You can execute 'make list-schemes' to list all schemes in any xcode projects any subdirectory.
+XCODESCHEME="'AEXML iOS'"
+#
+# The name of the resulting framework (unless it doesn't match the Xcode scheme).
+FRAMEWORKNAME=AEXML
+#
+# If the project fails to build/bind, set IGNORED=1
+# IGNORED=1
+#
+
+# These variables must be set before including Makefile.inc
+#
+
+include ../Makefile.inc
+
+# Standard targets: build, run
+# If the project does not need customization, we can forward to the default implementation of these targets.
+build-local: default-build
+run-local: default-run


### PR DESCRIPTION
This 3rd party framework previously failed. It now works. Fixes issue [148](https://github.com/xamarin/binding-tools-for-swift/issues/148).