### PR TITLE
Support added for property thunks

### DIFF
--- a/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
+++ b/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
@@ -101,6 +101,12 @@ namespace SwiftReflector.Demangling {
 
 				},
 				new MatchRule {
+					Name = "DispatchThunk",
+					NodeKind = NodeKind.DispatchThunk,
+					Reducer = ConvertToThunk,
+					ChildRules = new List<MatchRule> () { }
+				},
+				new MatchRule {
 					Name = "DynamicSelf",
 		    			NodeKind = NodeKind.DynamicSelf,
 					Reducer = ConvertFirstChildToSwiftType
@@ -772,6 +778,7 @@ namespace SwiftReflector.Demangling {
 			case NodeKind.MaterializeForSet:
 			case NodeKind.WillSet:
 			case NodeKind.ModifyAccessor:
+			case NodeKind.DispatchThunk:
 				return ConvertFunctionProp (node);
 			case NodeKind.Variable:
 				return ConvertVariable (node, false);
@@ -1549,6 +1556,15 @@ namespace SwiftReflector.Demangling {
 		SwiftType ConvertToSubscriptModifier (Node node, bool isReference, SwiftName name)
 		{
 			return ConvertToSubscriptEtter (node.Children [0], isReference, name, PropertyType.ModifyAccessor);
+		}
+
+		SwiftType ConvertToThunk (Node node, bool isReference, SwiftName name)
+		{
+			var thunkType = ConvertFirstChildToSwiftType (node, isReference, name);
+			if (thunkType == null)
+				return null;
+			var propThunk = thunkType as SwiftPropertyType;
+			return propThunk.AsSwiftPropertyThunkType ();
 		}
 
 		SwiftType ConvertToTupleElement (Node node, bool isReference, SwiftName name)

--- a/SwiftReflector/Inventory/PropertyContents.cs
+++ b/SwiftReflector/Inventory/PropertyContents.cs
@@ -50,32 +50,54 @@ namespace SwiftReflector.Inventory {
 			} else {
 				switch (prop.PropertyType) {
 				case PropertyType.Getter:
-					Getter = prop;
-					TLFGetter = tlf;
+					var oldget = Getter;
+					Getter = ConditionalChainThunk (prop, oldget);
+					TLFGetter = oldget == null || Getter != prop ? tlf : TLFGetter;
 					break;
 				case PropertyType.Setter:
-					Setter = prop;
-					TLFSetter = tlf;
+					var oldset = Setter;
+					Setter = ConditionalChainThunk (prop, oldset);
+					TLFSetter = oldset == null || Setter != prop ? tlf : TLFSetter;
 					break;
 				case PropertyType.Materializer:
-					Materializer = prop;
-					TLFMaterializer = tlf;
+					var oldmaterialize = Materializer;
+					Materializer = ConditionalChainThunk (prop, oldmaterialize);
+					TLFMaterializer = oldmaterialize == null || Materializer != prop ? tlf : TLFMaterializer;
 					break;
 				case PropertyType.DidSet:
-					DidSet = prop;
-					TLFDidSet = tlf;
+					var olddidset = DidSet;
+					DidSet = ConditionalChainThunk (prop, olddidset);
+					TLFDidSet = olddidset == null || DidSet != prop ? tlf : TLFDidSet;
 					break;
 				case PropertyType.WillSet:
-					WillSet = prop;
-					TLFWillSet = tlf;
+					var oldwillset = WillSet;
+					WillSet = ConditionalChainThunk (prop, oldwillset);
+					TLFWillSet = oldwillset == null || WillSet != prop ? tlf : TLFWillSet;
 					break;
 				case PropertyType.ModifyAccessor:
-					ModifyAccessor = prop;
-					TLFModifyAccessor = tlf;
+					var oldmodify = WillSet;
+					ModifyAccessor = ConditionalChainThunk (prop, oldmodify);
+					TLFModifyAccessor = oldmodify == null || ModifyAccessor != prop ? tlf : TLFModifyAccessor;
 					break;
 				default:
 					throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 2, $"Unexpected property element {prop.PropertyType.ToString ()}");
 				}
+			}
+		}
+
+		static SwiftPropertyType ConditionalChainThunk (SwiftPropertyType newProp, SwiftPropertyType oldProp)
+		{
+			if (oldProp == null) {
+				return newProp;
+			}
+			if (oldProp is SwiftPropertyThunkType oldthunk) {
+				newProp.Thunk = oldthunk;
+				return newProp;
+			} else if (newProp is SwiftPropertyThunkType newthunk) {
+				oldProp.Thunk = newthunk;
+				return oldProp;
+			} else {
+				throw new NotImplementedException ("At least one needs to be a thunk - should never happen");
 			}
 		}
 

--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -454,6 +454,8 @@ namespace SwiftReflector {
 		public bool IsPrivate { get { return PrivateName != null; } }
 		public bool IsGlobal { get { return UncurriedParameter == null; }}
 
+		public SwiftPropertyThunkType Thunk { get; set; }
+
 		public SwiftPropertyType RecastAsStatic()
 		{
 			if (IsStatic)
@@ -468,6 +470,35 @@ namespace SwiftReflector {
 			newProp.DiscretionaryString = DiscretionaryString;
 			newProp.ExtensionOn = this.ExtensionOn;
 			return newProp;
+		}
+
+		public SwiftPropertyThunkType AsSwiftPropertyThunkType ()
+		{
+			if (IsSubscript) {
+				var pt = new SwiftPropertyThunkType (UncurriedParameter, PropertyType, Name,
+					PrivateName, OfType as SwiftFunctionType, IsStatic, IsReference, ExtensionOn);
+				pt.DiscretionaryString = DiscretionaryString;
+				return pt;
+			} else {
+				var pt = new SwiftPropertyThunkType (UncurriedParameter, PropertyType, Name,
+					PrivateName, OfType, IsStatic, IsReference, ExtensionOn);
+				pt.DiscretionaryString = DiscretionaryString;
+				return pt;
+			}
+		}
+	}
+
+	public class SwiftPropertyThunkType : SwiftPropertyType {
+		public SwiftPropertyThunkType (SwiftType unCurriedParameter, PropertyType propType, SwiftName propName,
+					  SwiftName privateName, SwiftType ofType, bool isStatic, bool isReference, SwiftType extensionOn = null)
+			: base (unCurriedParameter, propType, propName, privateName, ofType, isStatic, isReference, extensionOn)
+		{
+		}
+
+		public SwiftPropertyThunkType (SwiftType unCurriedParameter, PropertyType propType, SwiftName propName,
+			  SwiftName privateName, SwiftFunctionType accessor, bool isStatic, bool isReference, SwiftType extensionOn = null)
+			: base (unCurriedParameter, propType, propName, privateName, accessor, isStatic, isReference, extensionOn)
+		{
 		}
 	}
 

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1729,5 +1729,18 @@ namespace SwiftReflector.Demangling {
 			Assert.IsNotNull (pd, "not a property descriptor");
 			Assert.AreEqual ("val", pd.Name.Name, "name mismatch");
 		}
+
+		[Test]
+		public void TestPropertyThunk ()
+		{
+			var tld = Decomposer.Decompose ("_$s7CanFind3BarC1xSbvgTj", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLFunction;
+			Assert.IsNotNull (tlf, "null function");
+			var getter = tlf.Signature as SwiftPropertyThunkType;
+			Assert.IsNotNull (getter, "not a property");
+			Assert.AreEqual (PropertyType.Getter, getter.PropertyType, "not a getter");
+			Assert.AreEqual ("x", getter.Name.Name, "wrong name");
+		}
 	}
 }


### PR DESCRIPTION
This PR addresses issue [460](https://github.com/xamarin/binding-tools-for-swift/issues/460).

In order to do this, I put in a new reducer for a `DispatchThunk`.
A DispatchThunk looks like this in demangling tree:
```
kind=Global
  kind=DispatchThunk
    kind=Getter
      kind=Variable
        kind=Class
          kind=Module, text="CanFind"
          kind=Identifier, text="Bar"
        kind=Identifier, text="x"
        kind=Type
          kind=Structure
            kind=Module, text="Swift"
            kind=Identifier, text="Bool"
```
So a `DispatchThunk` is conveniently identical to a property.
Made a subclass of `SwiftPropertyType` which can be chained onto an existing one. The idea is that it can operate as a `SwiftPropertyType` and if there is ever a public non-thunk version of this, we will favor the public non-thunk, but keep the thunk version around. This ought to future proof us.