### PR TITLE
Remove dup mapping onto SFError.Code

### DIFF
--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -363,7 +363,6 @@ namespace SwiftReflector.Importing {
 			// SafariServices
 			"SafariServices.SFSafariViewControllerDismissButtonStyle",
 			"SafariServices.SFContentBlockerErrorCode",
-
 			// SceneKit
 			"SceneKit.SCNErrorCode", // can't find it
 			"SceneKit.SCNTessellationSmoothingMode", // can't find it

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -362,6 +362,8 @@ namespace SwiftReflector.Importing {
 			"PdfKit.PdfPrintScalingMode", // macOS only
 			// SafariServices
 			"SafariServices.SFSafariViewControllerDismissButtonStyle",
+			"SafariServices.SFContentBlockerErrorCode",
+
 			// SceneKit
 			"SceneKit.SCNErrorCode", // can't find it
 			"SceneKit.SCNTessellationSmoothingMode", // can't find it
@@ -843,7 +845,6 @@ namespace SwiftReflector.Importing {
 			// ReplayKit
 			{ "ReplayKit.RPRecordingError", "RPRecordingErrorCode" },
 			// SafariServices
-			{ "SafariServices.SFContentBlockerErrorCode", "SFError.Code" },
 			{ "SafariServices.SFErrorCode", "SFError.Code" },
 			// SceneKit
 			{ "SceneKit.SCNAnimationImportPolicy", "SCNSceneSource.AnimationImportPolicy" },


### PR DESCRIPTION
Two types mapped onto `SFError.Code`, "there can be only one", fixes issue [479](https://github.com/xamarin/binding-tools-for-swift/issues/479)