### PR TITLE
Refactor value types

### DIFF
--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -283,6 +283,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeObject.cs">
       <Link>SwiftNativeObject.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeValueType.cs">
+      <Link>SwiftNativeValueType.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -288,6 +288,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeInstance.cs">
       <Link>SwiftNativeInstance.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftNativeValueType.cs">
+      <Link>SwiftNativeValueType.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="make --directory=../SwiftRuntimeLibrary create-pinvokes-ios configuration=$(Configuration)" />

--- a/SwiftRuntimeLibrary/SwiftArray.cs
+++ b/SwiftRuntimeLibrary/SwiftArray.cs
@@ -12,9 +12,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Array")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftArray_NominalTypeDescriptor, "", "")]
-	public sealed class SwiftArray<T> : ISwiftStruct, IList<T> {
-
-		public byte [] SwiftData { get; set; }
+	public sealed class SwiftArray<T> : SwiftNativeValueType, ISwiftStruct, IList<T> {
 
 		byte [] CheckedSwiftData {
 			get {
@@ -90,8 +88,9 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftArray (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
+			
 		}
 
 		public static SwiftMetatype GetSwiftMetatype ()
@@ -135,21 +134,6 @@ namespace SwiftRuntimeLibrary {
 			}
 		}
 
-		bool disposed = false;
-		public void Dispose ()
-		{
-			if (!disposed) {
-				disposed = true;
-				Dispose (true);
-				GC.SuppressFinalize (this);
-			}
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
-		}
-			
 		public IEnumerator<T> GetEnumerator ()
 		{
 			int count = Count;

--- a/SwiftRuntimeLibrary/SwiftCharacter.cs
+++ b/SwiftRuntimeLibrary/SwiftCharacter.cs
@@ -11,7 +11,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Character")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftCharacter_NominalTypeDescriptor, SwiftCoreConstants.SwiftCharacter_Metadata, "")]
-	public sealed class SwiftCharacter : ISwiftStruct {
+	public sealed class SwiftCharacter : SwiftNativeValueType, ISwiftStruct {
 		public unsafe SwiftCharacter (string character) : this (SwiftNominalCtorArgument.None)
 		{
 			SwiftString swiftString = SwiftString.FromString (character);
@@ -25,19 +25,13 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftCharacter (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
-		public byte [] SwiftData {
-			get;
-			set;
-		}
-
-		public void Dispose ()
+		~SwiftCharacter ()
 		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
+			Dispose (false);
 		}
 
 		[DllImport (SwiftCore.kXamGlue,
@@ -69,11 +63,6 @@ namespace SwiftRuntimeLibrary {
 
 		// Unlike the 3 above, this is unsafe as a SwiftCaracter may contain more than a char
 		//public static explicit operator char (SwiftCharacter character) => throw new NotImplementedException ();
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
-		}
 	}
 }
 

--- a/SwiftRuntimeLibrary/SwiftDate.cs
+++ b/SwiftRuntimeLibrary/SwiftDate.cs
@@ -10,7 +10,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Foundation.Date")]
 	[SwiftStruct (SwiftFoundationConstants.LibSwiftFoundation, SwiftFoundationConstants.SwiftDate_NominalTypeDescriptor, SwiftFoundationConstants.SwiftData_TypeMetadata, "")]
-	public class SwiftDate : ISwiftStruct {
+	public class SwiftDate : SwiftNativeValueType, ISwiftStruct {
 		public static SwiftDate SwiftDate_TimeIntervalSinceReferenceDate (double timeIntervalSinceReferenceDate)
 		{
 			unsafe {
@@ -79,8 +79,8 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftDate (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		public static SwiftMetatype GetSwiftMetatype ()
@@ -88,24 +88,6 @@ namespace SwiftRuntimeLibrary {
 			return NativeMethodsForDDate.PIMetadataAccessor_DDate (SwiftMetadataRequest.Complete);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			if (SwiftData != null) {
-				unsafe {
-					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.NominalDestroy (typeof (SwiftDate),
-						    p);
-					}
-					SwiftData = null;
-				}
-			}
-		}
 		~SwiftDate ()
 		{
 			Dispose (false);
@@ -124,10 +106,6 @@ namespace SwiftRuntimeLibrary {
 					return retval;
 				}
 			}
-		}
-		public byte [] SwiftData {
-			get;
-			set;
 		}
 
 		public static explicit operator NSDate (SwiftDate date)

--- a/SwiftRuntimeLibrary/SwiftDictionary.cs
+++ b/SwiftRuntimeLibrary/SwiftDictionary.cs
@@ -12,9 +12,7 @@ namespace SwiftRuntimeLibrary {
 
 	[SwiftTypeName ("Swift.Dictionary")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftDictionary_NominalTypeDescriptor, "", "")]
-	public class SwiftDictionary<T, U> : IDictionary<T, U>, ISwiftStruct {
-		public byte [] SwiftData { get; set; }
-
+	public class SwiftDictionary<T, U> : SwiftNativeValueType, IDictionary<T, U>, ISwiftStruct {
 		public SwiftDictionary () : this (0) { }
 
 		public SwiftDictionary (int capacity)
@@ -41,10 +39,14 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftDictionary (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
+		~SwiftDictionary ()
+		{
+			Dispose (false);
+		}
 
 		public static SwiftMetatype GetSwiftMetatype ()
 		{
@@ -219,23 +221,6 @@ namespace SwiftRuntimeLibrary {
 		{
 			return GetEnumerator ();
 		}
-
-
-		bool disposed = false;
-		public void Dispose ()
-		{
-			if (!disposed) {
-				disposed = true;
-				Dispose (true);
-				GC.SuppressFinalize (this);
-			}
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
-		}
-
 
 		public U this [T key] {
 			get {

--- a/SwiftRuntimeLibrary/SwiftHasher.cs
+++ b/SwiftRuntimeLibrary/SwiftHasher.cs
@@ -8,7 +8,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Hasher")]
 	[SwiftStruct(SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.Hasher_NominalTypeDescriptor, SwiftCoreConstants.Hasher_Metadata, "")]
-	public class SwiftHasher : ISwiftStruct {
+	public class SwiftHasher : SwiftNativeValueType, ISwiftStruct {
 		public unsafe SwiftHasher ()
 		{
 			fixed (byte * thisDataPtr = StructMarshal.Marshaler.PrepareNominal (this)) {
@@ -18,6 +18,7 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftHasher (SwiftNominalCtorArgument unused)
+			: base ()
 		{
 			StructMarshal.Marshaler.PrepareNominal (this);
 		}
@@ -25,22 +26,6 @@ namespace SwiftRuntimeLibrary {
 		public static SwiftMetatype GetSwiftMetatype ()
 		{
 			return NativeMethodsForSwiftHasher.PIMetadataAccessor_Hasher (SwiftMetadataRequest.Complete);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		unsafe void Dispose (bool disposing)
-		{
-			if (SwiftData != null) {
-				fixed (byte *p = SwiftData) {
-					StructMarshal.Marshaler.NominalDestroy (typeof (SwiftHasher), p);
-				}
-				SwiftData = null;
-			}
 		}
 
 		~SwiftHasher ()
@@ -109,11 +94,6 @@ namespace SwiftRuntimeLibrary {
 					return NativeMethodsForSwiftHasher.PI_hasherFinalize ((IntPtr)thisSwiftDataPtr);
 				}
 			}
-		}
-
-		public byte [] SwiftData {
-			get;
-			set;
 		}
 	}
 

--- a/SwiftRuntimeLibrary/SwiftNativeValueType.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeValueType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using SwiftRuntimeLibrary.SwiftMarshal;
+
+namespace SwiftRuntimeLibrary {
+	public abstract class SwiftNativeValueType : SwiftNativeInstance, ISwiftNominalType {
+		protected SwiftNativeValueType ()
+		{
+			StructMarshal.Marshaler.PrepareNominal (this);
+		}
+
+		bool disposed;
+		protected override void Dispose (bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+			StructMarshal.Marshaler.NominalDestroy (this);
+			SwiftData = null;
+		}
+
+		public byte [] SwiftData { get; set; }
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftOptional.cs
+++ b/SwiftRuntimeLibrary/SwiftOptional.cs
@@ -16,14 +16,16 @@ namespace SwiftRuntimeLibrary {
 
 	[SwiftTypeName ("Swift.Optional")]
 	[SwiftEnumType (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftOptional_NominalTypeDescriptor, "", "")]
-	public class SwiftOptional<T> : ISwiftEnum {
+	public class SwiftOptional<T> : SwiftNativeValueType, ISwiftEnum {
 		internal SwiftOptional (SwiftNominalCtorArgument unused)
+			: base ()
 		{
 		}
 		public SwiftOptional ()
+			: base ()
 		{
 			unsafe {
-				fixed (byte* p = StructMarshal.Marshaler.PrepareNominal (this)) {
+				fixed (byte* p = SwiftData) {
 					NativeMethodsForSwiftOptional.NewNone (new IntPtr (p),
 									       StructMarshal.Marshaler.Metatypeof (typeof (T)));
 				}
@@ -54,22 +56,9 @@ namespace SwiftRuntimeLibrary {
 				 StructMarshal.Marshaler.Metatypeof (typeof (T)));
 		}
 
-		public byte [] SwiftData { get; set; }
-
 		~SwiftOptional ()
 		{
 			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public static SwiftOptional<T> None ()

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -118,6 +118,7 @@
     <Compile Include="BaseAssociatedTypeProxy.cs" />
     <Compile Include="SwiftNativeObject.cs" />
     <Compile Include="SwiftNativeInstance.cs" />
+    <Compile Include="SwiftNativeValueType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftRuntimeLibrary/SwiftSet.cs
+++ b/SwiftRuntimeLibrary/SwiftSet.cs
@@ -8,7 +8,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.Set")]
 	[SwiftStruct(SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftSet_NominalTypeDescriptor, "", "")]
-	public class SwiftSet<T> : ISwiftStruct {
+	public class SwiftSet<T> : SwiftNativeValueType, ISwiftStruct {
 
 		public SwiftSet ()
 			: this ((nint)0)
@@ -27,8 +27,8 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal SwiftSet (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 
@@ -41,23 +41,6 @@ namespace SwiftRuntimeLibrary {
 		~SwiftSet ()
 		{
 			Dispose (false);
-		}
-
-		public byte [] SwiftData { get; set; }
-
-		bool disposed = false;
-		public void Dispose ()
-		{
-			if (!disposed) {
-				disposed = true;
-				Dispose (true);
-				GC.SuppressFinalize (this);
-			}
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public unsafe nint Count {

--- a/SwiftRuntimeLibrary/SwiftString.cs
+++ b/SwiftRuntimeLibrary/SwiftString.cs
@@ -12,10 +12,10 @@ namespace SwiftRuntimeLibrary {
 
 	[SwiftTypeName ("Swift.String")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.SwiftString_NominalTypeDescriptor, SwiftCoreConstants.SwiftString_Metadata, "")]
-	public sealed class SwiftString : ISwiftStruct {
+	public sealed class SwiftString : SwiftNativeValueType, ISwiftStruct {
 		internal SwiftString (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			SwiftData = StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		public unsafe SwiftString (string s) : this (SwiftNominalCtorArgument.None)
@@ -25,22 +25,9 @@ namespace SwiftRuntimeLibrary {
 			}
 		}
 
-		public byte [] SwiftData { get; set; }
-
 		~SwiftString ()
 		{
 			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		// As of the first release of Swift 5.0, using FromUTF16Pointer leaks memory for every string

--- a/SwiftRuntimeLibrary/UnsafeMutablePointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeMutablePointer.cs
@@ -9,7 +9,7 @@ namespace SwiftRuntimeLibrary {
 
 	[SwiftTypeName ("Swift.UnsafeMutablePointer")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.UnsafeMutablePointer_NominalTypeDescriptor, "", "")]
-	public class UnsafeMutablePointer<T> : ISwiftStruct {
+	public class UnsafeMutablePointer<T> : SwiftNativeValueType, ISwiftStruct {
 		internal UnsafeMutablePointer (SwiftNominalCtorArgument unused)
 		{
 		}
@@ -25,8 +25,8 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		UnsafeMutablePointer ()
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		UnsafeMutablePointer(IntPtr p)
@@ -39,22 +39,9 @@ namespace SwiftRuntimeLibrary {
 			}
 		}
 
-		public byte [] SwiftData { get; set; }
-
 		~UnsafeMutablePointer ()
 		{
 			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
 		}
 
 		public static UnsafeMutablePointer<T> Allocate(nint capacity)

--- a/SwiftRuntimeLibrary/UnsafeMutableRawBufferPointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeMutableRawBufferPointer.cs
@@ -10,7 +10,7 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.UnsafeMutableRawBufferPointer")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.UnsafeMutableRawBufferPointer_NominalTypeDescriptor, SwiftCoreConstants.UnsafeMutableRawBufferPointer_Metadata, "")]
-	public class UnsafeMutableRawBufferPointer : ISwiftStruct, IEnumerable<byte> {
+	public class UnsafeMutableRawBufferPointer : SwiftNativeValueType, ISwiftStruct, IEnumerable<byte> {
 
 		public unsafe UnsafeMutableRawBufferPointer (IntPtr start, nint count)
 		{
@@ -23,8 +23,8 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		internal UnsafeMutableRawBufferPointer (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		public unsafe SwiftString DebugDescription {
@@ -66,22 +66,6 @@ namespace SwiftRuntimeLibrary {
 			return NativeMethodsForUnsafeMutableRawBufferPointer.PIMetadataAccessor_UnsafeMutableRawBufferPointer (SwiftMetadataRequest.Complete);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-		void Dispose (bool disposing)
-		{
-			if (SwiftData != null) {
-				unsafe {
-					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.NominalDestroy (typeof (UnsafeRawBufferPointer), p);
-					}
-					SwiftData = null;
-				}
-			}
-		}
 
 		public IEnumerator<byte> GetEnumerator ()
 		{
@@ -99,8 +83,6 @@ namespace SwiftRuntimeLibrary {
 		{
 			Dispose (false);
 		}
-
-		public byte [] SwiftData { get; set; }
 	}
 
 	internal class NativeMethodsForUnsafeMutableRawBufferPointer {

--- a/SwiftRuntimeLibrary/UnsafePointer.cs
+++ b/SwiftRuntimeLibrary/UnsafePointer.cs
@@ -9,14 +9,15 @@ namespace SwiftRuntimeLibrary {
 
 	[SwiftTypeName ("Swift.UnsafePointer")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.UnsafePointer_NominalTypeDescriptor, "", "")]
-	public class UnsafePointer<T> : ISwiftStruct {
+	public class UnsafePointer<T> : SwiftNativeValueType, ISwiftStruct {
 		internal UnsafePointer (SwiftNominalCtorArgument unused)
+			: base ()
 		{
 		}
 
 		UnsafePointer ()
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		UnsafePointer (IntPtr p)
@@ -44,24 +45,10 @@ namespace SwiftRuntimeLibrary {
 		{
 		}
 
-		public byte [] SwiftData { get; set; }
-
 		~UnsafePointer ()
 		{
 			Dispose (false);
 		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			StructMarshal.Marshaler.NominalDestroy (this);
-		}
-
 
 		public IntPtr ToIntPtr ()
 		{

--- a/SwiftRuntimeLibrary/UnsafeRawBufferPointer.cs
+++ b/SwiftRuntimeLibrary/UnsafeRawBufferPointer.cs
@@ -10,21 +10,22 @@ using SwiftRuntimeLibrary.SwiftMarshal;
 namespace SwiftRuntimeLibrary {
 	[SwiftTypeName ("Swift.UnsafeRawBufferPointer")]
 	[SwiftStruct (SwiftCoreConstants.LibSwiftCore, SwiftCoreConstants.UnsafeRawBufferPointer_NominalTypeDescriptor, SwiftCoreConstants.UnsafeRawBufferPointer_Metadata, "")]
-	public class UnsafeRawBufferPointer : ISwiftStruct, IEnumerable<byte> {
+	public class UnsafeRawBufferPointer : SwiftNativeValueType, ISwiftStruct, IEnumerable<byte> {
 
 		public unsafe UnsafeRawBufferPointer (IntPtr start, nint count)
+			: base ()
 		{
 			if (start == IntPtr.Zero)
 				throw new ArgumentNullException (nameof (start));
-			fixed (byte *thisDataPtr = StructMarshal.Marshaler.PrepareNominal (this)) {
+			fixed (byte *thisDataPtr = SwiftData) {
 				IntPtr thisPtr = new IntPtr (thisDataPtr);
 				NativeMethodsForUnsafeRawBufferPointer.PI_UnsafeRawBufferPointer (thisPtr, start, count);
 			}
 		}
 
 		internal UnsafeRawBufferPointer (SwiftNominalCtorArgument unused)
+			: base ()
 		{
-			StructMarshal.Marshaler.PrepareNominal (this);
 		}
 
 		public unsafe SwiftString DebugDescription {
@@ -61,23 +62,6 @@ namespace SwiftRuntimeLibrary {
 			return NativeMethodsForUnsafeRawBufferPointer.PIMetadataAccessor_UnsafeRawBufferPointer (SwiftMetadataRequest.Complete);
 		}
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-		void Dispose (bool disposing)
-		{
-			if (SwiftData != null) {
-				unsafe {
-					fixed (byte* p = SwiftData) {
-						StructMarshal.Marshaler.NominalDestroy (typeof (UnsafeRawBufferPointer), p);
-					}
-					SwiftData = null;
-				}
-			}
-		}
-
 		public IEnumerator<byte> GetEnumerator ()
 		{
 			var count = Count;
@@ -94,8 +78,6 @@ namespace SwiftRuntimeLibrary {
 		{
 			Dispose (false);
 		}
-
-		public byte [] SwiftData { get; set; }
 	}
 
 	internal class NativeMethodsForUnsafeRawBufferPointer {


### PR DESCRIPTION
In this refactoring, I introduce `SwiftNativeValueType` to do the bulk of the implementation of `ISwiftNominalType`.

All existing tests pass.