### PR TITLE
Added platform #if protections

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSConditionalCompilation.cs
+++ b/Dynamo/Dynamo.CSLang/CSConditionalCompilation.cs
@@ -26,5 +26,12 @@ namespace Dynamo.CSLang {
 		{
 			return new CSConditionalCompilation (new CSIdentifier ("#if"), Exceptions.ThrowOnNull (condition, nameof (condition)));
 		}
+
+		public static void ProtectWithIfEndif (CSIdentifier condition, ICodeElement elem)
+		{
+			var @if = If (condition);
+			@if.AttachBefore (elem);
+			Endif.AttachAfter (elem);
+		}
 	}
 }

--- a/Dynamo/Dynamo.CSLang/CSUsing.cs
+++ b/Dynamo/Dynamo.CSLang/CSUsing.cs
@@ -38,18 +38,22 @@ namespace Dynamo.CSLang {
 
 		public CSUsingPackages And (string package) { return And (new CSUsing (package)); }
 
-		public void AddIfNotPresent (string package)
+		public void AddIfNotPresent (string package, CSIdentifier protectedBy = null)
 		{
 			if (String.IsNullOrEmpty (package))
 				return;
 			CSUsing target = new CSUsing (package);
-			if (!this.Exists (use => use.Contents == target.Contents))
+			if (!this.Exists (use => use.Contents == target.Contents)) {
+				if ((object)protectedBy != null) {
+					CSConditionalCompilation.ProtectWithIfEndif (protectedBy, target);
+				}
 				Add (target);
+			}
 		}
 
-		public void AddIfNotPresent (Type t)
+		public void AddIfNotPresent (Type t, CSIdentifier protectedBy = null)
 		{
-			AddIfNotPresent (t.Namespace);
+			AddIfNotPresent (t.Namespace, protectedBy);
 		}
 	}
 }

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -133,6 +133,7 @@ namespace SwiftReflector {
 		public static CSIdentifier kProtocolWitnessTable = new CSIdentifier (kProtocolWitnessTableName);
 		public static string kGenericSelfName = "TSelf";
 		public static CSIdentifier kGenericSelf = new CSIdentifier (kGenericSelfName);
+		public static CSIdentifier kMobilePlatforms = new CSIdentifier ("__IOS__ || __MACOS__ || __TVOS__ || __WATCHOS__");
 
 		SwiftCompilerLocation SwiftCompilerLocations;
 		ClassCompilerLocations ClassCompilerLocations;
@@ -2899,10 +2900,12 @@ namespace SwiftReflector {
 					new CSIdentifier (recvrName),
 					pl, body);
 
-			use.AddIfNotPresent (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute));
+			use.AddIfNotPresent (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), kMobilePlatforms);
 			var args = new CSArgumentList ();
 			args.Add (new CSFunctionCall ("typeof", false, new CSIdentifier (vtableName.Name + "." + delType.Name.Name)));
-			CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true).AttachBefore (recvr);
+			var attr = CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true);
+			CSConditionalCompilation.ProtectWithIfEndif (kMobilePlatforms, attr);
+			attr.AttachBefore (recvr);
 			return recvr;
 		}
 
@@ -2936,10 +2939,12 @@ namespace SwiftReflector {
 
 			recvr = new CSMethod (CSVisibility.None, CSMethodKind.Static, returnType, new CSIdentifier (recvrName), pl, body);
 
-			use.AddIfNotPresent ("ObjCRuntime");
+			use.AddIfNotPresent ("ObjCRuntime", kMobilePlatforms);
 			var args = new CSArgumentList ();
 			args.Add (new CSFunctionCall ("typeof", false, new CSIdentifier (vtableName.Name + "." + delType.Name.Name)));
-			CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true).AttachBefore (recvr);
+			var attr = CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true);
+			CSConditionalCompilation.ProtectWithIfEndif (kMobilePlatforms, attr);
+			attr.AttachBefore (recvr);
 			return recvr;
 		}
 
@@ -2964,11 +2969,12 @@ namespace SwiftReflector {
 			                          new CSIdentifier ("xamVtable_recv_" + publicMethod.Name.Name + homonymSuffix),
 										      pl, body);
 
-			// note for future - this is required for MonoPInvokeCallback
-			use.AddIfNotPresent ("ObjCRuntime");
+			use.AddIfNotPresent ("ObjCRuntime", kMobilePlatforms);
 			var args = new CSArgumentList ();
 			args.Add (new CSFunctionCall ("typeof", false, new CSIdentifier (vtableName.Name + "." + delType.Name.Name)));
