### PR TITLE
Added associated type descriptors

### DIFF
--- a/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
+++ b/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
@@ -819,6 +819,8 @@ namespace SwiftReflector.Demangling {
 				return ConvertProtocolRequirementsBaseDescriptor (node);
 			case NodeKind.BaseConformanceDescriptor:
 				return ConvertBaseConformanceDescriptor (node);
+			case NodeKind.AssociatedTypeDescriptor:
+				return ConvertAssocatedTypeDescriptor (node);
 			default:
 				return null;
 			}
@@ -1145,6 +1147,15 @@ namespace SwiftReflector.Demangling {
 			if (requirement == null)
 				return null;
 			return new TLBaseConformanceDescriptor (mangledName, protocol.ClassName.Module, protocol, requirement, offset);
+		}
+
+		TLAssociatedTypeDescriptor ConvertAssocatedTypeDescriptor (Node node)
+		{
+			var name = new SwiftName (node.Children [0].Text, false);
+			var protocol = ConvertToSwiftType (node.Children [0].Children [0], false, null) as SwiftClassType;
+			if (protocol == null)
+				return null;
+			return new TLAssociatedTypeDescriptor (mangledName, protocol.ClassName.Module, protocol, name, offset);
 		}
 
 

--- a/SwiftReflector/Demangling/TLDefinition.cs
+++ b/SwiftReflector/Demangling/TLDefinition.cs
@@ -232,5 +232,15 @@ namespace SwiftReflector.Demangling {
 		}
 		public SwiftClassType ProtocolRequirement { get; private set; }
 	}
+
+	public class TLAssociatedTypeDescriptor : TLClassElem {
+		public TLAssociatedTypeDescriptor (string mangledName, SwiftName module, SwiftClassType protocol, SwiftName associatedTypeName, ulong offset)
+			: base (CoreCompoundType.AssociatedTypeDescriptor, mangledName, module, protocol, offset)
+		{
+			AssociatedTypeName = associatedTypeName;
+		}
+
+		public SwiftName AssociatedTypeName { get; private set; }
+	}
 }
 

--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -31,6 +31,7 @@ namespace SwiftReflector {
 		MetadataDescriptor,
 		ProtocolRequirementsBaseDescriptor,
 		BaseConformanceDescriptor,
+		AssociatedTypeDescriptor,
 	}
 
 	public enum CoreBuiltInType {

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1646,5 +1646,38 @@ namespace SwiftReflector.Demangling {
 			Assert.IsNotNull (cl, "not a class");
 			Assert.AreEqual ("Swift.Equatable", cl.ClassName.ToFullyQualifiedName (), "wrong name");
 		}
+
+		[Test]
+		public void TestAssociatedTypeDescriptor0 ()
+		{
+			var tld = Decomposer.Decompose ("_$s12RowValueType6Eureka04RuleC0PTl", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var atdesc = tld as TLAssociatedTypeDescriptor;
+			Assert.IsNotNull (atdesc, "not an associated type desc");
+			Assert.AreEqual ("RowValueType", atdesc.AssociatedTypeName.Name, "wrong associated type name");
+			Assert.AreEqual ("Eureka.RuleType", atdesc.Class.ClassName.ToFullyQualifiedName (), "protocol name mismatch");
+		}
+
+		[Test]
+		public void TestAssociatedTypeDescriptor1 ()
+		{
+			var tld = Decomposer.Decompose ("_$s23PresentedControllerType6Eureka012PresenterRowC0PTl", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var atdesc = tld as TLAssociatedTypeDescriptor;
+			Assert.IsNotNull (atdesc, "not an associated type desc");
+			Assert.AreEqual ("PresentedControllerType", atdesc.AssociatedTypeName.Name, "wrong associated type name");
+			Assert.AreEqual ("Eureka.PresenterRowType", atdesc.Class.ClassName.ToFullyQualifiedName (), "protocol name mismatch");
+		}
+
+		[Test]
+		public void TestAssociatedTypeDescriptor2 ()
+		{
+			var tld = Decomposer.Decompose ("_$s9InlineRow6Eureka0aB4TypePTl", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var atdesc = tld as TLAssociatedTypeDescriptor;
+			Assert.IsNotNull (atdesc, "not an associated type desc");
+			Assert.AreEqual ("InlineRow", atdesc.AssociatedTypeName.Name, "wrong associated type name");
+			Assert.AreEqual ("Eureka.InlineRowType", atdesc.Class.ClassName.ToFullyQualifiedName (), "protocol name mismatch");
+		}
 	}
 }


### PR DESCRIPTION
Added support for demangling associated type descriptor fixing issue [48](https://github.com/xamarin/binding-tools-for-swift/issues/48)

An associated type descriptor looks like this:
```
->AssociatedTypeDescriptor
  ->DependentAssociatedTypeRef ("AssociatedTypeName")
    ->Type
      ->Protocol
        ->Module ("ModuleName")
        ->Identifier ("ProtocolName")
```

Everything from the `Type` node down we can convert directly, so all we need to do is pull out the associated type name.
Defined a new class in the `TL` hierarchy to contain the data and done.

Added 3 tests, which pass.