### PR TITLE
renamed RetainNominalData and ReleaseNominalData

### DIFF
--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -1092,7 +1092,7 @@ namespace SwiftReflector {
 				// StructMarshal.Marshaler.ToSwiftTuple(typeof(pType), pName, tupleIntPtr, map)
 				// ...
 				// SomePInvoke(... tupleIntPtr ...)
-				// StructMarshal.Marshaler.ReleaseNominalData (typeof (pType), tupleIntPtr);
+				// StructMarshal.Marshaler.NominalDestroy (typeof (pType), tupleIntPtr);
 				// only injected if the argument is by reference
 				// p.Name = StructMarshal.Marshaler.ToNetTuple<t1, t2, t3, t4>(tupleIntPtr, map);
 				// }
@@ -1127,7 +1127,7 @@ namespace SwiftReflector {
 				preMarshalCode.Add (pPtrDecl);
 
 				if (!MarshalingConstructor) {
-					var releaseNominal = CSFunctionCall.FunctionCallLine ("StructMarshal.Marshaler.ReleaseNominalData", false, p.CSType.Typeof (), pPtr);
+					var releaseNominal = CSFunctionCall.FunctionCallLine ("StructMarshal.Marshaler.NominalDestroy", false, p.CSType.Typeof (), pPtr);
 					postMarshalCode.Add (releaseNominal);
 				}
 

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -3566,7 +3566,7 @@ namespace SwiftReflector {
 			//		{
 			//			fixed (byte* p = SwiftData)
 			//			{
-			//				StructMarshal.Marshaler.ReleaseNominalData(typeof(this), p);
+			//				StructMarshal.Marshaler.NominalDestroy(typeof(this), p);
 			//			}
 			//			SwiftData = null;
 			//		}
@@ -3583,7 +3583,7 @@ namespace SwiftReflector {
 			var fixedBody = new CSCodeBlock ();
 			var fixedBlock = new CSFixedCodeBlock (CSSimpleType.ByteStar, bytestarID, swiftDataID, fixedBody);
 			use.AddIfNotPresent (typeof (StructMarshal));
-			fixedBlock.Add (CSFunctionCall.FunctionCallLine ("StructMarshal.Marshaler.ReleaseNominalData", false,
+			fixedBlock.Add (CSFunctionCall.FunctionCallLine ("StructMarshal.Marshaler.NominalDestroy", false,
 			                                               new CSFunctionCall ("typeof", false, new CSIdentifier (cl.ToCSType ().ToString ())),
 			                                               bytestarID));
 

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -27,7 +27,7 @@ namespace SwiftRuntimeLibrary {
 			if (swiftTypeData == null)
 				throw new ArgumentNullException (nameof (swiftTypeData));
 			var length = swiftTypeData.Length;
-			StructMarshal.Marshaler.RetainNominalData (mt, swiftTypeData);
+			StructMarshal.Marshaler.NominalInitializeWithCopy (mt, swiftTypeData);
 			SwiftData = new byte [length];
 			Array.Copy (swiftTypeData, SwiftData, length);
 			ProxiedMetatype = mt;
@@ -61,7 +61,7 @@ namespace SwiftRuntimeLibrary {
 			if (IsCSObjectProxy) {
 				SwiftCore.Release (SwiftObject);
 			} else {
-				StructMarshal.Marshaler.ReleaseNominalData (ProxiedMetatype, SwiftData);
+				StructMarshal.Marshaler.NominalDestroy (ProxiedMetatype, SwiftData);
 			}
 		}
 

--- a/SwiftRuntimeLibrary/SwiftArray.cs
+++ b/SwiftRuntimeLibrary/SwiftArray.cs
@@ -147,7 +147,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 			
 		public IEnumerator<T> GetEnumerator ()

--- a/SwiftRuntimeLibrary/SwiftCharacter.cs
+++ b/SwiftRuntimeLibrary/SwiftCharacter.cs
@@ -72,7 +72,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 	}
 }

--- a/SwiftRuntimeLibrary/SwiftDate.cs
+++ b/SwiftRuntimeLibrary/SwiftDate.cs
@@ -99,7 +99,7 @@ namespace SwiftRuntimeLibrary {
 			if (SwiftData != null) {
 				unsafe {
 					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.ReleaseNominalData (typeof (SwiftDate),
+						StructMarshal.Marshaler.NominalDestroy (typeof (SwiftDate),
 						    p);
 					}
 					SwiftData = null;

--- a/SwiftRuntimeLibrary/SwiftDictionary.cs
+++ b/SwiftRuntimeLibrary/SwiftDictionary.cs
@@ -25,7 +25,7 @@ namespace SwiftRuntimeLibrary {
 					DictPI.NewDict (new IntPtr(retvalData), capacity, StructMarshal.Marshaler.Metatypeof (typeof (T)),
 					                StructMarshal.Marshaler.Metatypeof (typeof (U)),
 					                StructMarshal.Marshaler.ProtocolWitnessof (typeof (ISwiftHashable), typeof (T)));
-					StructMarshal.Marshaler.RetainNominalData (typeof (SwiftDictionary<T, U>), retvalData, SwiftData.Length);
+					StructMarshal.Marshaler.NominalInitializeWithCopy (typeof (SwiftDictionary<T, U>), retvalData, SwiftData.Length);
 				}
 			}
 		}
@@ -132,7 +132,7 @@ namespace SwiftRuntimeLibrary {
 			unsafe {
 				fixed (byte* thisPtr = SwiftData) {
 					var thisIntPtr = new IntPtr (thisPtr);
-					StructMarshal.Marshaler.RetainNominalData (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
+					StructMarshal.Marshaler.NominalInitializeWithCopy (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
 					byte* keyBuffer = stackalloc byte [StructMarshal.Marshaler.Sizeof (typeof (T))];
 					var keyBufferPtr = new IntPtr (keyBuffer);
 					StructMarshal.Marshaler.ToSwift (typeof (T), key, keyBufferPtr);
@@ -167,7 +167,7 @@ namespace SwiftRuntimeLibrary {
 			unsafe {
 				fixed (byte* thisPtr = SwiftData) {
 					IntPtr thisIntPtr = new IntPtr (thisPtr);
-					StructMarshal.Marshaler.RetainNominalData (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
+					StructMarshal.Marshaler.NominalInitializeWithCopy (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
 					DictPI.DictClear (thisIntPtr, StructMarshal.Marshaler.Metatypeof (typeof (T)),
 							 StructMarshal.Marshaler.Metatypeof (typeof (U)),
 							 StructMarshal.Marshaler.ProtocolWitnessof (typeof (ISwiftHashable), typeof (T)));
@@ -188,7 +188,7 @@ namespace SwiftRuntimeLibrary {
 			unsafe {
 				fixed (byte* thisPtr = SwiftData) {
 					var thisIntPtr = new IntPtr (thisPtr);
-					StructMarshal.Marshaler.RetainNominalData (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
+					StructMarshal.Marshaler.NominalInitializeWithCopy (typeof (SwiftDictionary<T, U>), thisIntPtr, SwiftData.Length);
 					byte* keyBuffer = stackalloc byte [StructMarshal.Marshaler.Sizeof (typeof (T))];
 					var keyBufferPtr = new IntPtr (keyBuffer);
 					StructMarshal.Marshaler.ToSwift (typeof (T), key, keyBufferPtr);
@@ -233,7 +233,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 

--- a/SwiftRuntimeLibrary/SwiftHasher.cs
+++ b/SwiftRuntimeLibrary/SwiftHasher.cs
@@ -37,7 +37,7 @@ namespace SwiftRuntimeLibrary {
 		{
 			if (SwiftData != null) {
 				fixed (byte *p = SwiftData) {
-					StructMarshal.Marshaler.ReleaseNominalData (typeof (SwiftHasher), p);
+					StructMarshal.Marshaler.NominalDestroy (typeof (SwiftHasher), p);
 				}
 				SwiftData = null;
 			}

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -1461,29 +1461,29 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return p;
 		}
 
-		public unsafe void ReleaseNominalData (Type t, byte* p)
+		public unsafe void NominalDestroy (Type t, byte* p)
 		{
-			ReleaseNominalData (t, new IntPtr (p));
+			NominalDestroy (t, new IntPtr (p));
 		}
 
-		public unsafe void ReleaseNominalData (ISwiftNominalType obj)
+		public unsafe void NominalDestroy (ISwiftNominalType obj)
 		{
 			var data = obj.SwiftData;
 			if (data != null) {
 				fixed (byte* p = data)
-					ReleaseNominalData (obj.GetType (), p);
+					NominalDestroy (obj.GetType (), p);
 				obj.SwiftData = null;
 			}
 		}
 
-		public void ReleaseNominalData (Type t, IntPtr p)
+		public void NominalDestroy (Type t, IntPtr p)
 		{
 			var mt = Metatypeof (t);
 			var destroy = GetNominalDestroy (t);
 			destroy (p, mt);
 		}
 
-		public unsafe void ReleaseNominalData (SwiftMetatype mt, byte [] p)
+		public unsafe void NominalDestroy (SwiftMetatype mt, byte [] p)
 		{
 			var destroy = GetNominalDestroy (mt);
 			fixed (byte* pptr = p) {
@@ -1514,7 +1514,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				return; // nothing to release
 
 			if (IsSwiftNominal (type) || type.IsTuple ()) {
-				ReleaseNominalData (type, value);
+				NominalDestroy (type, value);
 				return;
 			}
 
@@ -1556,7 +1556,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return destroy;
 		}
 
-		public unsafe IntPtr RetainNominalData (ISwiftNominalType obj)
+		public unsafe IntPtr NominalInitializeWithCopy (ISwiftNominalType obj)
 		{
 			if (obj == null)
 				throw new ArgumentNullException (nameof (obj));
@@ -1565,15 +1565,15 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				throw new ObjectDisposedException (obj.GetType ().ToString ());
 
 			fixed (byte* ptr = obj.SwiftData)
-				return RetainNominalData (obj.GetType (), ptr, obj.SwiftData.Length);
+				return NominalInitializeWithCopy (obj.GetType (), ptr, obj.SwiftData.Length);
 		}
 
-		public unsafe IntPtr RetainNominalData (Type t, byte* p, int size)
+		public unsafe IntPtr NominalInitializeWithCopy (Type t, byte* p, int size)
 		{
-			return RetainNominalData (t, new IntPtr (p), size);
+			return NominalInitializeWithCopy (t, new IntPtr (p), size);
 		}
 
-		public IntPtr RetainNominalData (Type t, IntPtr p, int size)
+		public IntPtr NominalInitializeWithCopy (Type t, IntPtr p, int size)
 		{
 			unsafe {
 				byte* tbuf = stackalloc byte [size];
@@ -1586,7 +1586,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return p;
 		}
 
-		public unsafe void RetainNominalData (SwiftMetatype metadata, byte [] p)
+		public unsafe void NominalInitializeWithCopy (SwiftMetatype metadata, byte [] p)
 		{
 			byte* tbuf = stackalloc byte [p.Length];
 			var tbufPtr = new IntPtr (tbuf);
@@ -1672,7 +1672,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			Marshal.Copy (p, payload, 0, payload.Length);
 
 			if (!owns)
-				RetainNominalData (t, p, payload.Length);
+				NominalInitializeWithCopy (t, p, payload.Length);
 
 			return o;
 		}

--- a/SwiftRuntimeLibrary/SwiftOptional.cs
+++ b/SwiftRuntimeLibrary/SwiftOptional.cs
@@ -69,7 +69,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public static SwiftOptional<T> None ()

--- a/SwiftRuntimeLibrary/SwiftSet.cs
+++ b/SwiftRuntimeLibrary/SwiftSet.cs
@@ -57,7 +57,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public unsafe nint Count {

--- a/SwiftRuntimeLibrary/SwiftString.cs
+++ b/SwiftRuntimeLibrary/SwiftString.cs
@@ -40,7 +40,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		// As of the first release of Swift 5.0, using FromUTF16Pointer leaks memory for every string

--- a/SwiftRuntimeLibrary/UnsafeMutablePointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeMutablePointer.cs
@@ -54,7 +54,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public static UnsafeMutablePointer<T> Allocate(nint capacity)

--- a/SwiftRuntimeLibrary/UnsafeMutableRawBufferPointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeMutableRawBufferPointer.cs
@@ -76,7 +76,7 @@ namespace SwiftRuntimeLibrary {
 			if (SwiftData != null) {
 				unsafe {
 					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.ReleaseNominalData (typeof (UnsafeRawBufferPointer), p);
+						StructMarshal.Marshaler.NominalDestroy (typeof (UnsafeRawBufferPointer), p);
 					}
 					SwiftData = null;
 				}

--- a/SwiftRuntimeLibrary/UnsafePointer.cs
+++ b/SwiftRuntimeLibrary/UnsafePointer.cs
@@ -59,7 +59,7 @@ namespace SwiftRuntimeLibrary {
 
 		void Dispose (bool disposing)
 		{
-			StructMarshal.Marshaler.ReleaseNominalData (this);
+			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 

--- a/SwiftRuntimeLibrary/UnsafeRawBufferPointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeRawBufferPointer.cs
@@ -71,7 +71,7 @@ namespace SwiftRuntimeLibrary {
 			if (SwiftData != null) {
 				unsafe {
 					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.ReleaseNominalData (typeof (UnsafeRawBufferPointer), p);
+						StructMarshal.Marshaler.NominalDestroy (typeof (UnsafeRawBufferPointer), p);
 					}
 					SwiftData = null;
 				}


### PR DESCRIPTION
Refactor to change `RetainNominalData` and `ReleaseNominalData` to `NominalInitializeWithCopy` and `NominalDestroy` addressing issue [83](https://github.com/xamarin/binding-tools-for-swift/issues/83)