### PR TITLE
updated samples, QUICKSTART

### DIFF
--- a/Pack-Man/FilesToCopy.cake
+++ b/Pack-Man/FilesToCopy.cake
@@ -105,7 +105,7 @@ IEnumerable<(DirectoryPath Src, DirectoryPath Dest)> GetDirectoriesToBundle (Bui
 		dl.Add (GetInfo (bi.XamGlue, $"{glue}/FinalProduct/XamGlue.framework", $"lib/SwiftInterop/{glue}/XamGlue.framework"));
 
 	// Get 'Sample' folders to copy
-	var samples = new [] { "helloswift", "foreach", "piglatin", "propertybag", "sampler" };
+	var samples = new [] { "helloswift", "piglatin", "propertybag", "sampler", "sandwiches" };
 	foreach (var sample in samples)
 		dl.Add (GetInfo (bi.BaseDir, $"samples/{sample}", $"samples/{sample}"));
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -84,7 +84,9 @@ In addition, the tools can operator on separate `.swiftmodule` and `.dylib` file
 ## Building and Running Samples
 Samples source code is in the `samples` directory, but are will not build and run there.
 Instead you need to make a packaged build, from the root of binding-tools-for-swift execute the command:
+
 	`make package`
+	
 this will leave a directory inside of the directory `Pack-Man` named `binding-tools-for-swift` which contains buildable samples.
 Most samples can be built by executing `make` in their directory. To try out a sample, do `make runit` for most of the samples.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -68,7 +68,7 @@ A typical set of commands to generate bindings is:
 
     mono /path/to/tom-swifty.exe --swift-bin-path SWIFT_BIN_PATH --swift-lib-path SWIFT_LIB_PATH -o /path/to/output_directory -C /path/to/YOURLIBRARY.framework -C /path/to/binding-tools-for-swift/swiftglue/bin/Debug/PLATFORM/XamGlue.framework -module-name YOURLIBRARY
 
-In this example `SWIFT_BIN_PATH` and `SWIFT_LIB_PATH` are paths to the Swift reflector build (see above). `YOULIBRARY` is the name of the library you’re trying to bind. `PLATFORM` is one of `appletv`, `iphone`, `mac`, or `watch`.
+In this example `SWIFT_BIN_PATH` and `SWIFT_LIB_PATH` are paths to the Swift reflector build (see above). `YOURLIBRARY` is the name of the library you’re trying to bind. `PLATFORM` is one of `appletv`, `iphone`, `mac`, or `watch`.
 
 If you add the argument `--retain-swift-wrappers`, the binding tools will leave a directory that contains the source to the Swift wrappers written during the compilation. If you add the argument `--retain-xml-reflection`, the binding tools will leaves a directory that contains output of the reflector in XML format.
 
@@ -81,5 +81,10 @@ The binding tools need the following to operate:
 
 In addition, the tools can operator on separate `.swiftmodule` and `.dylib` files. This can be handled by using a `-M` argument for the `.swiftmodule` and `-L` for the library. It’s easier to use the `.framework` directory and a single `-C` argument.
 
-
+## Building and Running Samples
+Samples source code is in the `samples` directory, but are will not build and run there.
+Instead you need to make a packaged build, from the root of binding-tools-for-swift execute the command:
+	`make package`
+this will leave a directory inside of the directory `Pack-Man` named `binding-tools-for-swift` which contains buildable samples.
+Most samples can be built by executing `make` in their directory. To try out a sample, do `make runit` for most of the samples.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -82,7 +82,7 @@ The binding tools need the following to operate:
 In addition, the tools can operator on separate `.swiftmodule` and `.dylib` files. This can be handled by using a `-M` argument for the `.swiftmodule` and `-L` for the library. It’s easier to use the `.framework` directory and a single `-C` argument.
 
 ## Building and Running Samples
-Samples source code is in the `samples` directory, but are will not build and run there.
+Samples source code is in the `samples` directory, but will not build and run there.
 Instead you need to make a packaged build, from the root of binding-tools-for-swift execute the command:
 
 	`make package`

--- a/samples/foreach/Makefile
+++ b/samples/foreach/Makefile
@@ -12,7 +12,8 @@ libForeach.dylib: *.swift *.cs
 	@cp ../../lib/binding-tools-for-swift/SwiftRuntimeLibrary.dll .
 	@cp ../../lib/SwiftInterop/mac/XamGlue.framework/XamGlue .
 	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) *.swift
