### PR TITLE
Every protocol now behaves properly for constructor.

### DIFF
--- a/SwiftRuntimeLibrary/EveryProtocol.cs
+++ b/SwiftRuntimeLibrary/EveryProtocol.cs
@@ -22,7 +22,7 @@ namespace SwiftRuntimeLibrary {
 		static IntPtr _XamEveryProtocolCtorImpl ()
 		{
 			IntPtr retvalIntPtr;
-			retvalIntPtr = NativeMethodsForEveryProtocol.PI_EveryProtocol (EveryProtocol.GetSwiftMetatype ());
+			retvalIntPtr = NativeMethodsForEveryProtocol.PI_MakeEveryProtocol ();
 			return retvalIntPtr;
 
 		}
@@ -51,7 +51,7 @@ namespace SwiftRuntimeLibrary {
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.EveryProtocol_MetadataAccessor)]
 		internal static extern SwiftMetatype PIMetadataAccessor_EveryProtocol (SwiftMetadataRequest request);
 
-		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.EveryProtocolNew)]
-		internal static extern IntPtr PI_EveryProtocol (SwiftMetatype metaClass);
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.MakeEveryProtocol)]
+		internal static extern IntPtr PI_MakeEveryProtocol ();
 	}
 }

--- a/swiftglue/everyprotocol.swift
+++ b/swiftglue/everyprotocol.swift
@@ -5,3 +5,8 @@ public final class EveryProtocol
 {
 	public init () { }
 }
+
+public func makeEveryProtocol () -> EveryProtocol
+{
+	return EveryProtocol ()
+}

--- a/tools/symbolicator/XamGlueConstants.cs
+++ b/tools/symbolicator/XamGlueConstants.cs
@@ -298,7 +298,7 @@ namespace SwiftRuntimeLibrary {
 		[SymbolicatorInfo (Skip = true)]
 		internal const string EveryProtocol_MetadataAccessor = "$s7XamGlue13EveryProtocolCMa";
 		[SymbolicatorInfo (Skip = true)]
-		internal const string EveryProtocolNew = "$s7XamGlue13EveryProtocolCACycfC";
+		internal const string MakeEveryProtocol = "$s7XamGlue17makeEveryProtocolAA0dE0CyF";
 
 		// AnyHelpers
 		internal const string ToAny = "$s7XamGlue5toAny6result3valySpyypG_xtlF";


### PR DESCRIPTION
This addresses issue [475](https://github.com/xamarin/binding-tools-for-swift/issues/475)

All the protocol-based unit tests were failing for the same reason that other non-wrapped constructor tests were failing:
`EveryProtocol` was calling its constructor directly.