### PR TITLE
Step 2 in Minimizing TLFunction dependence

### DIFF
--- a/SwiftReflector/FunctionDeclarationWrapperFinder.cs
+++ b/SwiftReflector/FunctionDeclarationWrapperFinder.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dynamo;
+using ObjCRuntime;
+using SwiftReflector.Demangling;
+using SwiftReflector.SwiftXmlReflection;
+using SwiftReflector.TypeMapping;
+
+namespace SwiftReflector {
+	public class FunctionDeclarationWrapperFinder {
+		TypeMapper typeMapper;
+		WrappingResult wrappingResult;
+
+		public FunctionDeclarationWrapperFinder (TypeMapper mapper, WrappingResult wrappingResult)
+		{
+			typeMapper = Exceptions.ThrowOnNull (mapper, nameof (mapper));
+			this.wrappingResult = wrappingResult;
+		}
+
+		public FunctionDeclaration FindWrapper (FunctionDeclaration original)
+		{
+			var name = original.IsProperty ? original.PropertyName : original.Name;
+			var wrapperName = original.IsOperator ?
+				MethodWrapping.WrapperOperatorName (typeMapper, original.Parent.ToFullyQualifiedName (true), name, original.OperatorType) :
+				MethodWrapping.WrapperName (original.Parent.ToFullyQualifiedName (false), name, original.IsExtension, original.IsStatic);
+
+			return FindWrapperForMethod (original, wrapperName);
+		}
+
+		FunctionDeclaration FindWrapperForMethod (FunctionDeclaration funcDecl, string wrapperName)
+		{
+			var referenceCodedWrapper = LookupReferenceCodeForFunctionDeclaration (funcDecl, wrapperName, "method");
+			if (referenceCodedWrapper != null)
+				return referenceCodedWrapper;
+
+			var allWrappers = wrappingResult.Module.Functions.Where (fn => fn.Name == wrapperName).ToList ();
+			if (allWrappers == null || allWrappers.Count == 0)
+				return null;
+
+			// if this is not a static function, then there is an extra argument for the instance
+			var instanceSkip =  funcDecl.IsStatic ? 0 : 1;
+
+			var hasReturn = !TypeSpec.IsNullOrEmptyTuple (funcDecl.ReturnTypeSpec);
+			var returnOrExceptionSkip = (hasReturn && typeMapper.MustForcePassByReference (funcDecl, funcDecl.ReturnTypeSpec)) ||
+				funcDecl.HasThrows ? 1 : 0;
+
+			var argumentsToSkip = +instanceSkip + returnOrExceptionSkip;
+
+			return allWrappers.FirstOrDefault (fn => ParametersMatchExceptSkippingFirstN (fn, funcDecl, argumentsToSkip) &&
+							   ReturnTypesMatch (fn, funcDecl));
+		}
+
+		bool ParametersMatchExceptSkippingFirstN (FunctionDeclaration wrapper, FunctionDeclaration toWrap, int n)
+		{
+			var matchNames = !toWrap.IsProperty;
+			var wrapArgs = wrapper.ParameterLists.Last ().Skip (n).ToList ();
+			var toWrapArgs = toWrap.ParameterLists.Last ();
+
+			return ParametersMatch (wrapper, wrapArgs, toWrap, toWrapArgs, matchNames);
+		}
+
+		bool ParametersMatch (FunctionDeclaration wrapper, List<ParameterItem> wrapArgs,
+			FunctionDeclaration toWrap, List<ParameterItem> toWrapArgs, bool matchNames)
+		{
+			if (wrapArgs.Count != toWrapArgs.Count)
+				return false;
+			for (int i = 0; i < wrapArgs.Count; i++) {
+				var wrapArg = wrapArgs [i];
+				var toWrapArg = toWrapArgs [i];
+				if (wrapArg.TypeSpec is ClosureTypeSpec wrapClosure && toWrapArg.TypeSpec is ClosureTypeSpec toWrapClosure) {
+					return WrappedClosuresMatch (wrapper, wrapArg.PublicName, wrapClosure, toWrap, toWrapClosure);
+				}
+				if (!MatchSimple (wrapper, wrapArg.TypeSpec, toWrap, toWrapArg.TypeSpec))
+					return false;
+				if (matchNames && !NamesMatch (i, toWrapArg.PublicName, wrapArg.PublicName))
+					return false;
+			}
+			return true;
+		}
+
+		bool WrappedClosuresMatch (FunctionDeclaration wrapper, string funcName, ClosureTypeSpec wrapperFunc,
+			FunctionDeclaration toWrap, ClosureTypeSpec toWrapFunc)
+		{
+			if (wrapperFunc.ArgumentCount () < 1 || wrapperFunc.ArgumentCount () > 3)
+				throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 46, $"Unexpected parameter count in wrapper function {funcName}");
+			var opaquePointerType = wrapperFunc.GetArgument ((wrapperFunc.ArgumentCount () - 1)) as NamedTypeSpec;
+			if (opaquePointerType == null || opaquePointerType.Name != "Swift.OpaquePointer")
+				return false;
+
+			if (toWrapFunc.ArgumentCount () > 0) {
+				var wrapperArg = wrapperFunc.GetArgument (wrapperFunc.ArgumentCount () - 2); // second from last
+				var namedType = wrapperArg as NamedTypeSpec;
+				if (!IsUnsafeMutablePointer (namedType)) // returns false on null
+					return false;
+				var actualParms = namedType.GenericParameters;
+				var toWrapParms = toWrapFunc.GenericParameters;
+				bool argsMatch = TypeListMatches (wrapper, actualParms, toWrap, toWrapParms);
+				if (!argsMatch)
+					return false;
+			}
+			if (wrapperFunc.ArgumentCount () == 2 && TypeSpec.IsNullOrEmptyTuple (toWrapFunc.ReturnType))
+				return true;
+			var wrapperReturn = wrapperFunc.GetArgument (0);
+			var returnNamedTypeSpec = wrapperReturn as NamedTypeSpec;
+			if (!IsUnsafeMutablePointer (returnNamedTypeSpec))
+				return false;
+			var actualReturn = returnNamedTypeSpec.GenericParameters [0];
+			var toWrapReturn = toWrapFunc.ReturnType;
+			return TypeListMatches (wrapper, new List<TypeSpec> () { actualReturn }, toWrap, new List<TypeSpec> () { toWrapReturn });
+		}
+
+		static bool IsUnsafeMutablePointer (NamedTypeSpec nt)
+		{
+			if (nt == null) return false;
+			return nt.Name == "Swift.UnsafeMutablePointer";
+		}
+
+		bool TypeListMatches (FunctionDeclaration wrapper, List<TypeSpec> wrapTypes, FunctionDeclaration toWrap, List<TypeSpec> toWrapTypes)
+		{
+			if (wrapTypes.Count != toWrapTypes.Count)
+				return false;
+			for (int i = 0; i < wrapTypes.Count; i++) {
+				var wrapType = wrapTypes [i];
+				var toWrapType = toWrapTypes [i];
+				if (!MatchSimple (wrapper, wrapType, toWrap, toWrapType))
+					return false;
+			}
+			return true;
+		}
+
+		static bool NamesMatch (int index, string originalName, string wrappedName)
+		{
+			if (String.IsNullOrEmpty (originalName) || String.IsNullOrEmpty (wrappedName))
+				return true; // match on either or both names optional
+			return originalName == wrappedName;
+		}
+
+		bool MatchSimple (FunctionDeclaration wrapper, TypeSpec a, FunctionDeclaration toWrap, TypeSpec b)
+		{
+			bool aIsGeneric = wrapper.IsTypeSpecGenericReference (a);
+			bool bIsGeneric = toWrap.IsTypeSpecGenericReference (b);
+			if ((aIsGeneric && !bIsGeneric) || (!aIsGeneric && bIsGeneric))
+				return false;
+			if (!aIsGeneric && typeMapper.MustForcePassByReference (wrapper, a)) {
+				if (!a.EqualsReferenceInvaraint (b))
+					return false;
+			} else {
+				if (!a.Equals (b))
+					return false;
+			}
+			return true;
+		}
+
+		FunctionDeclaration LookupReferenceCodeForFunctionDeclaration (FunctionDeclaration funcDecl, string wrapperName, string functionKind)
+		{
+			var referenceCode = wrappingResult.FunctionReferenceCodeMap.ReferenceCodeFor (funcDecl);
+			if (referenceCode != null) {
+				var referenceCodeName = MethodWrapping.FuncNameWithReferenceCode (wrapperName, referenceCode.Value);
+				var wrappers = wrappingResult.Module.Functions.Where (fn => fn.Name == referenceCodeName).ToList ();
+				if (wrappers == null)
+					return null;
+				if (wrappers.Count != 1)
+					throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 37, $"The {functionKind} {funcDecl.ToFullyQualifiedName (true)} has {wrappers.Count} reference codes and should have exactly 1");
+				return wrappers [0];
+			}
+			return null;
+		}
+
+		bool ReturnTypesMatch (FunctionDeclaration wrapper, FunctionDeclaration toWrap)
+		{
+			var toWrapReturn = toWrap.ReturnTypeSpec ?? TupleTypeSpec.Empty;
+			TypeSpec wrapReturn = null;
+			if (toWrap.ReturnTypeSpec != null && typeMapper.MustForcePassByReference (toWrap, toWrap.ReturnTypeSpec) || toWrap.HasThrows) {
+				var returnParam = wrapper.ParameterLists.Last () [0].TypeSpec;
+				var named = returnParam as NamedTypeSpec;
+				if (named == null)
+					throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 38, $"failed to match return type passed by reference. Expected a SwiftBoundGenericType but got {returnParam.GetType ().Name}");
+				if (named.Name != "Swift.UnsafeMutablePointer")
+					throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 40, $"failed to match return type passed by reference. Expected an UnsafeMutablePointer, but got {named.Name}");
+				if (toWrap.HasThrows) {
+					var medusaTuple = named.GenericParameters [0] as TupleTypeSpec;
+					if (medusaTuple == null)
+						throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 41, $"failed to match return type passed by reference. Expected an UnsafeMutablePointer<TupleTypeSpec>, but got {named.GenericParameters [0]}");
+					wrapReturn = medusaTuple.Elements [0];
+				} else {
+					wrapReturn = named.GenericParameters [0];
+				}
+			} else {
+				wrapReturn = toWrap.ReturnTypeSpec ?? TupleTypeSpec.Empty;
+			}
+
+			bool aIsGeneric = toWrap.IsTypeSpecGenericReference (toWrapReturn);
+			bool bIsGeneric = wrapper.IsTypeSpecGenericReference (wrapReturn);
+			if ((aIsGeneric && !bIsGeneric) || (!aIsGeneric && bIsGeneric))
+				return false;
+
+			if (toWrapReturn is ClosureTypeSpec toWrapClosure && wrapReturn is ClosureTypeSpec wrapClosure) {
+				return ClosureTypesMatch (wrapper, wrapClosure, toWrap, toWrapClosure);
+			} else {
+				return toWrapReturn.Equals (wrapReturn);
+			}
+		}
+
+		bool ClosureTypesMatch (FunctionDeclaration wrapper, ClosureTypeSpec closureWrap, FunctionDeclaration toWrap, ClosureTypeSpec closureToWrap)
+		{
+			// to wrap will be: ()->()
+			// wrap will be: ()->()
+			// or
+			// to wrap will be: (args)->return
+			// wrap will be: (UnsafeMutablePointer<return>, UnsafeMutablePointer<(args)>)->()
+			// or
+			// to wrap will be (args)->()
+			// wrap will be (UnsafeMutablePointer<(args)>)-> ()
+
+			if (!TypeSpec.IsNullOrEmptyTuple (closureWrap.ReturnType))
+				return false;
+
+
+			if (IsVoidOnVoid (closureToWrap) && IsVoidOnVoid (closureWrap))
+				return true;
+
+			TypeSpec toMatchReturn = null;
+			int toMatchArgsIndex = 0;
+			if (closureToWrap.ReturnType != null && !closureToWrap.ReturnType.IsEmptyTuple) {
+				if (closureWrap.ArgumentCount () < 1 || closureWrap.ArgumentCount () > 2)
+					return false;
+				toMatchArgsIndex = closureToWrap.ArgumentCount () == 0 ? -1 : 1;
+				toMatchReturn = GetUnsafeMutablePointerBoundType (closureWrap.GetArgument (0));
+				if (toMatchReturn == null)
+					return false;
+			}
+
+			if (toMatchReturn != null) {
+				if (!toMatchReturn.Equals (closureToWrap.ReturnType))
+					return false;
+			}
+
+			if (toMatchArgsIndex >= 0) {
+				if (closureWrap.ArgumentCount () != toMatchArgsIndex + 1)
+					return false;
+				var opaqueArg = GetUnsafeMutablePointerBoundType (closureWrap.GetArgument (toMatchArgsIndex));
+				var toMatchArgs = opaqueArg as TupleTypeSpec;
+				if (toMatchArgs == null)
+					toMatchArgs = new TupleTypeSpec (opaqueArg);
+
+				var toWrapArgs = closureToWrap.Arguments as TupleTypeSpec;
+				if (toWrapArgs == null)
+					toWrapArgs = new TupleTypeSpec (closureToWrap.Arguments);
+
+				if (!TypeListMatches (wrapper, toMatchArgs.Elements, toWrap, toWrapArgs.Elements))
+					return false;
+			}
+			return true;
+		}
+
+		static bool IsVoidOnVoid (ClosureTypeSpec clos)
+		{
+			return TypeSpec.IsNullOrEmptyTuple (clos.Arguments) &&
+				TypeSpec.IsNullOrEmptyTuple (clos.ReturnType);
+		}
+
+		TypeSpec GetUnsafeMutablePointerBoundType (TypeSpec t)
+		{
+			var named = t as NamedTypeSpec;
+			if (named == null)
+				return null;
+			if (named.Name != "Swift.UnsafeMutablePointer")
+				return null;
+			return named.GenericParameters [0];
+		}
+	}
+}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -171,6 +171,7 @@
     <Compile Include="ProtocolMethodMatcher.cs" />
     <Compile Include="PatToGenericMap.cs" />
     <Compile Include="SwiftXmlReflection\GenericReferenceAssociatedTypeProtocol.cs" />
