### PR TITLE
bug in swift compiler rears it's less than appealing head

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/PropertyWrapTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/PropertyWrapTests.cs
@@ -190,6 +190,7 @@ public var DoubleStr: String {
 		}
 
 		[Test]
+		[Ignore ("apple's top level let issue")]
 		public void ClosureTLProp ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/PropertyWrapTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/PropertyWrapTests.cs
@@ -190,7 +190,7 @@ public var DoubleStr: String {
 		}
 
 		[Test]
-		[Ignore ("apple's top level let issue")]
+		[Ignore ("Ignore due to https://bugs.swift.org/browse/SR-13790")]
 		public void ClosureTLProp ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
@@ -177,7 +177,7 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("apple's top level let issue")]
+		[Ignore ("Ignore due to https://bugs.swift.org/browse/SR-13790")]
 		public void TheEpsilonIssue ()
 		{
 			string swiftCode =

--- a/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
@@ -177,6 +177,7 @@ namespace SwiftReflector {
 
 
 		[Test]
+		[Ignore ("apple's top level let issue")]
 		public void TheEpsilonIssue ()
 		{
 			string swiftCode =

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1400,5 +1400,30 @@ public protocol Simple {
 			Assert.IsNotNull (proto, "no protocol");
 			Assert.IsTrue (proto.HasDynamicSelf, "no dynamic self");
 		}
+
+		[Test]
+		public void TopLevelLet ()
+		{
+			var code = "public let myVar:Int = 42";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var prop = module.Properties.Where (p => p.Name == "myVar").FirstOrDefault ();
+			Assert.IsNotNull (prop, "no prop");
+			Assert.IsTrue (prop.IsLet, "not a let");
+			Assert.IsNull (prop.GetSetter (), "why is there a setter");
+		}
+
+
+		[Test]
+		public void TheEpsilonIssue ()
+		{
+			string code = "public let 𝑒 = 2.718\n";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var prop = module.Properties.Where (p => p.Name == "𝑒").FirstOrDefault ();
+			Assert.IsNotNull (prop, "no prop");
+			Assert.IsTrue (prop.IsLet, "not a let");
+			Assert.IsNull (prop.GetSetter (), "why is there a setter");
+		}
 	}
 }


### PR DESCRIPTION
This PR doesn't fix an issue but hides it.

There were two tests that were failing from swift code that looks like this:
```
public let e = 2.718
```

When we run the reflector on this, we were being told that the `e` was a `var` and not a `let` and that it had both a valid getter and a valid setter.

Ultimately the cause for this is...swift!
When we compile the module, it writes a `.swiftinterface` file that looks like this:
```
import Swift
public var e: Swift.Double
```
which is clearly incorrect. Handling this is completely out of my control and I've filed a bug with Apple [here](https://bugs.swift.org/browse/SR-13790). There is no workaround for this. I added a couple new unit tests, but these don't generate `.swiftinterface` files, so they pass as is. I've temporarily ignored the failing unit tests and opened [an issue](https://github.com/xamarin/binding-tools-for-swift/issues/493) to take care of these when Apple fixes this problem and we have integrated it.