### PR TITLE
Ignore tests due to Apple bug.

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -11,6 +11,7 @@ namespace SwiftReflector {
 	[TestFixture]
 	public class EnumTests {
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void PropOnTrivialEnum ()
 		{
 			var swiftCode = @"
@@ -30,6 +31,7 @@ public enum Rocks {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TrivialEnumCtor ()
 		{
 			var swiftCode = @"
@@ -80,6 +82,7 @@ public enum SomeForce {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void NestedEnum ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -638,6 +638,7 @@ public func Eat () { }
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumSmokeTest4 ()
 		{
 			EnumSmokeTest4RawValueImpl ("FooAST4", "FooAST4.A", "2");
@@ -964,6 +965,7 @@ public enum Position {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TestPropMatchesClassEnumName ()
 		{
 			string swiftCode =
@@ -984,6 +986,7 @@ public enum Position {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TestPropMatchesTrivialEnumName ()
 		{
 			string swiftCode =
@@ -1264,6 +1267,7 @@ open class LazyVariable
 
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TrivialEnumMember ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
@@ -309,6 +309,7 @@ public func ^++^ (left: IntOrFloat, right: IntOrFloat) -> IntOrFloat {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void SimpleEnumInfixOpTest ()
 		{
 			var swiftCode = @"
@@ -337,6 +338,7 @@ public prefix func ^-^(val: CompassPoints) -> CompassPoints {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void SimpleEnumPostfixOpTest ()
 		{
 			var swiftCode = @"
@@ -452,6 +454,7 @@ public class NumRep1 {
 		}
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumInlineInfixOperator ()
 		{
 			var swiftCode = @"
@@ -478,6 +481,7 @@ public enum CompassPoints3 {
 
 
 		[Test]
+		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumInlinePrefixOperator ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Apple has a code generation bug in the constructors for trivial enums that use RAX as a pointer to somewhere and then they write over it. Lucky us, we consistently get a segfault for this. I'm taking the tests that trigger it offline until apple fixed the bug. I opened up [this issue](https://github.com/xamarin/binding-tools-for-swift/issues/495) in order to remind us to do this work.

The full details of the compiler bug are [here](https://bugs.swift.org/browse/SR-13798).

Here's what we *could* do to work around this if we absolutely had no other choice:

```
@inline(never)
public func justReturnAPointer (p: OpaquePointer) -> OpaquePointer {
    return p
}

public func codeToWrapAnEnumCtor (rawValue: Int) -> SomeEnum {
    var foo = UnsafeMutablePointer<SomeEnum>.allocate (1);
    let p = justReturnAPointer(OpaquePointer(foo));
    let return value = SomeEnum(rawValue: rawValue);
    foo.deallocate ();
    return value;
}
```

Why is this likely to work?
Because `justReturnAPointer` gets passed a pointer to enough memory to hold the enum and when it returns, RAX will be set to that same pointer value.
Why is this going to fail?
Because I can't guarantee anything that happens between this call and the next. Who knows what happens to RAX in the meantime? Not me, that's who.
 