+    <Compile Include="FunctionDeclarationWrapperFinder.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
In this step, I ported the code that given a `FunctionDeclaration` and a `TLFunction` finds the wrapper `TLFunction` such that it has become given a `FunctionDeclaration` it returns the wrapper `FunctionDeclaration`.

In doing this, I tightened up the nomenclature being used in the arguments.
If you see a variable prefaced with `toWrap` it means it represents a type in the code that needed wrapping.
If you see a variable prefaced with `wrap` it means that it represents a wrapped type.

if you look at this code closely, you're going to see the large challenge in calling swift code. If a type T can't be passed directly by C#, the wrapper type is likely going to be either `UnsafeMutablePointer<T>` or `UnsafePointer<T>`. Further, closures types get replaced by something that we can reliably provide in C#, plus we have to take into accounts arguments that may have been prepended for an instance or for a return type or both.

On top of all of this, generic types matching is weak. We could have the method:

```
public class A<T> {
    public class B<U> {
        public class C<V> {
            public func foo<W> (a: T, b: U. c: V, d: W) { }
        }
    }
}
```
And the wrapper function will look like this:
```
public func foo_wrap<T, U, V, W> (this: A<T>.B<U>.C<V>, a: T, b: U. c: V, d: W) {
     this.foo(a: a, b: b, c: c, d: d)
}
```
The problem is there is no practical way to line up the generics so they don't match well. This is known.

In fact, all of this is known because this isn't new code, it's just old code running in a new type space.

In addition, we had code that could map a wrapper `TLFunction` to its equivalent `FunctionDeclaration`. I wrote the reflexive version of this that maps a wrapper `FunctionDeclaration` to it's equivalent `TLFunction`. Both methods use the same internals now because the mapping in this case is 1:1 and onto, which is great. 

Finally, I replaced the existing code where it made sense with the new code and trimmed out dead code.

Perfunctory unit tests are passing.

There is more to be done and more dead code to trim out, but this is getting substantial and I want to keep the chunks smaller.