### PR TITLE
Thunk all the things!

### DIFF
--- a/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
+++ b/SwiftReflector/Demangling/Swift5NodeToTLDefinition.cs
@@ -9,11 +9,11 @@ using SwiftRuntimeLibrary;
 namespace SwiftReflector.Demangling {
 	public class Swift5NodeToTLDefinition {
 		static List<NodeKind> nominalNodeKinds = new List<NodeKind> {
-			NodeKind.Class, NodeKind.Enum, NodeKind.Structure
+			NodeKind.Class, NodeKind.Enum, NodeKind.Structure, NodeKind.Protocol
 		};
 
 		static List<NodeKind> nominalNodeAndModuleKinds = new List<NodeKind> {
-			NodeKind.Class, NodeKind.Enum, NodeKind.Structure, NodeKind.Module
+			NodeKind.Class, NodeKind.Enum, NodeKind.Structure, NodeKind.Protocol, NodeKind.Module
 		};
 
 		static List<NodeKind> identifierOrOperatorOrPrivateDecl = new List<NodeKind> {
@@ -847,6 +847,8 @@ namespace SwiftReflector.Demangling {
 				return ConvertFunctionProp (node);
 			case NodeKind.Static:
 				return ConvertStaticDispatchThunk (node);
+			case NodeKind.Function:
+				return ConvertFunction (node, false);
 			default:
 				return null;
 			}
@@ -1598,11 +1600,8 @@ namespace SwiftReflector.Demangling {
 			var thunkType = ConvertFirstChildToSwiftType (node, isReference, name);
 			if (thunkType == null)
 				return null;
-			if (thunkType is SwiftPropertyType propThunk)
-				return propThunk.AsSwiftPropertyThunkType ();
-			if (thunkType is SwiftStaticFunctionType staticFunc) {
-				return staticFunc.AsSwiftStaticFunctionThunkType ();
-			}
+			if (thunkType is SwiftBaseFunctionType funcType)
+				return funcType.AsThunk ();
 			return null;
 		}
 

--- a/SwiftReflector/Inventory/ClassContents.cs
+++ b/SwiftReflector/Inventory/ClassContents.cs
@@ -42,14 +42,14 @@ namespace SwiftReflector.Inventory {
 			TLFunction tlf = tld as TLFunction;
 			if (tlf != null) {
 				if (IsConstructor (tlf.Signature, tlf.Class)) {
-					Constructors.Add (tlf, srcStm);
+					AddOrChainInNewThunk (Constructors, tlf, srcStm);
 				} else if (tlf.Signature is SwiftClassConstructorType) {
 					if (ClassConstructor.Values.Count () == 0)
-						ClassConstructor.Add (tlf, srcStm);
+						AddOrChainInNewThunk (ClassConstructor, tlf, srcStm);
 					else
 						throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 12, $"multiple type metadata accessors for {tlf.Class.ClassName.ToFullyQualifiedName ()}");
 				} else if (IsDestructor (tlf.Signature, tlf.Class)) {
-					Destructors.Add (tlf, srcStm);
+					AddOrChainInNewThunk (Destructors, tlf, srcStm);
 				} else if (IsProperty (tlf.Signature, tlf.Class)) {
 					if (IsSubscript (tlf.Signature, tlf.Class)) {
 						if (IsPrivateProperty (tlf.Signature, tlf.Class))
@@ -72,29 +72,15 @@ namespace SwiftReflector.Inventory {
 				} else if (IsMethodOnClass (tlf.Signature, tlf.Class)) {
 					if (tlf is TLMethodDescriptor)
 						MethodDescriptors.Add (tlf, srcStm);
-		    			else
-						Methods.Add (tlf, srcStm);
-				} else if (IsStaticMethod (tlf.Signature, tlf.Class)) {
-					var oldTLF = StaticFunctions.ContainsEquivalentFunction (tlf);
-					if (oldTLF == null)
-						StaticFunctions.Add (tlf, srcStm);
 					else {
-						var newSig = tlf.Signature as SwiftStaticFunctionType;
-						var oldSig = oldTLF.Signature as SwiftStaticFunctionType;
-						// if the old sig is the thunk, chain it into the new and
-						// replace the old with the new.
-						// Else chain the new (thunk) into the old.
-						if (oldSig is SwiftStaticFunctionThunkType thunk) {
-							newSig.Thunk = thunk;
-							StaticFunctions.ReplaceFunction (oldTLF, tlf);
-						} else {
-							oldSig.Thunk = newSig as SwiftStaticFunctionThunkType;
-						}
+						AddOrChainInNewThunk (Methods, tlf, srcStm);
 					}
+				} else if (IsStaticMethod (tlf.Signature, tlf.Class)) {
+					AddOrChainInNewThunk (StaticFunctions, tlf, srcStm);
 				} else if (IsWitnessTable (tlf.Signature, tlf.Class)) {
 					WitnessTable.Add (tlf, srcStm);
 				} else if (IsInitializer (tlf.Signature, tlf.Class)) {
-					Initializers.Add (tlf, srcStm);
+					AddOrChainInNewThunk (Initializers, tlf, srcStm);
 				} else {
 					FunctionsOfUnknownDestination.Add (tlf);
 				}
@@ -144,6 +130,23 @@ namespace SwiftReflector.Inventory {
 				return;
 			}
 			DefinitionsOfUnknownDestination.Add (tld);
+		}
+
+		static void AddOrChainInNewThunk (FunctionInventory inventory, TLFunction newTLF, Stream sourceStream)
+		{
+			var oldTLF = inventory.ContainsEquivalentFunction (newTLF);
+			if (oldTLF == null)
+				inventory.Add (newTLF, sourceStream);
+			else {
+				var newSig = newTLF.Signature;
+				var oldSig = oldTLF.Signature;
+				if (oldSig.IsThunk) {
+					newSig.Thunk = oldSig;
+					inventory.ReplaceFunction (oldTLF, newTLF);
+				} else {
+					oldSig.Thunk = newSig;
+				}
+			}
 		}
 
 		public bool IsFinal (TLFunction func)

--- a/SwiftReflector/Inventory/PropertyContents.cs
+++ b/SwiftReflector/Inventory/PropertyContents.cs
@@ -90,11 +90,11 @@ namespace SwiftReflector.Inventory {
 			if (oldProp == null) {
 				return newProp;
 			}
-			if (oldProp is SwiftPropertyThunkType oldthunk) {
-				newProp.Thunk = oldthunk;
+			if (oldProp.IsThunk) {
+				newProp.Thunk = oldProp;
 				return newProp;
-			} else if (newProp is SwiftPropertyThunkType newthunk) {
-				oldProp.Thunk = newthunk;
+			} else if (newProp.IsThunk) {
+				oldProp.Thunk = newProp;
 				return oldProp;
 			} else {
 				throw new NotImplementedException ("At least one needs to be a thunk - should never happen");


### PR DESCRIPTION
This PR fixes issue [468](https://github.com/xamarin/binding-tools-for-swift/issues/468) where most function dispatch thunks were being ignored.

This PR involves a big refactoring of the `SwiftBaseFunctionType` sub hierarchy to clean everything up. Well, at least as much as typical OO code will allow.

Every function type can (potentially) have a thunk associated with it, so I hoisted this notion into the thunk base class by adding an `IsThunk` property as well as an abstract `AsThunk` method which returns the thunk equivalent of the type. This would actually be a great place to use dynamic self if we had that in C#. I also briefly considered making the call be generic `T AsThunk<T>()` but decided that that doesn't really give us much in context.

The end result is that the handling of dispatch thunks in the demangler is much cleaner as is thunks in function handling.