-			CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true).AttachBefore (recvr);
+			var attr = CSAttribute.FromAttr (typeof (Xamarin.iOS.MonoPInvokeCallbackAttribute), args, true);
+			CSConditionalCompilation.ProtectWithIfEndif (kMobilePlatforms, attr);
+			attr.AttachBefore (recvr);
 			return recvr;
 		}
 

--- a/tests/tom-swifty-test/SwiftReflector/ArrayTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ArrayTests.cs
@@ -356,7 +356,7 @@ return a
 			feach.Body.Add (CSFunctionCall.FunctionCallLine ("Console.Write", false, feach.Ident));
 
 			var callingCode = CSCodeBlock.Create (arrDecl, varArrDecl, otherArrDecl, feach);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "123", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "123");
 
 		}
 

--- a/tests/tom-swifty-test/SwiftReflector/ComparableTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ComparableTests.cs
@@ -138,7 +138,7 @@ namespace SwiftReflector {
 			var printer = CSFunctionCall.ConsoleWriteLine (isEqual);
 			var callingCode = CSCodeBlock.Create (printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n", otherClass : lessClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "False\n", otherClass : lessClass);
 
 		}
 

--- a/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/DynamicSelfTests.cs
@@ -22,7 +22,7 @@ public protocol Identity0 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("Got here."));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n");
 
 		}
 
@@ -68,7 +68,7 @@ public func getName (a: Identity1) -> String {
 			var printer = CSFunctionCall.ConsoleWriteLine (nameName);
 			var callingCode = CSCodeBlock.Create (instDecl, nameDecl, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "() -> Identity1\n", otherClass: auxClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "() -> Identity1\n", otherClass: auxClass);
 		}
 
 		[Test]
@@ -113,7 +113,7 @@ public func whoWho<T> (a: T) where T : Identity2 {
 			var methodCall = CSFunctionCall.FunctionCallLine ("TopLevelEntities.WhoWho", false, instName);
 			var callingCode = CSCodeBlock.Create (instDecl, methodCall);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass);
 		}
 
 		[Test]
@@ -158,7 +158,7 @@ public func whoProp<T> (a: T) where T: Identity3 {
 			var methodCall = CSFunctionCall.FunctionCallLine ("TopLevelEntities.WhoProp", false, instName);
 			var callingCode = CSCodeBlock.Create (instDecl, methodCall);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass);
 		}
 
 		[Test]
@@ -207,7 +207,7 @@ public func whoProp<T> (a: T) where T: Identity4 {
 			var methodCall = CSFunctionCall.FunctionCallLine ("TopLevelEntities.WhoProp", false, instName);
 			var callingCode = CSCodeBlock.Create (instDecl, methodCall);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here.\n", otherClass: auxClass);
 
 		}
 
@@ -262,7 +262,7 @@ public func whoScript <T> (a: T) where T : Identity5 {
 			var methodCall = CSFunctionCall.FunctionCallLine ("TopLevelEntities.WhoScript", false, instName);
 			var callingCode = CSCodeBlock.Create (instDecl, methodCall);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "got here 7\n", otherClass: auxClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "got here 7\n", otherClass: auxClass);
 
 		}
 	}

--- a/tests/tom-swifty-test/SwiftReflector/EquatableTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EquatableTests.cs
@@ -154,7 +154,7 @@ namespace SwiftReflector {
 			var printer = CSFunctionCall.ConsoleWriteLine (isEqual);
 			var callingCode = CSCodeBlock.Create (printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", otherClass : eqClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", otherClass : eqClass);
 		}
 
 

--- a/tests/tom-swifty-test/SwiftReflector/ExceptionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ExceptionTests.cs
@@ -169,7 +169,7 @@ namespace SwiftReflector {
 			catchBlock.Add (CSFunctionCall.FunctionCallLine ("Console.Write", false, new CSIdentifier ("e").Dot (new CSIdentifier ("Message"))));
 			CSTryCatch catcher = new CSTryCatch (tryBlock, typeof (SwiftException), "e", catchBlock);
 			callingCode.Add (catcher);
-			TestRunning.TestAndExecute (swiftCode, callingCode, output, testName: $"VirtualMethodExceptionSimple{toAdd}", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, output, testName: $"VirtualMethodExceptionSimple{toAdd}");
 		}
 
 		[Test]
