### PR TITLE
static function thunks

### DIFF
--- a/SwiftReflector/Inventory/ClassContents.cs
+++ b/SwiftReflector/Inventory/ClassContents.cs
@@ -75,7 +75,22 @@ namespace SwiftReflector.Inventory {
 		    			else
 						Methods.Add (tlf, srcStm);
 				} else if (IsStaticMethod (tlf.Signature, tlf.Class)) {
-					StaticFunctions.Add (tlf, srcStm);
+					var oldTLF = StaticFunctions.ContainsEquivalentFunction (tlf);
+					if (oldTLF == null)
+						StaticFunctions.Add (tlf, srcStm);
+					else {
+						var newSig = tlf.Signature as SwiftStaticFunctionType;
+						var oldSig = oldTLF.Signature as SwiftStaticFunctionType;
+						// if the old sig is the thunk, chain it into the new and
+						// replace the old with the new.
+						// Else chain the new (thunk) into the old.
+						if (oldSig is SwiftStaticFunctionThunkType thunk) {
+							newSig.Thunk = thunk;
+							StaticFunctions.ReplaceFunction (oldTLF, tlf);
+						} else {
+							oldSig.Thunk = newSig as SwiftStaticFunctionThunkType;
+						}
+					}
 				} else if (IsWitnessTable (tlf.Signature, tlf.Class)) {
 					WitnessTable.Add (tlf, srcStm);
 				} else if (IsInitializer (tlf.Signature, tlf.Class)) {

--- a/SwiftReflector/SwiftType.cs
+++ b/SwiftReflector/SwiftType.cs
@@ -363,6 +363,21 @@ namespace SwiftReflector {
 		}
 
 		public SwiftClassType OfClass { get; private set; }
+		public SwiftStaticFunctionThunkType Thunk { get; set; }
+
+		public SwiftStaticFunctionThunkType AsSwiftStaticFunctionThunkType ()
+		{
+			var func = new SwiftStaticFunctionThunkType (Parameters, ReturnType, IsReference, CanThrow, OfClass, Name, ExtensionOn);
+			func.DiscretionaryString = DiscretionaryString;
+			return func;
+		}
+	}
+
+	public class SwiftStaticFunctionThunkType : SwiftStaticFunctionType {
+		public SwiftStaticFunctionThunkType (SwiftType parms, SwiftType ret, bool isReference, bool canThrow, SwiftClassType ofClass, SwiftName name = null, SwiftType extensionOn = null)
+			: base (parms, ret, isReference, canThrow, ofClass, name, extensionOn)
+		{
+		}
 	}
 
 
@@ -462,10 +477,21 @@ namespace SwiftReflector {
 				return this;
 			SwiftPropertyType newProp = null;
 			if (OfType is SwiftFunctionType) {
-				newProp = new SwiftPropertyType (UncurriedParameter, PropertyType, Name, PrivateName, OfType as SwiftFunctionType,
-							      true, IsReference);
+				if (this is SwiftPropertyThunkType) {
+					newProp = new SwiftPropertyThunkType (UncurriedParameter, PropertyType, Name, PrivateName, OfType as SwiftFunctionType,
+			      true, IsReference);
+
+				} else {
+					newProp = new SwiftPropertyType (UncurriedParameter, PropertyType, Name, PrivateName, OfType as SwiftFunctionType,
+								      true, IsReference);
+				}
 			} else {
-				newProp = new SwiftPropertyType (UncurriedParameter, PropertyType, Name, PrivateName, OfType, true, IsReference);
+				if (this is SwiftPropertyThunkType) {
+					newProp = new SwiftPropertyThunkType (UncurriedParameter, PropertyType, Name, PrivateName, OfType, true, IsReference);
+
+				} else {
+					newProp = new SwiftPropertyType (UncurriedParameter, PropertyType, Name, PrivateName, OfType, true, IsReference);
+				}
 			}
 			newProp.DiscretionaryString = DiscretionaryString;
 			newProp.ExtensionOn = this.ExtensionOn;

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1742,5 +1742,21 @@ namespace SwiftReflector.Demangling {
 			Assert.AreEqual (PropertyType.Getter, getter.PropertyType, "not a getter");
 			Assert.AreEqual ("x", getter.Name.Name, "wrong name");
 		}
+
+		[Test]
+		public void TestStaticFuncThunk ()
+		{
+			var tld = Decomposer.Decompose ("_$s21NewClassCompilerTests06Publicb4OpenB15MethodBoolFalseC5thingSbyFZTj", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLFunction;
+			Assert.IsNotNull (tlf, "null function");
+			var func = tlf.Signature as SwiftStaticFunctionThunkType;
+			Assert.IsNotNull (func, "not a static thunk func");
+			Assert.AreEqual ("thing", func.Name.Name, "wrong name");
+			Assert.AreEqual (0, func.ParameterCount, "wrong parameter count");
+			var ret = func.ReturnType as SwiftBuiltInType;
+			Assert.IsNotNull (ret, "wrong return type");
+			Assert.AreEqual (CoreBuiltInType.Bool, ret.BuiltInType, "not a bool");
+		}
 	}
 }


### PR DESCRIPTION
This addresses static function dispatch thunks in the same way as for properties, fixing issue [462](https://github.com/xamarin/binding-tools-for-swift/issues/462)

I renamed `ConvertToThunk` -> `ConvertToDispatchThunk` to be more clear.
I gave `ConvertDispatchThunk` its own method since it's too complicated to be in a switch
Dispatch thunks for variables are intentionally left out until I encounter them.

This fixes a third of the failing tests in `NewClassCompilerTests.cs`