### PR TITLE
Handle difference between static and instance properties with the same name

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -389,7 +389,7 @@ namespace SwiftReflector {
 			string piSetterRef = null;
 			string syntheticClassName = prop.Module.Name + "." + CompilerNames.GlobalFunctionClassName;
 
-			string getWrapperName = MethodWrapping.WrapperName (prop.Module.Name, prop.Name, PropertyType.Getter, false, prop.IsExtension);
+			string getWrapperName = MethodWrapping.WrapperName (prop.Module.Name, prop.Name, PropertyType.Getter, false, prop.IsExtension, prop.IsStatic);
 			getterWrapper = FindTLPropWrapper (prop, getWrapperName, wrapper);
 			var getterWrapperFunc = FindEquivalentFunctionDeclarationForWrapperFunction (getterWrapper, TypeMapper, wrapper);
 
@@ -405,7 +405,7 @@ namespace SwiftReflector {
 
 			if (!prop.IsLet && (prop.Storage != StorageKind.Computed ||
 			                    (prop.Storage == StorageKind.Computed && setter != null))) {
-				string setWrapperName = MethodWrapping.WrapperName (prop.Module.Name, prop.Name, PropertyType.Setter, false, prop.IsExtension);
+				string setWrapperName = MethodWrapping.WrapperName (prop.Module.Name, prop.Name, PropertyType.Setter, false, prop.IsExtension, prop.IsStatic);
 				setterWrapper = FindTLPropWrapper (prop, setWrapperName, wrapper);
 				setterWrapperFunc = FindEquivalentFunctionDeclarationForWrapperFunction (setterWrapper, TypeMapper, wrapper);
 				
@@ -1146,9 +1146,9 @@ namespace SwiftReflector {
 			var parentName = PrefixInsertedBeforeName (superFunc.Parent, superFunc.IsProperty, namePrefix);
 			if (superFunc.IsProperty) {
 				wrapperName = MethodWrapping.WrapperName (parentName,
-					superFunc.PropertyName, superFunc.IsGetter ? PropertyType.Getter : PropertyType.Setter, superFunc.IsSubscript, false);
+					superFunc.PropertyName, superFunc.IsGetter ? PropertyType.Getter : PropertyType.Setter, superFunc.IsSubscript, false, superFunc.IsStatic);
 			} else {
-				wrapperName = MethodWrapping.WrapperName (parentName, superFunc.Name, false);
+				wrapperName = MethodWrapping.WrapperName (parentName, superFunc.Name, false, superFunc.IsStatic);
 			}
 			var referenceCode = wrapper.FunctionReferenceCodeMap.ReferenceCodeFor (superFunc);
 			if (referenceCode != null) {
@@ -5127,9 +5127,10 @@ namespace SwiftReflector {
 			if (funcDeclToWrap.IsProperty) {
 				wrapperName = MethodWrapping.WrapperName (extensionOn.ToFullyQualifiedName (true), funcDeclToWrap.PropertyName,
 									  (funcDeclToWrap.IsGetter ? PropertyType.Getter :
-				                                           (funcDeclToWrap.IsSetter ? PropertyType.Setter : PropertyType.Materializer)), false, funcDeclToWrap.IsExtension);
+				                                           (funcDeclToWrap.IsSetter ? PropertyType.Setter : PropertyType.Materializer)), false, funcDeclToWrap.IsExtension,
+									  funcDeclToWrap.IsStatic);
 			} else {
-				wrapperName = MethodWrapping.WrapperName (extensionOn.ToFullyQualifiedName (false), funcDeclToWrap.Name, true);
+				wrapperName = MethodWrapping.WrapperName (extensionOn.ToFullyQualifiedName (false), funcDeclToWrap.Name, true, funcDeclToWrap.IsStatic);
 			}
 			return FindWrapperForMethod (funcDeclToWrap, funcToWrap, wrapperName, wrapper);
 
@@ -5165,7 +5166,7 @@ namespace SwiftReflector {
 			var prop = methodToWrap.Signature as SwiftPropertyType;
 			if (prop == null)
 				throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 34, $"Expected a SwiftPropertyType for method signature, but got {methodToWrap.Signature.GetType ().Name}");
-			var wrapperName = MethodWrapping.WrapperName (methodToWrap.Class.ClassName, methodToWrap.Name.Name, propType, prop.IsSubscript, funcToWrap.IsExtension);
+			var wrapperName = MethodWrapping.WrapperName (methodToWrap.Class.ClassName, methodToWrap.Name.Name, propType, prop.IsSubscript, funcToWrap.IsExtension, prop.IsStatic);
 			return FindWrapperForMethod (funcToWrap, methodToWrap, wrapperName, wrapper);
 		}
 
@@ -5173,7 +5174,7 @@ namespace SwiftReflector {
 		TLFunction FindWrapperForMethod (FunctionDeclaration funcToWrap, TLFunction methodToWrap, WrappingResult wrapper)
 		{
 			string wrapperName = methodToWrap.Operator == OperatorType.None ?
-							 MethodWrapping.WrapperName (methodToWrap.Class.ClassName, methodToWrap.Name.Name, funcToWrap.IsExtension) :
+							 MethodWrapping.WrapperName (methodToWrap.Class.ClassName, methodToWrap.Name.Name, funcToWrap.IsExtension, funcToWrap.IsStatic) :
 			                                 MethodWrapping.WrapperOperatorName (TypeMapper, funcToWrap.Parent.ToFullyQualifiedName (true), methodToWrap.Name.Name, funcToWrap.OperatorType);
 			return FindWrapperForMethod (funcToWrap, methodToWrap, wrapperName, wrapper);
 		}

--- a/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
@@ -65,6 +65,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		{
 			var funcs = GetFunctionsToSearch ();
 			return funcs.FirstOrDefault (f => f.IsProperty &&
+				f.IsStatic == IsStatic &&
 				f.Name.StartsWith (prefix, StringComparison.Ordinal) &&
 				(f.Name.Length == prefix.Length + Name.Length) &&
 				string.CompareOrdinal (f.Name, prefix.Length, Name, 0, Name.Length) == 0);

--- a/tests/tom-swifty-test/SwiftReflector/HomonymTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/HomonymTests.cs
@@ -167,5 +167,27 @@ namespace SwiftReflector {
 			var callingCode = CSCodeBlock.Create (printIt);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "success\n");
 		}
+
+		[Test]
+		public void TestPropNameConflict ()
+		{
+			var swiftCode = @"
+public class PropConflict {
+	public init () { }
+	public static var X:Int = 3
+	public var X:Float = 4.0
+}
+";
+			var classNameId = new CSIdentifier ("PropConflict");
+			var propVarId = new CSIdentifier ("X");
+			var propVarConflictId = new CSIdentifier ("X0");
+			var propId = new CSIdentifier ("p");
+			var propDecl = CSVariableDeclaration.VarLine (propId, new CSFunctionCall ("PropConflict", true));
+			var printer1 = CSFunctionCall.ConsoleWriteLine (propId.Dot (propVarConflictId));
+			var printer2 = CSFunctionCall.ConsoleWriteLine (classNameId.Dot (propVarId));
+			var callingCode = CSCodeBlock.Create (propDecl, printer1, printer2);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "4\n3\n");
+		}
 	}
 }


### PR DESCRIPTION
Addresses issue [155](https://github.com/xamarin/binding-tools-for-swift/issues/155)

I want to say up front that the problems here were totally **not** where I expected them to be.

Here's the setting. This is legal in swift:
```
public class Foo {
    public init () { }
    public static var X: Int = 3
    public var X: Float = 4.0
}
```

You can't have properties that are the same staticicity with the same name, but if one is static and the other is not, why yes, that's just fine thank you.

I fully expected this to break in the C# code. Reader, it did not.

There were two issues in that the wrapper name for static and non-static properties conflicted and the second was that the methods `GetGetter` and `GetSetter` weren't matching on staticicity.

Step 1 was to refactor all the flavors of `WrapperName` to understand when a function or property is static and it changes the caps of various things. Note that I don't change the marker for extensions because they're always effectively static anyway.

Step 2 was to change `SearchForPropertyAccessor` to do the right thing with regards to statics.

And much to my delight, the C# code works out of the box because I apparently already had code to disambiguate duplicate property names. Hooray!
