### PR TITLE
Better support for type arguments

### DIFF
--- a/Dynamo/Dynamo.SwiftLang/SLType.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLType.cs
@@ -292,7 +292,7 @@ namespace Dynamo.SwiftLang {
 
 
 	public class SLGenericReferenceType : SLType {
-		public SLGenericReferenceType (int depth, int index)
+		public SLGenericReferenceType (int depth, int index, bool isMetatype = false)
 		{
 			if (depth < 0)
 				throw new ArgumentOutOfRangeException (nameof (depth));
@@ -300,15 +300,18 @@ namespace Dynamo.SwiftLang {
 				throw new ArgumentOutOfRangeException (nameof (index));
 			Depth = depth;
 			Index = index;
+			IsMetatype = isMetatype;
 		}
 
 		public int Depth { get; private set; }
 		public int Index { get; private set; }
+		public bool IsMetatype { get; private set; }
 		public Func<int, int, string> ReferenceNamer { get; set; }
 
 		protected override void LLWrite (ICodeWriter writer, object o)
 		{
-			writer.Write (Name, true);
+			var name = IsMetatype ? (Name + ".Type") : Name;
+			writer.Write (name, true);
 		}
 
 		public string Name {

--- a/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
+++ b/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
@@ -726,6 +726,11 @@ namespace SwiftReflector.Demangling {
 					}
 				},
 				new MatchRule () {
+					Name = "Metatype",
+					NodeKind = NodeKind.Metatype,
+					Reducer = ConvertToMetatype,
+				},
+				new MatchRule () {
 					Name = "ExistentialMetatype",
 		    			NodeKind = NodeKind.ExistentialMetatype,
 					Reducer = ConvertToExistentialMetatype,
@@ -1682,6 +1687,18 @@ namespace SwiftReflector.Demangling {
 			if (childType == null)
 				return null;
 			return new SwiftExistentialMetaType (childType, isReference, null);
+		}
+
+		SwiftType ConvertToMetatype (Node node, bool isReference, SwiftName name)
+		{
+			var child = ConvertFirstChildToSwiftType (node, false, name);
+			if (child is SwiftClassType cl) {
+				return new SwiftMetaClassType (cl, isReference, name);
+			} else if (child is SwiftGenericArgReferenceType classReference) {
+				return new SwiftMetaClassType (classReference, isReference, name);
+			} else {
+				return null;
+			}
 		}
 
 		SwiftType ConvertToGenericFunction (Node node, bool isReference, SwiftName name)

--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -1455,6 +1455,8 @@ namespace SwiftReflector {
 		{
 			if (typeContext.IsProtocolWithAssociatedTypesFullPath (swiftType, typeMapper) || IsProtocolConstrained (wrapperFunc, swiftType)) {
 				return MarshalProtocolConstrained (typeContext, wrapperFunc, p, swiftType);
+			} else if (typeContext.IsTypeSpecGenericMetatypeReference (swiftType)) {
+				return p.Name;
 			} else {
 				// Class constraints:
 				// IntPtr pNameIntPtr

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5617,7 +5617,7 @@ namespace SwiftReflector {
 					return false;
 
 
-				if (!sp.ContainsGenericParameters && decl.IsTypeSpecGeneric (sp)) {
+				if (!sp.ContainsGenericParameters && decl.IsTypeSpecGeneric (sp) && !decl.IsTypeSpecGenericMetatypeReference (sp)) {
 					if (sp is NamedTypeSpec && !(st is SwiftGenericArgReferenceType))
 						return false;
 					continue;

--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -675,13 +675,24 @@ namespace SwiftReflector {
 		public SwiftMetaClassType (SwiftClassType classType, bool isReference, SwiftName name = null)
 		    : base (CoreCompoundType.MetaClass, isReference, name)
 		{
-			Class = Ex.ThrowOnNull (classType, nameof(classType));
+			Class = Ex.ThrowOnNull (classType, nameof (classType));
+		}
+		public SwiftMetaClassType (SwiftGenericArgReferenceType classGenericReference, bool isReference, SwiftName name = null)
+			: base (CoreCompoundType.MetaClass, isReference, name)
+		{
+			ClassGenericReference = Ex.ThrowOnNull (classGenericReference, nameof (classGenericReference));
 		}
 		public SwiftClassType Class { get; private set; }
+		public SwiftGenericArgReferenceType ClassGenericReference { get; private set; }
 		protected override bool LLEquals (SwiftType other)
 		{
 			var meta = other as SwiftMetaClassType;
-			return meta != null && Class.Equals (meta.Class);
+			if (meta == null)
+				return false;
+			if (Class != null)
+				return Class.Equals (meta.Class);
+			else
+				return ClassGenericReference.Equals (meta.ClassGenericReference);
 		}
 		public override string ToString ()
 		{

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -569,13 +569,17 @@ namespace SwiftReflector.TypeMapping {
 						return new NetTypeBundle (owningProtocol, assocType, false);
 					}
 				} else if (context.IsTypeSpecGeneric (spec) && (!spec.ContainsGenericParameters || isPinvoke)) {
-					if (isPinvoke) {
-						var isPAT = context.GetConstrainedProtocolWithAssociatedType (named, this) != null;
-						var isInOut = isPAT ? false : named.IsInOut;
-						return new NetTypeBundle ("System", "IntPtr", false, isInOut, EntityType.None);
+					if (context.IsTypeSpecGenericMetatypeReference (spec)) {
+						return new NetTypeBundle ("SwiftRuntimeLibrary", "SwiftMetatype", false, spec.IsInOut, EntityType.None);
 					} else {
-						var depthIndex = context.GetGenericDepthAndIndex (spec);
-						return new NetTypeBundle (depthIndex.Item1, depthIndex.Item2);
+						if (isPinvoke) {
+							var isPAT = context.GetConstrainedProtocolWithAssociatedType (named, this) != null;
+							var isInOut = isPAT ? false : named.IsInOut;
+							return new NetTypeBundle ("System", "IntPtr", false, isInOut, EntityType.None);
+						} else {
+							var depthIndex = context.GetGenericDepthAndIndex (spec);
+							return new NetTypeBundle (depthIndex.Item1, depthIndex.Item2);
+						}
 					}
 				} else if (context.IsTypeSpecAssociatedType (named)) {
 					if (isPinvoke) {

--- a/SwiftReflector/TypeMapping/TypeSpecToSLType.cs
+++ b/SwiftReflector/TypeMapping/TypeSpecToSLType.cs
@@ -244,7 +244,7 @@ namespace SwiftReflector.TypeMapping {
 						throw new NotImplementedException ("Can only have a named type spec here.");
 					var depthIndex = func.GetGenericDepthAndIndex (namedType.Name);
 					var gd = func.GetGeneric (depthIndex.Item1, depthIndex.Item2);
-					var genRef = new SLGenericReferenceType (depthIndex.Item1, depthIndex.Item2);
+					var genRef = new SLGenericReferenceType (depthIndex.Item1, depthIndex.Item2, func.IsTypeSpecGenericMetatypeReference (namedType));
 					parmType = genRef;
 				}
 			} else {

--- a/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
@@ -345,5 +345,33 @@ public extension Dictionary {
 			var callingCode = CSCodeBlock.Create (fooDecl, fooAdd, barDecl, printHasIt, printValue);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n43\n");
 		}
+
+		[Test]
+		public void GenericExtensionWithTypes ()
+		{
+			var swiftCode = @"
+public extension Dictionary {
+    func value<T>(forKey: String, ofType: T.Type) -> T? {
+        return nil
+    }
+}";
+
+			// var foo = new SwiftDictionary <SwiftString, nint> ();
+			// foo.Add (SwiftString.FromString ("key", 43);
+			// var bar = foo.Value<SwiftString, nint, nint> (SwiftString.FromString ("key"), StructMarshal.Marshaler.Metatypeof (typeof (nint)));
+			// Console.WriteLine (bar.HasValue);
+
+			var fooID = new CSIdentifier ("foo");
+			var barID = new CSIdentifier ("bar");
+			var stringExpr = new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("key"));
+			var fooDecl = CSVariableDeclaration.VarLine (fooID, new CSFunctionCall ("SwiftDictionary<SwiftString, nint>", true));
+			var fooAdd = CSFunctionCall.FunctionCallLine ($"{fooID.Name}.Add", false, stringExpr, CSConstant.Val (43));
+			var barDecl = CSVariableDeclaration.VarLine (barID, new CSFunctionCall ($"{fooID.Name}.Value<SwiftString, nint, nint>", false, stringExpr,
+				new CSFunctionCall ("StructMarshal.Marshaler.Metatypeof", false, new CSSimpleType ("nint").Typeof ())));
+			var printHasIt = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{barID.Name}.HasValue"));
+
+			var callingCode = CSCodeBlock.Create (fooDecl, fooAdd, barDecl, printHasIt);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n");
+		}
 	}
 }

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1414,5 +1414,19 @@ namespace SwiftReflector.Demangling {
 			Assert.AreEqual ("Thing", arg2.AssociatedTypePath [0], "Mismatch in assoc type name 0");
 			Assert.AreEqual ("Name", arg2.AssociatedTypePath [1], "Mismatch in assoc type name 1");
 		}
+
+		[Test]
+		public void TestGenericMetatype ()
+		{
+			var tld = Decomposer.Decompose ("_$sSD14ExtensionTestsE5value6forKey6ofTypeqd__SgSS_qd__mtlF", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLFunction;
+			Assert.IsNotNull (tlf, "not a function");
+			var arg0 = tlf.Signature.GetParameter (0) as SwiftClassType;
+			Assert.IsNotNull (arg0, "not a swift class type at arg0");
+			var arg1 = tlf.Signature.GetParameter (1) as SwiftMetaClassType;
+			Assert.IsNotNull (arg1, "not a metaclass type");
+			Assert.IsNotNull (arg1.ClassGenericReference, "not a generic reference metatype");
+		}
 	}
 }


### PR DESCRIPTION
Added preliminary support for generic Type arguments fixing issue [109](https://github.com/xamarin/binding-tools-for-swift/issues/109)

In this case, we get presented with a generic function on `T` with an argument of type `T.Type`. This was failing in a number of places. The first place was demangling because we had never seen this type before. To support this, I extended the `SwiftClassType` which is a stand-in for type metadata to act as a named metadata type or a generic reference to a metadata type.

Once that was done, I needed to change the predicate for `IsTypeSpecGeneric` because technically `T.Type` is generic. I did this by making a predicate to identify any `TypeSpec` of the form `generic_name.Type` as a generic which also returns the generic name. Similarly, I modded the code to get the generic depth and index to work with this form as well.

Next, I changed the code to match parameter types between `TypeSpec` and `SwiftType` types to understand that a `T.Type` form is not a generic reference. Then I changed the type mapper to understand this as well.

Finally, I had to mod the `SLGenericReferenceType` so that it could generate a `T.Type` form.

I say preliminary because this only addresses one narrow case. This is likely to work correctly in static and non-virtual methods, but is likely to not work in virtual functions and probably not as return values. I opened up an [issue](https://github.com/xamarin/binding-tools-for-swift/issues/387) to look at those.

Tests as per usual.