### PR TITLE
notify on use of disposed object

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -3693,11 +3693,14 @@ namespace SwiftReflector {
 			// protected virtual void DisposeUnmanagedResources()
 			// {
 			//      SwiftCore.Release(SwiftObject);
+			//      SwiftObject = IntPtr.Zero;
 			// }
 			var disposeUnmanaged = new CSMethod (CSVisibility.Protected,
 							  CSMethodKind.Virtual, CSSimpleType.Void, disposeUnmanagedIdent, new CSParameterList (),
 							  new CSCodeBlock ()
-				.And (CSFunctionCall.FunctionCallLine ("SwiftCore.Release", false, kSwiftObjectGetter)));
+				.And (CSFunctionCall.FunctionCallLine ("SwiftCore.Release", false, kSwiftObjectGetter))
+				.And (CSAssignment.Assign (kSwiftObjectGetter, CSConstant.IntPtrZero))
+				);
 			cl.Methods.Add (disposeUnmanaged);
 
 			var destructor = new CSMethod (CSVisibility.None, CSMethodKind.None, null, csDestructorIdent, new CSParameterList (),

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -26,6 +26,8 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			if (obj == null)
 				return IntPtr.Zero;
 			byte* valueBuffer = stackalloc byte [3 * IntPtr.Size];
+			if (obj.SwiftObject == IntPtr.Zero)
+				throw new SwiftRuntimeException ("SwiftObject handle is IntPtr.Zero, likely because it was disposed.");
 			SwiftCore.swift_beginAccess (obj.SwiftObject, valueBuffer, (uint)SwiftExclusivityFlags.Track, IntPtr.Zero);
 			var result = SwiftCore.Retain (obj.SwiftObject);
 			SwiftCore.swift_endAccess (valueBuffer);

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -25,9 +25,9 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		{
 			if (obj == null)
 				return IntPtr.Zero;
-			byte* valueBuffer = stackalloc byte [3 * IntPtr.Size];
 			if (obj.SwiftObject == IntPtr.Zero)
 				throw new SwiftRuntimeException ("SwiftObject handle is IntPtr.Zero, likely because it was disposed.");
+			byte* valueBuffer = stackalloc byte [3 * IntPtr.Size];
 			SwiftCore.swift_beginAccess (obj.SwiftObject, valueBuffer, (uint)SwiftExclusivityFlags.Track, IntPtr.Zero);
 			var result = SwiftCore.Retain (obj.SwiftObject);
 			SwiftCore.swift_endAccess (valueBuffer);

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1498,6 +1498,41 @@ public func reportIt (a: EasyToRepresent) -> Bool {
 
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Here.Value cannot be null.\nParameter name: a\n");
 		}
+
+		[Test]
+		public void CheckOnDisposeThanks ()
+		{
+			var swiftCode = @"
+public class DisposeMeThanks {
+    public init () { }
+    public func doIt () -> Int {
+        return 77
+    }
+}
+public func tryMeHere (a:DisposeMeThanks ) -> Int {
+    return a.doIt ()
+}
+";
+			// try {
+			//    var p = new DisposeMeThanks ();
+			//    p.Dispose ();
+			//    TopLevelEntities.TryMeHere (p);
+			// } catch (Exception err) {
+			//    Console.WriteLine (err.Message);
+			// }
+
+			var pID = new CSIdentifier ("p");
+			var errID = new CSIdentifier ("err");
+			var pDecl = CSVariableDeclaration.VarLine (pID, new CSFunctionCall ("DisposeMeThanks", true));
+			var disposeCall = CSFunctionCall.FunctionCallLine ($"{pID.Name}.Dispose", false);
+			var tryItCall = CSFunctionCall.FunctionCallLine ("TopLevelEntities.TryMeHere", false, pID);
+			var catchPrinter = CSFunctionCall.ConsoleWriteLine (errID.Dot (new CSIdentifier ("Message")));
+			var tryCatch = new CSTryCatch (CSCodeBlock.Create (pDecl, disposeCall, tryItCall),
+				typeof (Exception), errID.Name, CSCodeBlock.Create (catchPrinter));
+			var callingCode = CSCodeBlock.Create (tryCatch);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "SwiftObject handle is IntPtr.Zero, likely because it was disposed.\n");
+		}
 	}
 }
 


### PR DESCRIPTION
Check for 0 handle in retain fixing issue [414](https://github.com/xamarin/binding-tools-for-swift/issues/414)

Step 1:
Ensure that the handle gets set to `IntPtr.Zero` on Dispose
Step 2:
🤷‍♀️ 
Step 3: ~~Profit~~ check for `IntPtr.Zero` in `RetainSwiftObject`

Why does this work?
`IntPtr.Zero` is never a valid value for a swift class instance. If the object gets Disposed, setting the handle to `IntPtr.Zero` is the ideal value for "no good"
Why don't you check to see if `Dispose` was called?
Because `SwiftRetainObject` gets called before any handle gets passed to swift and it doesn't have access to the flag. In order to do that, I'd have to do one of the following:
1 - change the code generator to inject checks before calls to `RetainSwiftObject`, which also may not have access to the object's state
2 - put a disposed flag into a deliciously small interface which has a lot of fan-out of changes

Nope, this is small and relatively safe. I like those traits.


Test passes as expected.