### PR TITLE
wrap generic tuples

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -1840,7 +1840,7 @@ namespace SwiftReflector {
 					parms.Insert (0, new SLParameter (returnName, newReturnType));
 				} else {
 					if (funcDecl.IsTypeSpecGeneric (retType)) {
-						if (retType.ContainsGenericParameters) {
+						if (retType.ContainsGenericParameters || retType is TupleTypeSpec) {
 							SLType retSLType = typeMapper.TypeSpecMapper.MapType (funcDecl, modules, retType, true);
 							parms.Insert (0, new SLParameter (returnName,
 							                                  new SLBoundGenericType ("UnsafeMutablePointer", retSLType)));

--- a/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
@@ -1283,7 +1283,31 @@ public class Weak<T: AnyObject> {
 			var callingCode = CSCodeBlock.Create (printIt);
 
 			TestRunning.TestAndExecute (swiftCode, callingCode, "compiled\n");
-}
+		}
 
+		[Test]
+		public void TestGenericTuple ()
+		{
+			var swiftCode = @"
+public func rotate<T>(x: (T, T, T)) -> (T, T, T)
+{
+	return (x.1, x.2, x.0)
+}
+";
+
+			// var t = new Tuple<nint, nint, nint>(1, 2, 3)
+			// var u = TopLevelFunctions.Rotate(t);
+			// Console.WriteLine (u);
+
+			var tID = new CSIdentifier ("t");
+			var uID = new CSIdentifier ("u");
+			var tDecl = CSVariableDeclaration.VarLine (tID, new CSFunctionCall ("Tuple<nint, nint, nint>", true,
+				CSConstant.Val (1), CSConstant.Val (2), CSConstant.Val (3)));
+			var uDecl = CSVariableDeclaration.VarLine (uID, new CSFunctionCall ("TopLevelEntities.Rotate", false, tID));
+			var printer = CSFunctionCall.ConsoleWriteLine (uID);
+			var callingCode = CSCodeBlock.Create (tDecl, uDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "(2, 3, 1)\n");
+		}
 	}
 }


### PR DESCRIPTION
Allow generic tuples fixing issue [33](https://github.com/xamarin/binding-tools-for-swift/issues/33)

This is a fix that falls into the category of "this never happens". Here's why:

There are 5 fundamental steps in BTfS
1 - Reflection
2 - Write swift wrappers
3 - Compile wrappers
4 - More reflection
5 - Write C# bindings

This failure was in step 2. Usually, if I have a bug in step 2, I missed a case and I usually see that issue in step 5, but more often than not, it shows up in steps 3 and 4.

The code here looks at the return type looks in the wrapper. If a `TypeSpec` is generic, then it exists in several possible forms: `T`, `SomeType<T>` or in this case `(T, T, T)`. The predicate `funcDecl.IsTypeSpecGeneric` returns true if a `TypeSpec` is any one of these forms. From there, we care about whether this is the first form or the others, so the test was augmented to ask if type has generic parameters (the second form) or a tuple.

And I fully expected this to fail at least in step 5, but no everything else apparently works.
Knock me over with a feather.