-	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . $(OUTPUT_MODULE) 
+	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . -module-name $(OUTPUT_MODULE)
+	@xcrun install_name_tool -change "@rpath/XamGlue.framework/XamGlue" XamGlue libXamWrapping.dylib
 	mcs -nowarn:CS0169 -lib:../lib -r:SwiftRuntimeLibrary -lib:. *.cs -out:$(OUTPUT_MODULE).exe
 
 runit:
@@ -20,4 +21,4 @@ runit:
 
 clean:
 	@rm -f *.dylib *.swiftmodule *.swiftdoc *.dll *.exe XamGlue LooperForeach.cs
-	@rm -rf XamWrappingSource x86_64 *.framework XmlReflection
+	@rm -rf XamWrappingSource x86_64 *.framework XmlReflection bindings

--- a/samples/helloswift/Makefile
+++ b/samples/helloswift/Makefile
@@ -11,7 +11,8 @@ libHello.dylib: *.swift *.cs
 	@cp ../../lib/SwiftInterop/SwiftRuntimeLibrary.Mac.dll .
 	@cp ../../lib/SwiftInterop/mac/XamGlue.framework/XamGlue .
 	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) *.swift
-	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . $(OUTPUT_MODULE) 
+	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . -module-name $(OUTPUT_MODULE) 
+	@xcrun install_name_tool -change "@rpath/XamGlue.framework/XamGlue" XamGlue libXamWrapping.dylib
 	mcs -nowarn:CS0169 -lib:../lib -r:SwiftRuntimeLibrary.Mac -lib:. *.cs -out:$(OUTPUT_MODULE).exe
 
 runit:

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -12,7 +12,7 @@ swift:
 	$(MAKE) -C swiftsrc
 
 tomswifty:
-	mono $(TOM_SWIFTY) --retain-swift-wrappers --swift-bin-path $(SWIFT_BIN) --swift-lib-path $(SWIFT_LIB) -o . -C swiftsrc -C $(SWIFT_GLUE) HelloWorld
+	mono $(TOM_SWIFTY) --retain-swift-wrappers --swift-bin-path $(SWIFT_BIN) --swift-lib-path $(SWIFT_LIB) -o . -C swiftsrc -C $(SWIFT_GLUE) -module-name HelloWorld
 
 csharp: *.cs
 	mcs -nowarn:CS0169 -lib:$(TOM_SWIFTY_LIB) -r:SwiftRuntimeLibrary.Mac -lib:swiftsrc *.cs -out:HelloWorld.exe
@@ -20,7 +20,8 @@ clean:
 	$(MAKE) -C swiftsrc clean
 	rm -f TopLevelEntitiesHelloWorld.cs
 	rm -f HelloWorld.exe
+	rm -rf bindings
 
-run:
+runit:
 	LD_LIBRARY_PATH=.:swiftsrc:$(TOM_SWIFTY_LIB):$(SWIFT_GLUE) \
 	mono HelloWorld.exe

--- a/samples/propertybag/Makefile
+++ b/samples/propertybag/Makefile
@@ -15,7 +15,8 @@ libPropertyBag.dylib: *.swift
 	@cp ../../lib/SwiftInterop/mac/XamGlue.framework/XamGlue .
 	@cp ../../lib/binding-tools-for-swift/SwiftRuntimeLibrary.dll .
 	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) *.swift
-	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . $(OUTPUT_MODULE) 
+	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . -module-name $(OUTPUT_MODULE) 
+	@xcrun install_name_tool -change "@rpath/XamGlue.framework/XamGlue" XamGlue libXamWrapping.dylib
 	mcs -nowarn:CS0169 -lib:../lib -r:SwiftRuntimeLibrary -lib:. *.cs -unsafe+ -out:$(OUTPUT_MODULE).exe
 
 runit:
@@ -23,4 +24,4 @@ runit:
 
 clean:
 	@rm -f *.dylib *.swiftmodule *.swiftdoc *.dll *.exe XamGlue PropertyBagProps.cs
-	@rm -rf XamWrappingSource armv7 armv7s arm64 x86_64
+	@rm -rf XamWrappingSource armv7 armv7s arm64 x86_64 bindings

--- a/samples/sandwiches/Makefile
+++ b/samples/sandwiches/Makefile
@@ -1,25 +1,28 @@
 SWIFT_BIN = ../../bin/swift/bin
 SWIFT_LIB = ../../bin/swift/lib/swift/macosx/
 
