### PR TITLE
Added null checks to arguments

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSFunctionCall.cs
+++ b/Dynamo/Dynamo.CSLang/CSFunctionCall.cs
@@ -67,6 +67,18 @@ namespace Dynamo.CSLang {
 				new CommaListElementCollection<CSBaseExpression> (parameters), isConstructor));
 		}
 
+		static CSIdentifier iNameOf = new CSIdentifier ("nameof");
+		
+		public static CSFunctionCall Nameof (CSIdentifier id)
+		{
+			return FooOf (iNameOf, id);
+		}
+
+		public static CSFunctionCall Nameof (string name)
+		{
+			return Nameof (new CSIdentifier (name));
+		}
+
 		static CSIdentifier iTypeof = new CSIdentifier ("typeof");
 
 		public static CSFunctionCall Typeof (Type t)
@@ -76,28 +88,27 @@ namespace Dynamo.CSLang {
 
 		public static CSFunctionCall Typeof (string t)
 		{
-			CommaListElementCollection<CSBaseExpression> parms = new CommaListElementCollection<CSBaseExpression> ();
-			parms.Add (new CSIdentifier (t));
-			return new CSFunctionCall (iTypeof, parms, false);
+			return FooOf (iTypeof, new CSIdentifier (t));
 		}
 
 		public static CSFunctionCall Typeof (CSSimpleType t)
 		{
-			CommaListElementCollection<CSBaseExpression> parms = new CommaListElementCollection<CSBaseExpression> ();
-			parms.Add (new CSIdentifier (t.Name));
-			return new CSFunctionCall (iTypeof, parms, false);
+			return Typeof (t.Name);
 		}
-
 
 		static CSIdentifier iSizeof = new CSIdentifier ("sizeof");
 
 		public static CSFunctionCall Sizeof (CSBaseExpression expr)
 		{
-			CommaListElementCollection<CSBaseExpression> parms = new CommaListElementCollection<CSBaseExpression> ();
-			parms.Add (expr);
-			return new CSFunctionCall (iSizeof, parms, false);
+			return FooOf (iSizeof, expr);
 		}
 
+		static CSFunctionCall FooOf (CSIdentifier foo, CSBaseExpression parameter)
+		{
+			CommaListElementCollection<CSBaseExpression> parms = new CommaListElementCollection<CSBaseExpression> ();
+			parms.Add (parameter);
+			return new CSFunctionCall (foo, parms, false);
+		}
 	}
 
 }

--- a/Dynamo/Dynamo.CSLang/CSThrow.cs
+++ b/Dynamo/Dynamo.CSLang/CSThrow.cs
@@ -34,6 +34,13 @@ namespace Dynamo.CSLang {
 				args.Add (CSConstant.Val (message));
 			return ThrowLine (exType, args);
 		}
+
+		public static CSLine ThrowLine<T>(T exType, CSBaseExpression expr) where T : Exception
+		{
+			CommaListElementCollection<CSBaseExpression> args = new CommaListElementCollection<CSBaseExpression> ();
+			args.Add (Exceptions.ThrowOnNull (expr, nameof (expr)));
+			return ThrowLine (exType, args);
+		}
 	}
 }
 

--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -1600,6 +1600,9 @@ namespace SwiftReflector {
 			// someCallToAPinvoke(new IntPtr(nameSwiftDataPtr))
 			// ...
 
+			if (p.Name.Name != "this")
+				preMarshalCode.Add (ThrowOnNull (p.Name));
+
 			string nomDataPtrName = Uniqueify (String.Format ("{0}SwiftDataPtr", p.Name.Name), identifiersUsed);
 			identifiersUsed.Add (nomDataPtrName);
 			var enumDataPtr = new CSIdentifier (nomDataPtrName);
@@ -1610,6 +1613,12 @@ namespace SwiftReflector {
 							       new CSFunctionCall ("StructMarshal.Marshaler.PrepareNominal", false, p.Name), null);
 			fixedChain.Add (fixedBlock);
 			return new CSCastExpression ("IntPtr", enumDataPtr);
+		}
+
+		CSLine ThrowOnNull (CSIdentifier parameterName)
+		{
+			use.AddIfNotPresent (typeof (SwiftRuntimeLibrary.Exceptions));
+			return CSFunctionCall.FunctionCallLine ("Exceptions.ThrowOnNull", parameterName, CSFunctionCall.Nameof (parameterName));
 		}
 
 		CSBaseExpression MarshalClass (CSParameter p, NamedTypeSpec cl)
