### PR TITLE
Bad wrapper bad

### DIFF
--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -1418,31 +1418,6 @@ namespace SwiftReflector {
 			return false;
 		}
 
-		SwiftClassType GetSwiftClassTypeFromProperty (TLFunction func)
-		{
-			if (func == null)
-				return null;
-			return func.Class;
-		}
-
-
-		IEnumerable<SLParameter> FilterCallParams (BaseDeclaration declContext, List<SLParameter> callParms, List<ParameterItem> originalParms,
-			SLImportModules modules)
-		{
-			return callParms.Select ((ntp, i) => {
-				if (originalParms [i].TypeSpec is TupleTypeSpec) {
-					var interiorType = ntp.TypeAnnotation;
-					if (ntp.TypeAnnotation is SLBoundGenericType bgt && (bgt.Name == "UnsafePointer" || bgt.Name == "UnsafeMutablePointer"))
-						interiorType = bgt.BoundTypes [0];
-					string type = ntp.ParameterKind == SLParameterKind.InOut ? "UnsafeMutablePointer" : "UnsafePointer";
-					return new SLParameter (ntp.PublicName, ntp.PrivateName, new SLBoundGenericType (type, interiorType));
-				} else {
-					return ntp;
-				}
-			});
-		}
-
-
 		SLFunc MapFuncDeclToWrapperFunc (SwiftClassName className, SLImportModules modules, FunctionDeclaration funcDecl)
 		{
 			var usedNames = new List<string> ();
@@ -1460,7 +1435,7 @@ namespace SwiftReflector {
 
 			typeMapper.TypeSpecMapper.MapParams (typeMapper, funcDecl, modules, callParms, funcDecl.ParameterLists.Last (), false, genericDeclaration,
 				!String.IsNullOrEmpty (substituteForSelf), substituteForSelf);
-			parms.AddRange (FilterCallParams (funcDecl, callParms, funcDecl.ParameterLists.Last (), modules));
+			parms.AddRange (callParms);
 
 			usedNames.AddRange (parms.Select (p => p.PrivateName.Name));
 			usedNames.Add (funcDecl.Name);
@@ -1836,7 +1811,7 @@ namespace SwiftReflector {
 				callParms [i] = candidateParm;
 			}
 
-			parms.AddRange (FilterCallParams (funcDecl, callParms, funcDecl.ParameterLists.Last (), modules));
+			parms.AddRange (callParms);
 
 			var retType = funcDecl.ReturnTypeSpec;
 

--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -1431,8 +1431,11 @@ namespace SwiftReflector {
 		{
 			return callParms.Select ((ntp, i) => {
 				if (originalParms [i].TypeSpec is TupleTypeSpec) {
+					var interiorType = ntp.TypeAnnotation;
+					if (ntp.TypeAnnotation is SLBoundGenericType bgt && (bgt.Name == "UnsafePointer" || bgt.Name == "UnsafeMutablePointer"))
+						interiorType = bgt.BoundTypes [0];
 					string type = ntp.ParameterKind == SLParameterKind.InOut ? "UnsafeMutablePointer" : "UnsafePointer";
-					return new SLParameter (ntp.PublicName, ntp.PrivateName, new SLBoundGenericType (type, ntp.TypeAnnotation));
+					return new SLParameter (ntp.PublicName, ntp.PrivateName, new SLBoundGenericType (type, interiorType));
 				} else {
 					return ntp;
 				}


### PR DESCRIPTION
This addresses issue [488](https://github.com/xamarin/binding-tools-for-swift/issues/488)
There was a previous bug where I was not mapping tuple parameters to pointers to tuples in swift wrappers. This was because `MustForcePassByReference` was returning false for tuples. I fixed this bug in the previous PR, but the code was now mapping a tuple of type `(a, b, c)` to `UnsafePointer<UnsafePointer<(a, b, c)>>` this is because the type mapping code was correct, but a hack I had to specifically detect the tuple case and force it to a pointer was now making it a pointer to a pointer.

This is an object lesson in why you should try to fully understand the cause of a bug instead of fixing the symptom.

I did not refactor the `params.AddRange` to not even use `parms`, but instead use `callParms` because `parms` gets side-effected later on while `callParms` stays the same and is used later. That's asking for a world of hurt.
