### PR TITLE
Ensured we get UTF8 encoding

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/CharacterTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/CharacterTests.cs
@@ -44,7 +44,7 @@ namespace SwiftReflector {
 				}
 			}
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString ());
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString (), enforceUTF8Encoding: true);
 		}
 
 		[Test]
@@ -88,7 +88,7 @@ public class CharacterEcho
 				callingCode.Add (block);
 			}
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString ());
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString (), enforceUTF8Encoding: true);
 		}
 
 		[Test]
@@ -123,7 +123,7 @@ public class CharacterHolder
 				testCharacter (new CSCastExpression ((CSSimpleType)"SwiftCharacter", testIdentifier));	
 			}
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString ());
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected.ToString (), enforceUTF8Encoding: true);
 		}
 	}
 }

--- a/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
@@ -147,7 +147,7 @@ public enum BoringEnum3 {
 
 			if (hexEncode) {
 				nameExpr = new CSFunctionCall ("BitConverter.ToString", false,
-					new CSFunctionCall ("System.Text.Encoding.Default.GetBytes", false, nameExpr));
+					new CSFunctionCall ("new System.Text.UTF8Encoding (false).GetBytes", false, nameExpr));
 			}
 
 			var printer = CSFunctionCall.ConsoleWriteLine (nameExpr);


### PR DESCRIPTION
Address 3 failing tests depending on Unicode fixing issue [477](https://github.com/xamarin/binding-tools-for-swift/issues/477)

When I started working on this issue, I said that I was going to learn something in the process. I didn't know what that thing was going to be, but I knew it was waiting there for me.

The symptoms I had were that unit tests were failing that previously did not fail which depending on printing some 16 bit unicode characters that were passed into swift and then passed back then printed.

There were several possible points of failure:
1 - conversion from C# char to swift char
2 - conversion from swift char to swift string
3 - conversion from swift string to C# string
4 - printing the C# string
5 - collecting the output from printing the C# string

As Sherlock Holmes would say "Once you eliminate the impossible, whatever remains, no matter how improbable , must be the truth." I eliminated 1, 2, 3, and 5, which left 4.

Out of nowhere, the output TextWriter I was being given was no longer using UTF8. I was not expecting this. If I ran the compiled test code from the shell instead of from nunit, the output was correct. So likely there was a change in nunit, VisualStudio or the OS that changes the output encoding when being run from a unit test. I could dig into those further, but as the Bard was fond of saying, "ain't nobody got time for that".

Added an option to inject the following code into any unit test:
```
System.Console.OutputEncoding = new System.Text.UTF8Encoding (false);
```
Remember when I said that I was going learn something? I learned that if you don't use the `bool` constructor for `UTF8Encoding` you get unicode byte order markers at the start of the output, which failed the tests until I changed that. It was jarring to see two identical strings being marked as different at character 0. The length of the expected string was 39 while the length of the generated was 41. 🤔 Ah. Two bytes for the byte order.
