### PR TITLE
moving common code for ISwiftObject

### DIFF
--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -277,6 +277,12 @@
     <Compile Include="..\SwiftRuntimeLibrary\BaseAssociatedTypeProxy.cs">
       <Link>BaseAssociatedTypeProxy.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeInstance.cs">
+      <Link>SwiftNativeInstance.cs</Link>
+    </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeObject.cs">
+      <Link>SwiftNativeObject.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -282,6 +282,12 @@
     <Compile Include="..\SwiftRuntimeLibrary\BaseAssociatedTypeProxy.cs">
       <Link>BaseAssociatedTypeProxy.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeObject.cs">
+      <Link>SwiftNativeObject.cs</Link>
+    </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeInstance.cs">
+      <Link>SwiftNativeInstance.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="make --directory=../SwiftRuntimeLibrary create-pinvokes-ios configuration=$(Configuration)" />

--- a/SwiftRuntimeLibrary/EveryProtocol.cs
+++ b/SwiftRuntimeLibrary/EveryProtocol.cs
@@ -7,7 +7,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 	[SwiftNativeObject]
-	public class EveryProtocol : ISwiftObject {
+	public class EveryProtocol : SwiftNativeObject {
 		protected IntPtr handle;
 
 		protected SwiftMetatype class_handle;
@@ -28,21 +28,11 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		public EveryProtocol ()
-			: this (_XamEveryProtocolCtorImpl (), GetSwiftMetatype (), SwiftObjectRegistry.Registry)
+			: base (_XamEveryProtocolCtorImpl (), GetSwiftMetatype (), SwiftObjectRegistry.Registry)
 		{
 		}
 
-		protected EveryProtocol (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
-		{
-			if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
-				object_flags |= SwiftObjectFlags.IsDirectBinding;
-			}
-			class_handle = classHandle;
-			SwiftObject = handle;
-			registry.Add (this);
-		}
-
-		EveryProtocol (IntPtr handle, SwiftObjectRegistry registry) : this (handle, GetSwiftMetatype (), registry)
+		EveryProtocol (IntPtr handle, SwiftObjectRegistry registry) : base (handle, GetSwiftMetatype (), registry)
 		{
 		}
 
@@ -51,46 +41,9 @@ namespace SwiftRuntimeLibrary {
 			return new EveryProtocol (p, SwiftObjectRegistry.Registry);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if ((object_flags & SwiftObjectFlags.Disposed) !=
-			    SwiftObjectFlags.Disposed) {
-				if (disposing) {
-					DisposeManagedResources ();
-				}
-				SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
-				DisposeUnmanagedResources ();
-				object_flags |= SwiftObjectFlags.Disposed;
-			}
-		}
-
-		protected virtual void DisposeManagedResources ()
-		{
-		}
-
-		protected virtual void DisposeUnmanagedResources ()
-		{
-			SwiftCore.Release (SwiftObject);
-		}
-
 		~EveryProtocol ()
 		{
 			Dispose (false);
-		}
-
-		public IntPtr SwiftObject {
-			get {
-				return handle;
-			}
-			private set {
-				handle = value;
-			}
 		}
 	}
 

--- a/SwiftRuntimeLibrary/SwiftNativeInstance.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeInstance.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace SwiftRuntimeLibrary {
+	public abstract class SwiftNativeInstance : IDisposable {
+		~SwiftNativeInstance ()
+		{
+			Dispose (false);
+		}
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+		protected abstract void Dispose (bool disposing);
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftNativeObject.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeObject.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using SwiftRuntimeLibrary.SwiftMarshal;
+
+namespace SwiftRuntimeLibrary {
+	public abstract class SwiftNativeObject : SwiftNativeInstance, ISwiftObject {
+	IntPtr handle;
+	SwiftMetatype class_handle;
+	SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
+
+	protected SwiftNativeObject (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
+	{
+		if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
+			object_flags |= SwiftObjectFlags.IsDirectBinding;
+		}
+		class_handle = classHandle;
+		SwiftObject = handle;
+		registry.Add (this);
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
+			if (disposing) {
+				DisposeManagedResources ();
+			}
+			DisposeUnmanagedResources ();
+			SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
+			object_flags |= SwiftObjectFlags.Disposed;
+		}
+	}
+
+	protected virtual void DisposeManagedResources ()
+	{
+	}
+
+	protected virtual void DisposeUnmanagedResources ()
+	{
+		SwiftCore.Release (SwiftObject);
+	}
+
+	public IntPtr SwiftObject {
+		get {
+			return handle;
+		}
+		private set {
+			handle = value;
+		}
+	}
+}
+}

--- a/SwiftRuntimeLibrary/SwiftNativeObject.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeObject.cs
@@ -6,48 +6,48 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
 	public abstract class SwiftNativeObject : SwiftNativeInstance, ISwiftObject {
-	IntPtr handle;
-	SwiftMetatype class_handle;
-	SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
+		IntPtr handle;
+		SwiftMetatype class_handle;
+		SwiftObjectFlags object_flags = SwiftObjectFlags.IsSwift;
 
-	protected SwiftNativeObject (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
-	{
-		if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
-			object_flags |= SwiftObjectFlags.IsDirectBinding;
-		}
-		class_handle = classHandle;
-		SwiftObject = handle;
-		registry.Add (this);
-	}
-
-	protected override void Dispose (bool disposing)
-	{
-		if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
-			if (disposing) {
-				DisposeManagedResources ();
+		protected SwiftNativeObject (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
+		{
+			if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
+				object_flags |= SwiftObjectFlags.IsDirectBinding;
 			}
-			DisposeUnmanagedResources ();
-			SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
-			object_flags |= SwiftObjectFlags.Disposed;
+			class_handle = classHandle;
+			SwiftObject = handle;
+			registry.Add (this);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if ((object_flags & SwiftObjectFlags.Disposed) != SwiftObjectFlags.Disposed) {
+				if (disposing) {
+					DisposeManagedResources ();
+				}
+				DisposeUnmanagedResources ();
+				SwiftObjectRegistry.Registry.RemoveAndWeakRelease (this);
+				object_flags |= SwiftObjectFlags.Disposed;
+			}
+		}
+
+		protected virtual void DisposeManagedResources ()
+		{
+		}
+
+		protected virtual void DisposeUnmanagedResources ()
+		{
+			SwiftCore.Release (SwiftObject);
+		}
+
+		public IntPtr SwiftObject {
+			get {
+				return handle;
+			}
+			private set {
+				handle = value;
+			}
 		}
 	}
-
-	protected virtual void DisposeManagedResources ()
-	{
-	}
-
-	protected virtual void DisposeUnmanagedResources ()
-	{
-		SwiftCore.Release (SwiftObject);
-	}
-
-	public IntPtr SwiftObject {
-		get {
-			return handle;
-		}
-		private set {
-			handle = value;
-		}
-	}
-}
 }

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -116,6 +116,8 @@
     <Compile Include="SwiftMarshal\SwiftProtocolWitnessTable.cs" />
     <Compile Include="SwiftMarshal\SwiftAssociatedTypeDescriptor.cs" />
     <Compile Include="BaseAssociatedTypeProxy.cs" />
+    <Compile Include="SwiftNativeObject.cs" />
+    <Compile Include="SwiftNativeInstance.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftRuntimeLibrary/XamTrivialSwiftObject.cs
+++ b/SwiftRuntimeLibrary/XamTrivialSwiftObject.cs
@@ -5,56 +5,21 @@ using System;
 using System.Runtime.InteropServices;
 
 namespace SwiftRuntimeLibrary {
-	public class XamTrivialSwiftObject : ISwiftObject {
-		bool disposed;
-
+	public class XamTrivialSwiftObject : SwiftNativeObject {
 		public XamTrivialSwiftObject ()
+			: base (NativeMethodsForXamTrivialSwiftObject.PIctor (NativeMethodsForXamTrivialSwiftObject.PImeta ()),
+				NativeMethodsForXamTrivialSwiftObject.PImeta (), SwiftObjectRegistry.Registry)
 		{
-			SwiftObject = NativeMethodsForXamTrivialSwiftObject.PIctor (NativeMethodsForXamTrivialSwiftObject.PImeta ());
-			SwiftCore.Retain (SwiftObject);
-			SwiftObjectRegistry.Registry.Add (this);
 		}
+
 		XamTrivialSwiftObject (IntPtr p, SwiftObjectRegistry registry)
+			: base (p, NativeMethodsForXamTrivialSwiftObject.PImeta (), registry)
 		{
-			SwiftObject = p;
-			SwiftCore.Retain (p);
-			registry.Add (this);
 		}
 
 		public static object XamarinFactory (IntPtr p)
 		{
 			return new XamTrivialSwiftObject (p, SwiftObjectRegistry.Registry);
-		}
-
-		public IntPtr SwiftObject { get; set; }
-
-		~XamTrivialSwiftObject ()
-		{
-			Dispose (false);
-		}
-		public void Dispose ()
-		{
-			Dispose (true);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (!disposed) {
-				if (disposing) {
-					DisposeManagedResources ();
-				}
-				DisposeUnmanagedResources ();
-				disposed = true;
-			}
-		}
-
-		protected virtual void DisposeManagedResources ()
-		{
-		}
-
-		protected virtual void DisposeUnmanagedResources ()
-		{
-			SwiftCore.Release (SwiftObject);
 		}
 	}
 


### PR DESCRIPTION
As per issue [77](https://github.com/xamarin/binding-tools-for-swift/issues/77), moving common code into base classes.

This PR includes the implementation for heap allocated objects but doesn't change the generated code (yet).

Notes:
I'm using `SwiftNativeObject` for any _class based_ swift type and `SwiftNativeInstance` for its parent class, representing any swift type that can be instantiated. This differs from the suggestion in the PR, because I want to move away from the term `NominalType` for enums and structs since it is incorrect. I'm going to be shifting to `ValueType` instead, so the struct/enum version will be `SwiftNativeValueType` instead of `SwiftNativeNominalObject`.

Q: should I implement the finalizer in children of `SwiftNativeObject`? I currently am - I'm not sure if its redundant.