@@ -1631,7 +1640,9 @@ namespace SwiftReflector {
 			// In the second case, we reassign the argument.
 
 			// I put all the swift_beginAccess/swift_endAccess code into
-			// StructMarshal.   
+			// StructMarshal.
+			if (p.Name.Name != "this")
+				preMarshalCode.Add (ThrowOnNull (p.Name));
 
 			var fullClassName = cl.Name;
 			var backingFieldAccessor = NewClassCompiler.SafeBackingFieldAccessor (p.Name, use, fullClassName, typeMapper);

--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -1617,8 +1617,14 @@ namespace SwiftReflector {
 
 		CSLine ThrowOnNull (CSIdentifier parameterName)
 		{
-			use.AddIfNotPresent (typeof (SwiftRuntimeLibrary.Exceptions));
-			return CSFunctionCall.FunctionCallLine ("Exceptions.ThrowOnNull", parameterName, CSFunctionCall.Nameof (parameterName));
+			// code to generate:
+			// if (p == null)
+			//    throw new ArgumentNullException (nameof (p));
+
+			var ifTest = parameterName == CSConstant.Null;
+			var throwCall = CSThrow.ThrowLine (new ArgumentNullException (), CSFunctionCall.Nameof (parameterName));
+			var ifStatement = new CSIfElse (ifTest, CSCodeBlock.Create (throwCall), null);
+			return new CSLine (ifStatement, false);
 		}
 
 		CSBaseExpression MarshalClass (CSParameter p, NamedTypeSpec cl)

--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -211,8 +211,8 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftCharacter.cs">
       <Link>SwiftCharacter.cs</Link>
     </Compile>
-    <Compile Include="..\SwiftRuntimeLibrary\Extensions.cs">
-      <Link>Extensions.cs</Link>
+    <Compile Include="..\SwiftRuntimeLibrary\Exceptions.cs">
+      <Link>Exceptions.cs</Link>
     </Compile>
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\ImportedTypeCache.cs">
       <Link>SwiftMarshal\ImportedTypeCache.cs</Link>

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -135,8 +135,8 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\DynamicLib.cs">
       <Link>SwiftMarshal\DynamicLib.cs</Link>
     </Compile>
-    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Extensions.cs">
-      <Link>SwiftMarshal\Extensions.cs</Link>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Exceptions.cs">
+      <Link>SwiftMarshal\Exceptions.cs</Link>
     </Compile>
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Memory.cs">
       <Link>SwiftMarshal\Memory.cs</Link>

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -216,8 +216,8 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftCharacter.cs">
       <Link>SwiftCharacter.cs</Link>
     </Compile>
-    <Compile Include="..\SwiftRuntimeLibrary\Extensions.cs">
-      <Link>Extensions.cs</Link>
+    <Compile Include="..\SwiftRuntimeLibrary\Exceptions.cs">
+      <Link>Exceptions.cs</Link>
     </Compile>
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\ImportedTypeCache.cs">
       <Link>SwiftMarshal\ImportedTypeCache.cs</Link>

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -135,8 +135,8 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\DynamicLib.cs">
       <Link>SwiftMarshal\DynamicLib.cs</Link>
     </Compile>
-    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Exceptions.cs">
-      <Link>SwiftMarshal\Exceptions.cs</Link>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Extensions.cs">
+      <Link>SwiftMarshal\Extentions.cs</Link>
     </Compile>
     <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\Memory.cs">
       <Link>SwiftMarshal\Memory.cs</Link>

--- a/SwiftRuntimeLibrary/Exceptions.cs
+++ b/SwiftRuntimeLibrary/Exceptions.cs
@@ -3,7 +3,7 @@
 
 using System;
 namespace SwiftRuntimeLibrary {
-	public static class Exceptions {
+	internal static class Exceptions {
 		public static T ThrowOnNull<T> (T o, string name, string message = null) where T : class
 		{
 			name = name ?? "::no name supplied::";

--- a/SwiftRuntimeLibrary/Exceptions.cs
+++ b/SwiftRuntimeLibrary/Exceptions.cs
@@ -3,7 +3,7 @@
 
 using System;
 namespace SwiftRuntimeLibrary {
-	internal static class Exceptions {
+	public static class Exceptions {
 		public static T ThrowOnNull<T> (T o, string name, string message = null) where T : class
 		{
 			name = name ?? "::no name supplied::";

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -88,7 +88,7 @@
     <Compile Include="SwiftComparableProxy.cs" />
     <Compile Include="ISwiftComparable.cs" />
     <Compile Include="SwiftCharacter.cs" />
-    <Compile Include="Extensions.cs" />
+    <Compile Include="Exceptions.cs" />
     <Compile Include="SwiftMarshal\ImportedTypeCache.cs" />
     <Compile Include="..\tools\symbolicator\XamGlueConstants.cs">
       <Link>XamGlueConstants.cs</Link>

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1468,6 +1468,36 @@ public struct PitchSet
 			var callingCode = CSCodeBlock.Create (printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "got here\n");
 		}
+
+		[Test]
+		public void DontPassMeNull ()
+		{
+			var swiftCode = @"
+public class EasyToRepresent
+{
+	public init () {}
+}
+
+public func reportIt (a: EasyToRepresent) -> Bool {
+	return true;
+}
+";
+
+			// try {
+			//    TopLevelEntities.ReportIt (null);
+			// } catch (ArgumentNullException err) {
+			//    Console.WriteLine("Here." + err.Message);
+			// }
+
+			var errID = new CSIdentifier ("err");
+			var callIt = CSFunctionCall.FunctionCallLine ("TopLevelEntities.ReportIt", false, CSConstant.Null);
+			var printer = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("Here.") + errID.Dot(new CSIdentifier ("Message")));
+			var tryCatch = new CSTryCatch (CSCodeBlock.Create (callIt),
+				typeof (ArgumentNullException), errID.Name, CSCodeBlock.Create (printer));
+			var callingCode = CSCodeBlock.Create (tryCatch);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Here.Value cannot be null.\nParameter name: a\n");
+		}
 	}
 }
 


### PR DESCRIPTION
Added code to generate null argument checks fixing issue [66](https://github.com/xamarin/binding-tools-for-swift/issues/66)

First I added `nameof` to `CSFunctionCall` and while I was in there, I refactored all the `_of` functions to all go through the same code, getting rid of duplicate code.

Second I exposed `ThrowOnNull` as public. There is another copy of this in the SwiftReflector project and since SwiftReflector has a reference to SwiftRuntimeLibrary, I should get rid of it and refactor. I didn't do this because that's potentially a big change and belongs in a PR of its own (ooh! premonition!).

The actual change happens in `MarshalEngine`. There's a bottleneck for marshaling `ISwiftObject` derived types and one for `ISwiftNominalType` derived types. This makes it really easy to make this a uniform change. 

TIL that `nameof(this)` in C# is meaningless, which is weird because it does have a name. No matter - not generating a null test for `this` is the right thing anyway since `this` damn well better be non-null. That particular code generated 392 test failures, so I think the coverage is pretty good here.

Finally for the test specific to this, I test a positive failure by trying to pass null to a function that takes an `ISwiftObject` to see what happens.