@@ -218,7 +218,7 @@ namespace SwiftReflector {
 			catchBlock.Add (CSFunctionCall.FunctionCallLine ("Console.Write", false, new CSIdentifier ("e").Dot (new CSIdentifier ("Message"))));
 			CSTryCatch catcher = new CSTryCatch (tryBlock, typeof (SwiftException), "e", catchBlock);
 			callingCode.Add (catcher);
-			TestRunning.TestAndExecute (swiftCode, callingCode, output, testName: $"VirtualMethodException{toAdd}", otherClass: fooOver, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, output, testName: $"VirtualMethodException{toAdd}", otherClass: fooOver);
 		}
 
 

--- a/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
@@ -314,7 +314,7 @@ public extension HotDogOnUserType
 	}";
 
 			var callingCode = CSCodeBlock.Create ();
-			TestRunning.TestAndExecute (swiftCode, callingCode, "", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "");
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
@@ -472,7 +472,7 @@ namespace SwiftReflector {
 				CodeWriter.WriteToFile (csOutFilename, csfile);
 
 				Assert.Throws <Exception> (() => {
-					Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename, platform: PlatformName.macOS);
+					Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename);
 				});
 			}
 		}
@@ -524,7 +524,7 @@ namespace SwiftReflector {
 				CodeWriter.WriteToFile (csOutFilename, csfile);
 
 				Assert.Throws<Exception> (() => {
-					Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename, platform: PlatformName.macOS);
+					Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename);
 				});
 			}
 		}
@@ -741,7 +741,7 @@ namespace SwiftReflector {
 
 			CSCodeBlock callingCode = CSCodeBlock.Create (intUpperDecl, fooDecl, doUpper, doUpper, doDowner, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "1\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "1\n");
 		}
 
 		void WrapGenNonVirtClassPropFunc (string appendage, string cstype, string val1, string expected)

--- a/tests/tom-swifty-test/SwiftReflector/HomonymTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/HomonymTests.cs
@@ -142,7 +142,7 @@ namespace SwiftReflector {
 			CSLine printer1 = CSFunctionCall.ConsoleWriteLine (call1);
 			CSLine printer2 = CSFunctionCall.ConsoleWriteLine (call2);
 			CSCodeBlock callingCode = CSCodeBlock.Create (foo, printer, printer1, printer2);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "14\n28\nTrue\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "14\n28\nTrue\n");
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -115,7 +115,7 @@ public func Eat () { }
 ";
 			var print = CSFunctionCall.FunctionLine ("Console.Write", (CSIdentifier)"42");
 			var callingCode = CSCodeBlock.Create (print);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "42", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "42");
 		}
 
 		void TestCtor (string testName, string type, string value, string output = null)
@@ -170,7 +170,7 @@ public func Eat () { }
 			callingCode.Add (CSFunctionCall.ConsoleWriteLine ((CSIdentifier)"bar.Y"));
 
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "42\nhi mom\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "42\nhi mom\n");
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
@@ -81,7 +81,7 @@ namespace SwiftReflector {
 			overCS.Methods.Add (printIt);
 			callingCode.Add (CSVariableDeclaration.VarLine (new CSSimpleType ($"OverWSM{type}"), "printer", new CSFunctionCall ($"OverWSM{type}", true)));
 			callingCode.Add (CSFunctionCall.FunctionCallLine ("printer.PrintIt", false));
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapSingleMethod{type}", otherClass: overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapSingleMethod{type}", otherClass: overCS);
 		}
 
 		[Test]
@@ -138,7 +138,7 @@ namespace SwiftReflector {
 			CodeElementCollection<ICodeElement> callingCode = new CodeElementCollection<ICodeElement> ();
 			callingCode.Add (CSVariableDeclaration.VarLine (new CSSimpleType ($"FooWVVC{safeType}"), "foo", new CSFunctionCall ($"FooWVVC{safeType}", true, new CSFunctionCall ($"OverWCCV{safeType}", true))));
 			callingCode.Add (CSFunctionCall.FunctionCallLine ("foo.DoIt", false));
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapClassCallsVirtual{safeType}", otherClass: overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapClassCallsVirtual{safeType}", otherClass: overCS);
 		}
 
 		[Test]
