### PR TITLE
Get rid of ARC change

### DIFF
--- a/SwiftRuntimeLibrary/SwiftNativeObject.cs
+++ b/SwiftRuntimeLibrary/SwiftNativeObject.cs
@@ -27,7 +27,6 @@ namespace SwiftRuntimeLibrary {
 			class_handle = classHandle;
 			SwiftObject = handle;
 			registry.Add (this);
-			SwiftCore.Retain (SwiftObject);
 		}
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
There were two ARC unit tests failing because of an ARC change. Turns out it's not needed. Fixes issue [501](https://github.com/xamarin/binding-tools-for-swift/issues/501).

The full details is that errors in the way we were calling constructors with direct pinvokes were exacerbating an error that looked like and ARC undercount. It turns out it was just memory getting munged and we can undo the ARC change. This fixes the two failing tests and no new ones are failing.