### PR TITLE
Clean up top level fn code, stop using constructor code.

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -99,8 +99,13 @@ namespace SwiftReflector {
 
 		public static string WrapperCtorName (SwiftClassName name, bool isExtension)
 		{
-			string classPrefix = name.ToFullyQualifiedName (false).Replace ('.', 'D');
-			return $"{kXamPrefix}{classPrefix}{(isExtension ? 'E' : 'D')}{name.Terminus}";
+			return WrapperCtorName (name.ToFullyQualifiedName (false), name.Terminus.Name, isExtension);
+		}
+
+		public static string WrapperCtorName (string fullyQualifedNameNoModule, string classNameAlone, bool isExtension)
+		{
+			var classPrefix = fullyQualifedNameNoModule.Replace ('.', 'D');
+			return $"{kXamPrefix}{classPrefix}{(isExtension ? 'E' : 'D')}{classNameAlone}";
 		}
 
 		public static string WrapperName (SwiftClassName name, string methodName, PropertyType propType, bool isSubScript, bool isExtension, bool isStatic)

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -1055,6 +1055,8 @@ namespace SwiftReflector.TypeMapping {
 		{
 			if (sp.IsEmptyTuple)
 				return false;
+			if (sp is TupleTypeSpec tuple)
+				return tuple.Elements.Count > 1;
 			if (sp is ClosureTypeSpec)
 				return false;
 			if (context.IsTypeSpecGeneric (sp) && context.IsTypeSpecGenericReference (sp))


### PR DESCRIPTION
In this step of refactoring I cleaned up top-level functions which were generating some errors in binding due to name mismatches.

I also created a function -> function wrapper finder for constructors.