### PR TITLE
Make constructor wrapping mandatory.

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -542,6 +542,8 @@ namespace SwiftReflector {
 				return true;
 			if (fn.IsExtension)
 				return true;
+			if (fn.IsConstructor)
+				return true;
 			var tlf = XmlToTLFunctionMapper.ToTLFunction (fn, modInventory, typeMapper);
 			if (tlf == null) {
 				throw ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 1, $"Unable to find function for declaration of {fn.ToFullyQualifiedName ()}.");
@@ -561,6 +563,8 @@ namespace SwiftReflector {
 			if (fn.IsOperator)
 				return true;
 			if (fn.IsExtension)
+				return true;
+			if (fn.IsConstructor)
 				return true;
 			bool hasReturn = fn.ReturnTypeSpec != null && !fn.ReturnTypeSpec.IsEmptyTuple;
 			bool returnNeedsWrapping = false;
@@ -1216,17 +1220,15 @@ namespace SwiftReflector {
 						continue;
 					if (BoundClosureError (funcDecl, cl, "wrapping an overrider constructor in a class"))
 						continue;
-					if (FuncNeedsWrapping (funcDecl, typeMapper)) {
-						SLFunc func = null;
-						try {
-							func = MapFuncDeclToWrapperFunc (swiftClassName, modules, funcDecl);
-						} catch (Exception e) {
-							SkipWithWarning (funcDecl, cl, "wrapping an overrider constructor in a class", e);
-							continue;
-						}
-						funcs.Add (func);
-						AddFunctionToOverallList (externalCl, func.Name.Name);
+					SLFunc func = null;
+					try {
+						func = MapFuncDeclToWrapperFunc (swiftClassName, modules, funcDecl);
+					} catch (Exception e) {
+						SkipWithWarning (funcDecl, cl, "wrapping an overrider constructor in a class", e);
+						continue;
 					}
+					funcs.Add (func);
+					AddFunctionToOverallList (externalCl, func.Name.Name);
 				}
 
 				foreach (FunctionDeclaration funcDecl in externalCl.AllMethodsNoCDTor ().Where (fd => fd.Access == Accessibility.Internal
@@ -1295,19 +1297,17 @@ namespace SwiftReflector {
 				foreach (FunctionDeclaration funcDecl in cl.AllConstructors ().Where (fd => fd.Access == Accessibility.Public)) {
 					if (ShouldSkipDeprecated (funcDecl, "Constructor"))
 						continue;
-					if (FuncNeedsWrapping (funcDecl, typeMapper)) {
-						if (BoundClosureError (funcDecl, cl, "wrapping a constructor in a class"))
-							continue;
-						SLFunc func = null;
-						try {
-							func = MapFuncDeclToWrapperFunc (swiftClassName, modules, funcDecl);
-						} catch (Exception e) {
-							SkipWithWarning (funcDecl, cl, "wrapping a constructor in a class", e);
-							continue;
-						}
-						funcs.Add (func);
-						AddFunctionToOverallList (cl, func.Name.Name);
+					if (BoundClosureError (funcDecl, cl, "wrapping a constructor in a class"))
+						continue;
+					SLFunc func = null;
+					try {
+						func = MapFuncDeclToWrapperFunc (swiftClassName, modules, funcDecl);
+					} catch (Exception e) {
+						SkipWithWarning (funcDecl, cl, "wrapping a constructor in a class", e);
+						continue;
 					}
+					funcs.Add (func);
+					AddFunctionToOverallList (cl, func.Name.Name);
 				}
 			}
 

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -3637,17 +3637,10 @@ namespace SwiftReflector {
 					MakeOptionalConstructor (cl, picl, usedPinvokeNames, classDecl, superClassContents ?? classContents, use, csClassType, wrapper, swiftLibraryPath, funcDecl, tlf, errors);
 					continue;
 				}
-				if (MethodWrapping.FuncNeedsWrapping (funcDecl, TypeMapper)) {
-					foreach (var m in ConstructorWrapperToMethod (classDecl, superClassDecl, funcDecl, cl, picl, usedPinvokeNames, csClassType, tlf,
-								    superClassName, use, wrapper, superClassContents ?? classContents,
-								    PInvokeName (wrapper.ModuleLibPath, swiftLibraryPath), errors, genericNamer, isAssociatedTypeProxy))
-						yield return m;
-				} else {
-					string pinvokeName = isSubclass ? PInvokeName (wrapper.ModuleLibPath, swiftLibraryPath) : PInvokeName (swiftLibraryPath);
-					foreach (var m in ConstructorToMethod (classDecl, superClassDecl, funcDecl, cl, picl, usedPinvokeNames,
-									       csClassType, tlf, superClassName, use, pinvokeName, wrapper, errors, isAssociatedTypeProxy))
-						yield return m;
-				}
+				foreach (var m in ConstructorWrapperToMethod (classDecl, superClassDecl, funcDecl, cl, picl, usedPinvokeNames, csClassType, tlf,
+								superClassName, use, wrapper, superClassContents ?? classContents,
+								PInvokeName (wrapper.ModuleLibPath, swiftLibraryPath), errors, genericNamer, isAssociatedTypeProxy))
+					yield return m;
 			}
 			string className = StubbedClassName (superClassName ?? classContents.Name);
 			if (!inheritsISwiftObject && classDecl.IsObjCOrInheritsObjC (TypeMapper))


### PR DESCRIPTION
This fixes all the issues in optional tests as laid out in issue [470](https://github.com/xamarin/binding-tools-for-swift/issues/470)

Ultimately this is my fault from months back, but I didn't catch it.

Let's take a trip down memory lane in swift land. In the dim dark ages, any constructor in swift had an additional argument prepended to it which was the type metadata for the object being constructed. Up until swift 5.3, this argument was entirely ignored except in the case of generic types.

Constructors get wrapped if and only if one of more of the arguments can't be passed in a swift-like manner or if the constructor is generic. In the case of a wrapped constructor, we don't call the constructor directly. Instead it gets called from swift after marshaling in the arguments.

Probably in swift 5 (but I'm thinking in swift 5.3), the implicit argument to constructors was now put into R13 (or whatever the `self` register is on the target platform) instead of an extra argument. What was going on was that in constructors the didn't need wrapping, we were likely passing in garbage in the `self` register.

How is the self register used now? It turns out that static methods with `-enable-library-evolution` are being treated like virtual methods on the type metadata object and this is done by grabbing the ISA pointer out of an object and then grabbing a vtable entry off that and calling it. If the metadata is garbage (it is), then we get a crash.

The fix is decidedly simple: flag all constructors as needing wrapping.
I added that to the predicate `FuncNeedsWrapping`, but I've also removed the use of this function in the case of constructors in `MethodWrapping` and `NewClassCompiler`.

For the curious - how did I narrow this down?
I ran the code failing test from lldb and tracked swift call that was crashing. I noted that the code was doing this to invoke a regular method on an object:
```
    0x1012cd0e7 <+391>: movq   (%rax), %rcx  // put the ISA (type metadata) in rcx
    0x1012cd0ea <+394>: movq   %rax, %r13 // put the instance in r13
    0x1012cd0ed <+397>: movq   %rax, -0xa0(%rbp) // save the instance
    0x1012cd0f4 <+404>: callq  *0x78(%rcx) // call a vtable based method which is garbage
```
This said to me that the ISA pointer was wrong. So very wrong. I checked my C# code and it looked good to my eye.
I wrote the same code to do what my unit test was doing in swift instead of C#, injected it into my unit test and called it from my code and stepped through it to see what was different from mine. And here it is - code to construct an object.

```
    0x1017bb892 <+34>: movl   $0x1, %edi // true -> rdi, first argument to the constructor
    0x1017bb897 <+39>: movq   %rax, %r13 // rax has the metadata in it
    0x1017bb89a <+42>: movq   %rdx, -0x20(%rbp) // save rdx
    0x1017bb89e <+46>: callq  0x1017bb160               ; SwiftOptionalTypeTests.FooWOCABooltrue_.__allocating_init(a: Swift.Bool) -> SwiftOptionalTypeTests.FooWOCABooltrue_
```
And that sure was different from my code, which was effectively:
```
movq %rax, rdi // metadata in rdi
movl $0x1, %esi // true in rsi
callq allocating_init_etc
```