### PR TITLE
Ignoring tests that trigger compiler bug

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
@@ -501,6 +501,7 @@ $"import Foundation\nopen class AnotherVirtualClass{platform} {{\n\tpublic init 
 		[Test]
 		[TestCase (PlatformName.macOS)]
 		[TestCase (PlatformName.iOS)]
+		[Ignore ("Waiting on Apple issue https://bugs.swift.org/browse/SR-13832")]
 		public void CallAVirtualInACtor (PlatformName platform)
 		{
 			string swiftCode =

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1312,6 +1312,7 @@ public enum Counters {
 		}
 
 		[Test]
+		[Ignore ("Waiting on Apple issue https://bugs.swift.org/browse/SR-13832")]
 		public void WatchThoseConstructors ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Ignoring tests that trigger a swift compiler bug in the .swiftinterface file. Details are [here](https://bugs.swift.org/browse/SR-13832).

The short of this is that the generated `.swiftinterface` includes a constructor that it should not. No workaround on our end.