+
 SWIFTC = $(SWIFT_BIN)/swiftc
 SDK = `xcrun --sdk macosx --show-sdk-path`
 SWIFTARGS = -v -sdk $(SDK) -L $(SWIFT_LIB) -emit-module -emit-library
 
 BINDINGTOOLSFORSWIFT=../../binding-tools-for-swift
 
-OUTPUT_MODULE=Sampler
+OUTPUT_MODULE=Sandwiches
 
-libSampler.dylib: *.swift 
-	@cp ../../lib/binding-tools-for-swift/SwiftRuntimeLibrary.dll .
+libSandwiches.dylib: *.swift 
+	@rm -rf XamWrappingSource armv7 armv7s arm64 x86_64
+	@mkdir XamGlue.framework
 	@cp ../../lib/SwiftInterop/mac/XamGlue.framework/XamGlue .
+	@cp ../../lib/binding-tools-for-swift/SwiftRuntimeLibrary.dll .
 	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) *.swift
 	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers -o . -C . -module-name $(OUTPUT_MODULE) 
 	@xcrun install_name_tool -change "@rpath/XamGlue.framework/XamGlue" XamGlue libXamWrapping.dylib
 	mcs -nowarn:CS0169 -lib:../lib -r:SwiftRuntimeLibrary -lib:. *.cs -unsafe+ -out:$(OUTPUT_MODULE).exe
 
 runit:
-	@LD_LIBRARY_PATH=$(SWIFT_LIB) mono --arch=64 $(OUTPUT_MODULE).exe
+	@DYLD_LIBRARY_PATH=$(SWIFT_LIB):$(SWIFT_GLUE):. mono --arch=64 $(OUTPUT_MODULE).exe
 
 clean:
-	@rm -f *.dylib *.swiftmodule *.swiftdoc *.dll *.exe XamGlue AFinalClassSampler.cs NumberSampler.cs
-	@rm -rf XamWrappingSource x86_64 bindings
+	@rm -f *.dylib *.swiftmodule *.swiftdoc *.dll *.exe TopLevelEntities.cs IBreadSandwiches.cs IFillingSandwiches.cs HamSandwiches.cs RyeSandwiches.cs XamGlue
+	@rm -rf XamWrappingSource armv7 armv7s arm64 x86_64 bindings

--- a/samples/sandwiches/SandwichesMain.cs
+++ b/samples/sandwiches/SandwichesMain.cs
@@ -1,0 +1,28 @@
+
+using System;
+using System.IO;
+using SwiftRuntimeLibrary;
+using SwiftRuntimeLibrary.SwiftMarshal;
+using System.Runtime.InteropServices;
+using Sandwiches;
+
+namespace SandwichesCSharp
+{
+
+    public class WholeWheat : IBread {
+	public SwiftString Name => (SwiftString)"whole wheat";
+	public bool Sliced => true;
+    }
+
+    public class SharpCheddar : IFilling {
+        public SwiftString Stuff => (SwiftString)"sharp cheddar";
+    }
+
+    public class SandwichesMain
+    {
+        public static void Main(string[] args)
+        {
+		TopLevelEntities.PrintSandwich (new WholeWheat (), new SharpCheddar ());
+        }
+    }
+}

--- a/samples/sandwiches/sandwiches.swift
+++ b/samples/sandwiches/sandwiches.swift
@@ -1,0 +1,30 @@
+
+public protocol Filling {
+    var stuff: String { get }
+}
+
+public protocol Bread {
+    var name: String { get }
+    var sliced: Bool { get }
+}
+
+public struct Rye : Bread {
+    public init () { }
+    public var name:String {
+        get { return "rye" }
+    }
+    public var sliced:Bool {
+        get { return true }
+    }
+}
+
+public struct Ham : Filling {
+    public init () { }
+    public var stuff: String {
+        get { return "ham" }
+    }
+}
+
+public func printSandwich (of: Bread, with: Filling) {
+    print ("\(with.stuff) on \(of.name)")
+}


### PR DESCRIPTION
Addressing issue [444](https://github.com/xamarin/binding-tools-for-swift/issues/444)
Changed:
Added the sample `sandwiches` because who doesn't like a good sandwich?
Removed `foreach` sample which was crashing on run (issue [here](https://github.com/xamarin/binding-tools-for-swift/issues/445))
fixed a typo in `QUICKSTART.md `
added a section on building and running samples
Fixed broken makefiles