### PR TITLE
test for base conformance descriptor

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1634,5 +1634,17 @@ namespace SwiftReflector.Demangling {
 			Assert.IsNotNull (cl, "not a class");
 			Assert.AreEqual ("itsAFive.E2", cl.ClassName.ToFullyQualifiedName (), "wrong name");
 		}
+
+		[Test]
+		public void TestBaseConformanceDescriptor ()
+		{
+			var tld = Decomposer.Decompose ("_$sSHSQTb", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var bcd = tld as TLBaseConformanceDescriptor;
+			Assert.IsNotNull (bcd, "not a conformance descriptor");
+			var cl = bcd.ProtocolRequirement as SwiftClassType;
+			Assert.IsNotNull (cl, "not a class");
+			Assert.AreEqual ("Swift.Equatable", cl.ClassName.ToFullyQualifiedName (), "wrong name");
+		}
 	}
 }


### PR DESCRIPTION
Addressing issue [63](https://github.com/xamarin/binding-tools-for-swift/issues/63)

Wherein, Present Steve, Past Steve and Very Past Steve meet for tea.

Test passes, no changes needed.