### PR TITLE
chop out dead code.

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -625,6 +625,14 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return Arguments != null && !Arguments.IsEmptyTuple;
 		}
 
+		public TupleTypeSpec ArgumentsAsTuple {
+			get {
+				if (Arguments is TupleTypeSpec tuple)
+					return tuple;
+				return new TupleTypeSpec (Arguments);
+			}
+		}
+
 		public int ArgumentCount ()
 		{
 			if (!HasArguments ())

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -1059,6 +1059,11 @@ namespace SwiftReflector.TypeMapping {
 				return tuple.Elements.Count > 1;
 			if (sp is ClosureTypeSpec)
 				return false;
+			if (sp is ProtocolListTypeSpec protolist) {
+				if (protolist.Protocols.Count > 1)
+					return true;
+				return MustForcePassByReference (context, protolist.Protocols.ElementAt (0).Key);
+			}
 			if (context.IsTypeSpecGeneric (sp) && context.IsTypeSpecGenericReference (sp))
 				return true;
 			if (context.IsProtocolWithAssociatedTypesFullPath (sp as NamedTypeSpec, this))


### PR DESCRIPTION
In this final installment, which fixes issue [481](https://github.com/xamarin/binding-tools-for-swift/issues/481) and [482](https://github.com/xamarin/binding-tools-for-swift/issues/482), the refactoring and fallout are more or less complete.

In this PR, I've:
- ported `FindWrapperForMethod` and `FindWrapperForExtension`
- refactored subscript and property code to use these
- fixed some naming of overridden methods
- fixed an issue in `MustForcePassByReference` for protocol list types
- removed usage of TLFunctions from the original module (wrappers are OK)
- chopped out huge swaths of dead code