@@ -199,7 +199,7 @@ namespace SwiftReflector {
 			CSLine invoker = CSFunctionCall.FunctionCallLine ("printer.PrintIt", false);
 			CSCodeBlock callingCode = CSCodeBlock.Create (decl, invoker);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapSingleProperty{appendage}", otherClass: overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName: $"WrapSingleProperty{appendage}", otherClass: overCS);
 		}
 
 		[Test]
@@ -456,7 +456,7 @@ namespace SwiftReflector {
 			var printer = CSFunctionCall.ConsoleWriteLine (CSFunctionCall.Function ("pop.WhoAmI"));
 			var callingCode = CSCodeBlock.Create (decl, decl2, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "who I yam\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "who I yam\n");
 		}
 
 		[Test]
@@ -610,7 +610,7 @@ namespace SwiftReflector {
 			var printer = CSFunctionCall.ConsoleWriteLine (piID.Dot (getGet.Dot (new CSIdentifier ("IsVirtual"))));
 			var callingCode = CSCodeBlock.Create (propInfo, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
 		}
 
 
@@ -627,7 +627,7 @@ namespace SwiftReflector {
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("ok"));
 			var callingCode = CSCodeBlock.Create (printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n");
 		}
 
 		[Test]
@@ -651,7 +651,7 @@ namespace SwiftReflector {
 
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("ok"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n");
 		}
 
 		[Test]
@@ -667,7 +667,7 @@ namespace SwiftReflector {
 				"}\n";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("ok"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ok\n");
 		}
 
 		[Test]
@@ -687,7 +687,7 @@ open class TrivClass0 {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("TrivClass0", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (declID.Dot (new CSIdentifier ("X")));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Blind\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Blind\n");
 		}
 
 
@@ -711,7 +711,7 @@ open class TrivClass1 {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("TrivClass1", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{declID.Name}.Foo", false));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Blind\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Blind\n");
 
 		}
 
@@ -759,13 +759,11 @@ open class TheBaseClass {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("TheBaseClass", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{declID.Name}.GetValue", false, CSConstant.Val (42)));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
-
-
-		[TestCase (PlatformName.macOS)]
-		public void TestMultiOverride (PlatformName platform)
+		[Test]
+		public void TestMultiOverride ()
 		{
 			
 			var swiftCode = @"
@@ -788,7 +786,7 @@ open class SecondClass : FirstClass {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("SecondClass", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{declID.Name}.FirstFunc", false));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "42\n", "TestMultiOverride", platform: platform);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "42\n", "TestMultiOverride");
 		}
 
 		[Test]
@@ -807,7 +805,7 @@ open class ClosureFunc {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("ClosureFunc", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{declID.Name}.Returns5", false));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "5\n", testName: "TestClosureProp", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "5\n", testName: "TestClosureProp");
 		}
 
 		[Test]
@@ -826,7 +824,7 @@ public class ClosureArg {
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{declID.Name}.Caller", false, new CSIdentifier ("x => (x & 1) != 0"),
 				CSConstant.Val (7)));
 			var callingCode = CSCodeBlock.Create (decl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
 		}
 
 		[Test]
@@ -848,7 +846,7 @@ public class ClosureReturn {
 			var xdecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, funcID, new CSFunctionCall ($"{declID.Name}.Caller", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall (funcID.Name, false, CSConstant.Val (7)));
 			var callingCode = CSCodeBlock.Create (decl, xdecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
 		}
 
 
@@ -871,7 +869,7 @@ open class ClosureVirtualReturn {
 			var xdecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, funcID, new CSFunctionCall ($"{declID.Name}.Caller", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall (funcID.Name, false, CSConstant.Val (7)));
 			var callingCode = CSCodeBlock.Create (decl, xdecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
 		}
 
 
@@ -890,7 +888,7 @@ open class ClosureSimpleProp {
 			var setter = CSAssignment.Assign ($"{declID}.X", new CSIdentifier ("() => { Console.WriteLine (\"here\"); }"));
 			var execIt = CSFunctionCall.FunctionCallLine ($"{declID}.X");
 			var callingCode = CSCodeBlock.Create (decl, setter, execIt);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "here\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "here\n");
 		}
 
 
@@ -910,7 +908,7 @@ open class SimpleSetClosure {
 			var decl = CSVariableDeclaration.VarLine (CSSimpleType.Var, declID, new CSFunctionCall ("SimpleSetClosure", true));
 			var execIt = CSFunctionCall.FunctionCallLine ($"{declID}.SetValue", new CSIdentifier ("() => { Console.WriteLine (\"here\"); }"));
 			var callingCode = CSCodeBlock.Create (decl, execIt);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "here\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "here\n");
 		}
 	}
 }

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolConformanceTests.cs
@@ -212,7 +212,7 @@ public protocol Iterator0 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -226,7 +226,7 @@ public protocol Iterator1 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -240,7 +240,7 @@ public protocol Iterator2 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -254,7 +254,7 @@ public protocol Iterator3 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -270,7 +270,7 @@ public protocol Iterator4 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -286,7 +286,7 @@ public protocol Iterator5 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -302,7 +302,7 @@ public protocol Iterator6 {
 ";
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 			var callingCode = CSCodeBlock.Create (printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]
@@ -335,7 +335,7 @@ public func doPrint<T>(a:T) where T:Simplest0 {
 			var instDecl = CSVariableDeclaration.VarLine (instID, new CSFunctionCall ("Simple0Impl", true));
 			var doPrint = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoPrint<Simple0Impl, SwiftString>", false, instID);
 			var callingCode = CSCodeBlock.Create (instDecl, doPrint);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 
 		[Test]
@@ -368,7 +368,7 @@ public func doPrint<T>(a:T) where T:Simplest1 {
 			var instDecl = CSVariableDeclaration.VarLine (instID, new CSFunctionCall ("Simple1Impl", true));
 			var doPrint = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoPrint<Simple1Impl, SwiftString>", false, instID);
 			var callingCode = CSCodeBlock.Create (instDecl, doPrint);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 
 		[Test]
@@ -397,7 +397,7 @@ public func doSetProp<T, U> (a: inout T, b:U) where T:Simplest2, U==T.Item {
 				new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("Got here!")));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{instID.Name}.Thing"));
 			var callingCode = CSCodeBlock.Create (instDecl, doSetProp, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 
 		[Test]
@@ -426,7 +426,7 @@ public func doSetProp<T> (a: inout T, b:T.Item) where T:Simplest3 {
 				new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("Got here!")));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{instID.Name}.Thing"));
 			var callingCode = CSCodeBlock.Create (instDecl, doSetProp, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 
 		[Test]
@@ -460,7 +460,7 @@ public func doGetIt<T:Simplest4> (a: T, i: Int) -> T.Item {
 			var resultDecl = CSVariableDeclaration.VarLine (resultID, new CSFunctionCall ("TopLevelEntities.DoGetIt<Simple4Impl, SwiftString>", false, instID, CSConstant.Val (3)));
 			var printer = CSFunctionCall.ConsoleWriteLine (resultID);
 			var callingCode = CSCodeBlock.Create (instDecl, resultDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 
 		[Test]
@@ -497,7 +497,7 @@ public func doSetIt<T:Simplest5> (a: inout T, i: Int, v: T.Item) {
 			var callSetter = CSFunctionCall.FunctionCallLine ("TopLevelEntities.DoSetIt", false, instID, CSConstant.Val (3), new CSFunctionCall ("SwiftString.FromString", false, CSConstant.Val ("Got here!")));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSIdentifier ($"{instID.Name}[3]"));
 			var callingCode = CSCodeBlock.Create (instDecl, callSetter, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here!\n", otherClass: altClass);
 		}
 	}
 }

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolListTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolListTests.cs
@@ -57,7 +57,7 @@ public func infoOn(a: ProtoA & ProtoB) -> String {
 			var printer = CSFunctionCall.ConsoleWriteLine (clCall);
 			var callingCode = CSCodeBlock.Create (clDecl, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3 4 7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3 4 7\n");
 		}
 
 
@@ -90,7 +90,7 @@ public func getDual () -> ProtoRA & ProtoRB {
 			var thingDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, thingID, new CSFunctionCall ("(ImplRARB)TopLevelEntities.GetDual", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 
@@ -121,7 +121,7 @@ public var DualProp : ProtoPA & ProtoPB = ImplPAPB ()
 			var thingDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, thingID, new CSFunctionCall ("(ImplPAPB)TopLevelEntities.GetDualProp", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 
@@ -158,7 +158,7 @@ public class ImplMPAMPB : ProtoMPA, ProtoMPB {
 			var thingDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, thingID, new CSFunctionCall ("ImplMPAMPB", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.InfoOn", false, thingID));
 			var callingCode = CSCodeBlock.Create (thingDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3 4 7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3 4 7\n");
 		}
 
 
@@ -194,7 +194,7 @@ public class ImplMRAMRB : ProtoMRA, ProtoMRB {
 			var anotherDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, anotherID, new CSFunctionCall ($"(ImplMRAMRB){thingID.Name}.GetMeA", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{anotherID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 
@@ -240,7 +240,7 @@ public class ImplMPRAMPRB : ProtoMPRA, ProtoMPRB {
 			var anotherDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, anotherID, new CSIdentifier ($"(ImplMPRAMPRB){thingID.Name}").Dot (new CSIdentifier ("PropStuff")));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{anotherID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 
@@ -282,7 +282,7 @@ public class ImplMSRAMSRB : ProtoMSRA, ProtoMSRB {
 			var anotherDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, anotherID, new CSFunctionCall ($"(ImplMSRAMSRB){thingID.Name}.GetSubscript", false, CSConstant.Val (7)));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{anotherID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 		[Test]
@@ -321,7 +321,7 @@ public class ImplMEAMEB : ProtoMEA, ProtoMEB {
 			var quaDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, quaID, new CSFunctionCall ($"(ImplMEAMEB){anotherID.Name}.GetValueProtoValue", false));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{quaID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, quaDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 		[Test]
@@ -359,7 +359,7 @@ public class ImplMEFAMFEB : ProtoMEFA, ProtoMEFB {
 			var anotherDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, anotherID, new CSFunctionCall ($"NotParticularlyUseful.NewProtoValue", false, thingID));
 			var printer = CSFunctionCall.ConsoleWriteLine (anotherID.Dot (new CSIdentifier ("Case")));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "ProtoValue\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ProtoValue\n");
 		}
 
 
@@ -400,7 +400,7 @@ public func getDual (doThrow: Bool) throws -> ProtoERA & ProtoERB {
 			var thingDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, thingID, new CSFunctionCall ("(ImplERAERB)TopLevelEntities.GetDual", false, CSConstant.Val (false)));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.ConstantA", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "3\n");
 		}
 
 		[Test]
@@ -437,7 +437,7 @@ open class UsingClass {
 			var anotherDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, anotherID, new CSFunctionCall ($"UsingClass", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{anotherID.Name}.DoAThing", false, thingID));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 
 		[Test]
@@ -485,7 +485,7 @@ open class UsingClassP {
 			var resetter = CSFunctionCall.FunctionCallLine ($"{thingID}.SetImpl", false, new CSFunctionCall ("ImplVAVB", true));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.DoAThing", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, resetter, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 
 		[Test]
@@ -535,7 +535,7 @@ open class UsingClassPI {
 			var resetter = CSFunctionCall.FunctionCallLine ($"{thingID}.SetSubscript", false, new CSFunctionCall ("ImplVIPAVIPB", true), CSConstant.Val (18));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{thingID.Name}.DoAThing", false));
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, resetter, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 
 		[Test]
@@ -578,7 +578,7 @@ public class UsingClassPP : UsingProto {
 			var invoke = new CSFunctionCall ($"{anotherID.Name}.TryItOut", false, thingID);
 			var printer = CSFunctionCall.ConsoleWriteLine (invoke);
 			var callingCode = CSCodeBlock.Create (thingDecl, anotherDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 
 		[Test]
@@ -628,7 +628,7 @@ public func tryItOut (a: UsingClassPProp) -> Int {
 			var invoke = new CSFunctionCall ($"TopLevelEntities.TryItOut", false, thingID);
 			var printer = CSFunctionCall.ConsoleWriteLine (invoke);
 			var callingCode = CSCodeBlock.Create (thingDecl, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "7\n");
 		}
 
 	}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -38,7 +38,7 @@ namespace SwiftReflector {
 			CSLine invoker = CSFunctionCall.FunctionCallLine ("tester.DoIt", false, new CSIdentifier ("myOver"));
 			CSCodeBlock callingCode = CSCodeBlock.Create (decl, decl1, invoker);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSingleMethod{type}", otherClass: overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSingleMethod{type}", otherClass: overCS);
 		}
 
 		[Test]
@@ -161,7 +161,7 @@ namespace SwiftReflector {
 			CSLine invoker = CSFunctionCall.FunctionCallLine ("tester.DoIt", false, new CSIdentifier ("myOver"));
 			CSCodeBlock callingCode = CSCodeBlock.Create (decl, decl1, invoker);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSinglePropertyGetOnly{appendage}", otherClass : overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSinglePropertyGetOnly{appendage}", otherClass : overCS);
 		}
 
 		[Test]
@@ -220,7 +220,7 @@ namespace SwiftReflector {
 			CSLine invoker = CSFunctionCall.FunctionCallLine ("tester.DoIt", false, new CSIdentifier ("myOver"));
 			CSCodeBlock callingCode = CSCodeBlock.Create (decl, decl1, initer, invoker);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSinglePropertyGetSetOnly{type}", otherClass : overCS, platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSinglePropertyGetSetOnly{type}", otherClass : overCS);
 		}
 
 		[Test]
@@ -388,8 +388,8 @@ namespace SwiftReflector {
 
 			var caller = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("did it"));
 			var callingCode = CSCodeBlock.Create (caller);
-      
-      TestRunning.TestAndExecute (swiftCode, callingCode, "did it\n", platform: PlatformName.macOS);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "did it\n", platform: PlatformName.macOS);
 		}
 
 
@@ -545,7 +545,6 @@ namespace SwiftReflector {
 			var callingCode = CSCodeBlock.Create (inst, morphIt, printIt);
 
 			TestRunning.TestAndExecute (swiftCode, callingCode, "42\n", platform: PlatformName.macOS);
-
 		}
 
 
@@ -588,7 +587,7 @@ public class FilmStrip<T: Interpolatable> where T.ValueType == T {
 	    		// associated type
 			// equality constraint
 	    		// skipping FilmString (due to previous errors)
-			TestRunning.TestAndExecute (swiftCode, callingCode, "No smoke\n", expectedErrorCount: 1, platform:PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "No smoke\n", expectedErrorCount: 1);
 		}
 
 		[Test]
@@ -606,7 +605,7 @@ public protocol Useless {
 			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("OK"));
 		
 			var callingCode = CSCodeBlock.Create (getter, printer);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "OK\n");
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/SwiftOptionalTypeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftOptionalTypeTests.cs
@@ -413,7 +413,7 @@ namespace SwiftReflector {
 
 			var callingCode = CSCodeBlock.Create (classDecl, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "17\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "17\n");
 		}
 
 		[Test]
@@ -435,7 +435,7 @@ namespace SwiftReflector {
 
 			var callingCode = CSCodeBlock.Create (classDecl, printer);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "17\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "17\n");
 		}
 
 

--- a/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
@@ -75,7 +75,7 @@ public protocol BoringProtocol {
 }
 ";
 			var callingCode = PrintTypeName ("IBoringProtocol");
-			TestRunning.TestAndExecute (swiftCode, callingCode, ".BoringProtocol\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, ".BoringProtocol\n");
 		}
 
 
@@ -91,7 +91,7 @@ public enum BoringEnum1 : Int {
 }
 ";
 			var callingCode = PrintTypeName ("BoringEnum1");
-			TestRunning.TestAndExecute (swiftCode, callingCode, ".BoringEnum1\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, ".BoringEnum1\n");
 		}
 
 

--- a/tests/tom-swifty-test/SwiftReflector/SwiftTypeRegistryTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftTypeRegistryTests.cs
@@ -325,7 +325,7 @@ public protocol SomeProtocol {
 			var print2 = CSFunctionCall.ConsoleWriteLine (csTypeID == ocsTypeID);
 			var callingCode = CSCodeBlock.Create (ocstyDecl, mtDecl, cstyDecl, tryGetLine, print1, print2);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, "ISomeProtocol\nTrue\n", platform: PlatformName.macOS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ISomeProtocol\nTrue\n");
 		}
 
 	}


### PR DESCRIPTION
This change puts
```
#if __IOS__ || __MACOS__ || __TVOS__ || __WATCHOS__
// ...
#endif
```
protections around all cases of `using ObjCRuntime;` and all `[MonoPInvokeCallback]` usages.
To make this happen, I added a utility method `ProtectWithIfEndif` in `CSConditionalCompilation` which wraps an `ICodeElement` in the wrapping. Then I modified `AddIfNotPresent` to take an optional identifier to put in a `#if` and wrap around the package.

There is a minor bug here in that if the package has been already included without the protection, then the protection won't be added. Since we always add the protection fo `ObjCRuntime` I'm not concerned about this.

All the test changes remove the platform usage in tests. The end result of this is that tests run almost 1/3 faster on my machine (30:40 vs 44:59 minutes).