### PR TITLE
No longer implementing all of ISwiftObject

### DIFF
--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -113,7 +113,8 @@ namespace SwiftReflector {
 				} else {
 					if (isHomonym) {
 						use.AddIfNotPresent (typeof (SwiftObjectRegistry));
-						postMarshalCode.Add (CSReturn.ReturnLine (new CSFunctionCall (cl.Name.Name, true, thisIntPtr, new CSIdentifier ("SwiftObjectRegistry.Registry"))));
+						postMarshalCode.Add (CSReturn.ReturnLine (new CSFunctionCall (cl.Name.Name, true, thisIntPtr,
+							new CSFunctionCall ($"{cl.Name.Name}.GetSwiftMetatype", false), new CSIdentifier ("SwiftObjectRegistry.Registry"))));
 					} else {
 						postMarshalCode.Add (CSReturn.ReturnLine (thisIntPtr));
 					}

--- a/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
+++ b/SwiftRuntimeLibrary/BaseAssociatedTypeProxy.cs
@@ -5,7 +5,7 @@ using System;
 using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
-	[SwiftNativeObject ()]
+	[SwiftNativeObjectTag ()]
 	public class BaseAssociatedTypeProxy : SwiftNativeObject {
 		protected BaseAssociatedTypeProxy (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
 			: base (handle, classHandle, registry)

--- a/SwiftRuntimeLibrary/EveryProtocol.cs
+++ b/SwiftRuntimeLibrary/EveryProtocol.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using SwiftRuntimeLibrary.SwiftMarshal;
 
 namespace SwiftRuntimeLibrary {
-	[SwiftNativeObject]
+	[SwiftNativeObjectTag]
 	public class EveryProtocol : SwiftNativeObject {
 		protected IntPtr handle;
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftNativeObjectAttribute.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftNativeObjectAttribute.cs
@@ -4,12 +4,12 @@
 using System;
 namespace SwiftRuntimeLibrary.SwiftMarshal {
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-	public class SwiftNativeObjectAttribute : Attribute {
+	public class SwiftNativeObjectTagAttribute : Attribute {
 		public static bool IsSwiftNativeObject (object o)
 		{
 			if (o == null)
 				throw new ArgumentNullException (nameof (o));
-			return o.GetType ().GetCustomAttributes (typeof (SwiftNativeObjectAttribute), false).Length > 0;
+			return o.GetType ().GetCustomAttributes (typeof (SwiftNativeObjectTagAttribute), false).Length > 0;
 		}
 	}
 }

--- a/SwiftRuntimeLibrary/SwiftNativeObject.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeObject.cs
@@ -12,7 +12,7 @@ namespace SwiftRuntimeLibrary {
 
 		protected SwiftNativeObject (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)
 		{
-			if (SwiftNativeObjectAttribute.IsSwiftNativeObject (this)) {
+			if (SwiftNativeObjectTagAttribute.IsSwiftNativeObject (this)) {
 				object_flags |= SwiftObjectFlags.IsDirectBinding;
 			}
 			class_handle = classHandle;
@@ -39,6 +39,7 @@ namespace SwiftRuntimeLibrary {
 		protected virtual void DisposeUnmanagedResources ()
 		{
 			SwiftCore.Release (SwiftObject);
+			SwiftObject = IntPtr.Zero;
 		}
 
 		public IntPtr SwiftObject {


### PR DESCRIPTION
Two changes: first did a rename of `SwiftNativeObjectAttribute` to `SwiftNativeObjectTagAttribute`. The reason being that there exists a class `SwiftNativeObject` and code that gets generated often looks like this:
```
[SwiftNativeObject]
public class Foo : SwiftNativeObject {
}
```
and that's confusing. Lesson: naming is hard.

The rest was removing the code that generates `ISwiftObject` requirements. Previously, I had a "standard" constructor with the signature `SomeClass (IntPtr handle, SwiftObjectRegistry registry)`, but it was better to have the signature `protected SomeClass (IntPtr handle, SwiftMetatype classHandle, SwiftObjectRegistry registry)`.
"Hey Steve, since the SwiftObjectRegistry is a singleton, why don't you lost that argument?" Because it's quite possible for a swift constructor to have the signature `SomeClass (IntPtr handle, SwiftMetatype classHandle)` and we don't want to have to deal with that conflict, whereas `SwiftObjectRegistry` should never appear in a Swift signature.