### PR TITLE
Trivial enums new calling conventions

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSFunctionCall.cs
+++ b/Dynamo/Dynamo.CSLang/CSFunctionCall.cs
@@ -103,6 +103,23 @@ namespace Dynamo.CSLang {
 			return FooOf (iSizeof, expr);
 		}
 
+		static CSIdentifier iDefault = new CSIdentifier ("default");
+
+		public static CSFunctionCall Default (Type t)
+		{
+			return Default (t.Name);
+		}
+
+		public static CSFunctionCall Default (string t)
+		{
+			return FooOf (iDefault, new CSIdentifier (t));
+		}
+
+		public static CSFunctionCall Default (CSSimpleType t)
+		{
+			return Default (t.Name);
+		}
+
 		static CSFunctionCall FooOf (CSIdentifier foo, CSBaseExpression parameter)
 		{
 			CommaListElementCollection<CSBaseExpression> parms = new CommaListElementCollection<CSBaseExpression> ();

--- a/SwiftReflector/FunctionDeclarationWrapperFinder.cs
+++ b/SwiftReflector/FunctionDeclarationWrapperFinder.cs
@@ -111,7 +111,6 @@ namespace SwiftReflector {
 
 			var returnType = funcDecl.ReturnTypeSpec;
 			var entity = typeMapper.GetEntityForTypeSpec (returnType);
-//			var isTrivialEnum = entity.EntityType == EntityType.TrivialEnum;
 			var isClass = entity.EntityType == EntityType.Class;
 			int skipCount = isClass ? 0 : 1;
 

--- a/SwiftReflector/FunctionDeclarationWrapperFinder.cs
+++ b/SwiftReflector/FunctionDeclarationWrapperFinder.cs
@@ -111,9 +111,9 @@ namespace SwiftReflector {
 
 			var returnType = funcDecl.ReturnTypeSpec;
 			var entity = typeMapper.GetEntityForTypeSpec (returnType);
-			var isTrivialEnum = entity.EntityType == EntityType.TrivialEnum;
+//			var isTrivialEnum = entity.EntityType == EntityType.TrivialEnum;
 			var isClass = entity.EntityType == EntityType.Class;
-			int skipCount = isClass || isTrivialEnum ? 0 : 1;
+			int skipCount = isClass ? 0 : 1;
 
 			return allWrappers.FirstOrDefault (fn => ParametersMatchExceptSkippingFirstN (fn, funcDecl, skipCount));
 		}

--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -2324,7 +2324,7 @@ namespace SwiftReflector {
 			var en = t.GetEntityForTypeSpec (item.TypeSpec);
 			if (en == null)
 				return false;
-			return en.IsStructOrEnum && en.EntityType != EntityType.TrivialEnum;
+			return en.IsStructOrEnum;
 		}
 
 		public static bool IsProtocol (TypeMapper t, ParameterItem item)

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -4698,12 +4698,13 @@ namespace SwiftReflector {
 			if (propGetter != null) {
 				var marshaler = new MarshalEngine (use, useLocals, TypeMapper, wrapper.Module.SwiftCompilerVersion);
 
-				var wrapperGetter = TLFCompiler.CompileMethod (getterWrapperFunc, use, null, null, getterName, false, false, true);
-
 				var getter = TLFCompiler.CompileMethod (propDecl.GetGetter (), use, null, null, getterName, false, false, true);
 
-				var thisParm = wrapperGetter.Parameters.Last ();
-				getter.Parameters.Add (new CSParameter (thisParm.CSType, thisParm.Name, propDecl.Parent.IsNested ? CSParameterKind.None : CSParameterKind.This));
+				var thisTypeSpec = new NamedTypeSpec (propDecl.Parent.ToFullyQualifiedNameWithGenerics ());
+				var ntb = TypeMapper.MapType (propDecl, thisTypeSpec, false);
+				var thisCSType = ntb.ToCSType (use);
+
+				getter.Parameters.Add (new CSParameter (thisCSType, new CSIdentifier ("this0"), propDecl.Parent.IsNested ? CSParameterKind.None : CSParameterKind.This));
 
 				getter.Body.AddRange (marshaler.MarshalFunctionCall (getterWrapperFunc, false, piGetterRef, getter.Parameters,
 					propDecl.GetGetter (), propDecl.GetGetter ().ReturnTypeSpec, getter.Type, null, null, false, wrapper));

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -999,7 +999,7 @@ namespace SwiftReflector.TypeMapping {
 			// can't big structs, non-blitable structs, or plain enums
 			if (en.EntityType == EntityType.Scalar)
 				return false;
-			return en.EntityType == EntityType.Struct || (en.EntityType == EntityType.Protocol && !en.IsObjCProtocol) || en.EntityType == EntityType.Enum;
+			return en.IsStructOrEnum || (en.EntityType == EntityType.Protocol && !en.IsObjCProtocol);
 		}
 
 		public bool MustForcePassByReference (TypeDeclaration decl)
@@ -1108,7 +1108,7 @@ namespace SwiftReflector.TypeMapping {
 							}
 						}
 					}
-					return new NetTypeBundle ("System", "nint", false, false, EntityType.None);
+					return new NetTypeBundle ("System", "IntPtr", false, false, EntityType.None);
 				} else {
 					return new NetTypeBundle (en.SharpNamespace, en.SharpTypeName, false, isReference, en.EntityType);
 				}

--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -11,7 +11,25 @@ namespace SwiftReflector {
 	[TestFixture]
 	public class EnumTests {
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
+		public void TestTrivialEnumReturn ()
+		{
+			var swiftCode = @"
+public enum ArmBones {
+	case ulna, radius, brachia
+}
+public func getArmBone () -> ArmBones {
+	return .radius;
+}
+";
+			var gottenID = new CSIdentifier ("arm");
+			var getterDecl = CSVariableDeclaration.VarLine (gottenID, new CSFunctionCall ("TopLevelEntities.GetArmBone", false));
+			var printer = CSFunctionCall.ConsoleWriteLine (gottenID == new CSIdentifier ("ArmBones.Radius"));
+			var callingCode = CSCodeBlock.Create (getterDecl, printer);
+
+			TestRunning.TestAndExecute (swiftCode, callingCode, "True\n");
+
+		}
+		[Test]
 		public void PropOnTrivialEnum ()
 		{
 			var swiftCode = @"
@@ -31,7 +49,6 @@ public enum Rocks {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TrivialEnumCtor ()
 		{
 			var swiftCode = @"
@@ -82,7 +99,6 @@ public enum SomeForce {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void NestedEnum ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -638,7 +638,6 @@ public func Eat () { }
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumSmokeTest4 ()
 		{
 			EnumSmokeTest4RawValueImpl ("FooAST4", "FooAST4.A", "2");
@@ -965,7 +964,6 @@ public enum Position {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TestPropMatchesClassEnumName ()
 		{
 			string swiftCode =
@@ -986,7 +984,6 @@ public enum Position {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TestPropMatchesTrivialEnumName ()
 		{
 			string swiftCode =
@@ -1267,7 +1264,6 @@ open class LazyVariable
 
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void TrivialEnumMember ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
@@ -309,7 +309,6 @@ public func ^++^ (left: IntOrFloat, right: IntOrFloat) -> IntOrFloat {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void SimpleEnumInfixOpTest ()
 		{
 			var swiftCode = @"
@@ -338,7 +337,6 @@ public prefix func ^-^(val: CompassPoints) -> CompassPoints {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void SimpleEnumPostfixOpTest ()
 		{
 			var swiftCode = @"
@@ -454,7 +452,6 @@ public class NumRep1 {
 		}
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumInlineInfixOperator ()
 		{
 			var swiftCode = @"
@@ -481,7 +478,6 @@ public enum CompassPoints3 {
 
 
 		[Test]
-		[Ignore ("apple bug - https://bugs.swift.org/browse/SR-13798")]
 		public void EnumInlinePrefixOperator ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Change the calling conventions for trivial enums, fixing issue [495](https://github.com/xamarin/binding-tools-for-swift/issues/495)

I categorize enums into 3 categories:
1. objc (contains a scalar backing type)
2. trivial enums (no payloads, all cases but no backing type)
3. non-trivial enums (has one or more payload)

We used to like category 2 because they can be treated like 1 and can be passed by value. Unfortunately, this is no longer the case because the swift compiler is super-cautious when it comes to trivial enums now. The reason is that if I compile against library A and it has a trivial enum **today**, it might not be a trivial enum **tomorrow** and may no longer fit within a register. Apple made these types pass-by-reference in the current revision.

These changes make that happen.

In `CSFunctionCall` I added a `Default(t)` because of reasons.

For the most part, I had to change the definition of `MustForcePassByReference` as well as change the marshaling of the type.

I tried to make the P/Invoke have a signature of `ref enumType`, but had significant issues that made this problematic so I went to an IntPtr instead.

Added a new unit test, current tests pass.