### PR TITLE
Fix for nested trivial enums

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5024,7 +5024,7 @@ namespace SwiftReflector {
 				var getter = TLFCompiler.CompileMethod (propDecl.GetGetter (), use, null, null, getterName, false, false, true);
 
 				var thisParm = wrapperGetter.Parameters.Last ();
-				getter.Parameters.Add (new CSParameter (thisParm.CSType, thisParm.Name, CSParameterKind.This));
+				getter.Parameters.Add (new CSParameter (thisParm.CSType, thisParm.Name, propDecl.Parent.IsNested ? CSParameterKind.None : CSParameterKind.This));
 
 				getter.Body.AddRange (marshaler.MarshalFunctionCall (getterWrapperFunc, false, piGetterRef, getter.Parameters,
 					propDecl.GetGetter (), propDecl.GetGetter ().ReturnTypeSpec, getter.Type, null, null, false, wrapper));
@@ -5296,7 +5296,8 @@ namespace SwiftReflector {
 			if (isTrivialEnum && !methodIsStatic) {
 				// abracadabra! you're an extension!
 				var instance = publicMethod.Parameters [0];
-				publicMethod.Parameters [0] = new CSParameter (instance.CSType, instance.Name, CSParameterKind.This);
+				publicMethod.Parameters [0] = new CSParameter (instance.CSType, instance.Name,
+					funcToWrap.Parent.IsNested ? CSParameterKind.None : CSParameterKind.This);
 			}
 
 			var genericParameters = publicMethod.GenericParameters;

--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -66,6 +66,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return proto.AssociatedTypeNamed (named.NameWithoutModule) != null;
 		}
 
+		public bool IsNested => this is TypeDeclaration && Parent != null;
+
 		public ProtocolDeclaration GetConstrainedProtocolWithAssociatedType (NamedTypeSpec named, TypeMapper typeMapper)
 		{
 			var depthIndex = GetGenericDepthAndIndex (named);

--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -78,5 +78,25 @@ public enum SomeForce {
 			var callingCode = CSCodeBlock.Create (forceDecl, printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n");
 		}
+
+		[Test]
+		public void NestedEnum ()
+		{
+			var swiftCode = @"
+public struct System {
+    public enum LOAD_AVG {
+        case short
+        case long
+    }    
+    public static func loadAverage(type: LOAD_AVG = .long) -> Int {
+        return 42
+    }
+}";
+			var getVal = new CSFunctionCall ("System.LoadAverage", false, new CSIdentifier ("System.LOAD_AVG.Short"));
+			var printer = CSFunctionCall.ConsoleWriteLine (getVal);
+
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "42\n");
+		}
 	}
 }


### PR DESCRIPTION
Made minor adjustment in handling of methods and properties on trivial enums, fixing issue [119](https://github.com/xamarin/binding-tools-for-swift/issues/119).

The problem in the initial issue was that the enum was nested and wrapping code wasn't using the proper path to the type, but that apparently has been solved at some point in the past.

Trivial swift enums are represented by real C# enums and all methods and properties get implemented as extensions. Today I learned that C# doesn't allow extension methods on nested classes, so this doesn't work so well. I put in code to detect this case and still write static methods, just not make them extensions.

How do we know that a `BaseDeclaration` is a nested type? If `this` is a `TypeDeclaration` (parent type of `ClassDeclaration`, `StructDeclaration`, `EnumDeclaration` and `ProtocolDeclaration`) and its `Parent` property is non-null.

Test as per usual.