### PR TITLE
Added more 3rd party code

### DIFF
--- a/tests/3rd-party/Neon/Makefile
+++ b/tests/3rd-party/Neon/Makefile
@@ -19,7 +19,7 @@ XCODESCHEME=Neon iOS
 FRAMEWORKNAME=Neon
 #
 # If the project fails to build/bind, set IGNORED=1
-IGNORED=1
+# IGNORED=1
 # Changing IGNORED? Consider updating the README.txt file and any Git issues
 # referenced therein.
 

--- a/tests/3rd-party/Spring/Makefile
+++ b/tests/3rd-party/Spring/Makefile
@@ -19,7 +19,7 @@ XCODEPROJECT=./repository/SpringApp.xcodeproj
 # FRAMEWORKNAME=name
 #
 # If the project fails to build/bind, set IGNORED=1
-IGNORED=1
+# IGNORED=1
 # Changing IGNORED? Consider updating the README.txt file and any Git issues
 # referenced therein.
 


### PR DESCRIPTION
Noted that issue [36](https://github.com/xamarin/binding-tools-for-swift/issues/36) no longer applies.

Both Neon and Spring frameworks now bind. paper-switch was already active.