### PR TITLE
More dead code.

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -198,12 +198,6 @@ namespace SwiftReflector {
 			var declsPerModule = new List<List<BaseDeclaration>> ();
 			foreach (ModuleDeclaration moduleDeclaration in moduleDeclarations) {
 				var allTypesAndTopLevel = moduleDeclaration.AllTypesAndTopLevelDeclarations;
-
-				var modContents = ModuleContentsForModuleDeclaration (moduleDeclaration, moduleInventory);
-				if (modContents == null) {
-					var ex = ErrorHelper.CreateError (ReflectorError.kCompilerReferenceBase + 4, $"Unable to find module contents for module {moduleDeclaration.Name}");
-					errors.Add (ex); 
-				}
 				TypeMapper.RegisterClasses (allTypesAndTopLevel.OfType<TypeDeclaration> ());
 				declsPerModule.Add (allTypesAndTopLevel);
 			}

--- a/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ExtensionTests.cs
@@ -301,22 +301,6 @@ public extension HotDogOnUserType
 			TestRunning.TestAndExecute (swiftCode, callingCode, "2.99\n");
 		}
 
-
-		[Test]
-		public void NonPublicExtensionOnNotification ()
-		{
-			var swiftCode = @"import Foundation
-	extension Notification {
-	
-	    func myFrame () -> CGRect? {
-	        return CGRect.init ();
-	    }
-	}";
-
-			var callingCode = CSCodeBlock.Create ();
-			TestRunning.TestAndExecute (swiftCode, callingCode, "");
-		}
-
 		[Test]
 		public void GenericExtensionOnDictionary ()
 		{


### PR DESCRIPTION
This (useless) test was triggering a fail that was effectively dead code.
Removing the dead code made the test "fail" in a place saying it was had no work to do (correct), so this is a useless test.

Historically, I think it was there because I was originally trying to bind to private extensions, which is a no-no. Now this isn't a problem because only public-facing APIs show up from the `.swifinterface` file.