### PR TITLE
Let's get unit tests going on the CLI

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSShortCircuit.cs
+++ b/Dynamo/Dynamo.CSLang/CSShortCircuit.cs
@@ -1,0 +1,32 @@
+﻿using System;
+namespace Dynamo.CSLang {
+	public class CSShortCircuit : DelegatedSimpleElement, ICSLineable  {
+		public CSShortCircuit (CSShortCircuitKind kind)
+		{
+			Kind = kind;
+		}
+
+		public CSShortCircuitKind Kind { get; private set; }
+
+		protected override void LLWrite (ICodeWriter writer, object o)
+		{
+			var keyword = Kind == CSShortCircuitKind.Break ? "break" : "continue";
+			writer.Write (keyword, false);
+		}
+
+		public static CSLine ShortCircuit (CSShortCircuitKind kind)
+		{
+			return new CSLine (new CSShortCircuit (kind));
+		}
+
+		public static CSLine Continue ()
+		{
+			return ShortCircuit (CSShortCircuitKind.Continue);
+		}
+
+		public static CSLine Break ()
+		{
+			return ShortCircuit (CSShortCircuitKind.Break);
+		}
+	}
+}

--- a/Dynamo/Dynamo.CSLang/Enums.cs
+++ b/Dynamo/Dynamo.CSLang/Enums.cs
@@ -79,5 +79,10 @@ namespace Dynamo.CSLang {
 		Params,
 		This
 	}
+
+	public enum CSShortCircuitKind {
+		Break,
+		Continue,
+	}
 }
 

--- a/Dynamo/Dynamo.csproj
+++ b/Dynamo/Dynamo.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Dynamo.CSLang\CSConditionalCompilation.cs" />
     <Compile Include="Dynamo.CSLang\CSInject.cs" />
     <Compile Include="Dynamo.SwiftLang\SLInject.cs" />
+    <Compile Include="Dynamo.CSLang\CSShortCircuit.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/Inventory/ClassContents.cs
+++ b/SwiftReflector/Inventory/ClassContents.cs
@@ -249,6 +249,17 @@ namespace SwiftReflector.Inventory {
 				yield return prop;
 		}
 
+		public TLFunction SoleMetadataAccessor {
+			get {
+				if (ClassConstructor == null || ClassConstructor.Values.Count () == 0)
+					return null;
+				var elem = ClassConstructor.Values.ElementAt (0);
+				if (elem.Functions.Count == 0)
+					return null;
+				return elem.Functions [0];
+			}
+		}
+
 
 		public SwiftClassName Name { get; private set; }
 		public FunctionInventory Constructors { get; private set; }

--- a/SwiftRuntimeLibrary/SwiftMarshal/DynamicLib.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/DynamicLib.cs
@@ -99,10 +99,8 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		{
 			var path = Environment.GetEnvironmentVariable ("DYLD_LIBRARY_PATH");
 			if (path == null)
-				yield break;
-			foreach (var subPart in path.Split (':')) {
-				yield return subPart;
-			}
+				return new string [0];
+			return path.Split (':');
 		}
 
 		public string FileName { get; private set; }

--- a/SwiftRuntimeLibrary/SwiftMarshal/DynamicLib.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/DynamicLib.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -55,12 +57,19 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				throw new ArgumentOutOfRangeException (nameof (flags));
 
 			string selfPath = Path.GetDirectoryName (typeof (DynamicLib).Assembly.Location);
-			string [] possibleFiles = new string [] {
+			List<string> possibleFiles = new List<string> () {
 				fileName,
 				Path.Combine(selfPath, Path.Combine($"Frameworks/{fileName}.framework/{fileName}"))
 			};
 
 			var sb = new StringBuilder ();
+			var dylibPaths = LibraryPaths ();
+			sb.AppendLine ("DYLD_LIBRARY_PATH: ");
+			foreach (var path in dylibPaths) {
+				sb.AppendLine (path);
+				possibleFiles.Add (Path.Combine (path, fileName));
+			}
+			sb.AppendLine ("Checking possible files:");
 
 			foreach (string file in possibleFiles) {
 				FileName = file;
@@ -84,6 +93,16 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 				throw new ArgumentException ($"Unable to load library {fileName}:{sbbuff}", nameof (fileName));
 			}
 
+		}
+
+		IEnumerable<string> LibraryPaths ()
+		{
+			var path = Environment.GetEnvironmentVariable ("DYLD_LIBRARY_PATH");
+			if (path == null)
+				yield break;
+			foreach (var subPart in path.Split (':')) {
+				yield return subPart;
+			}
 		}
 
 		public string FileName { get; private set; }

--- a/SwiftRuntimeLibrary/SwiftMetatype.cs
+++ b/SwiftRuntimeLibrary/SwiftMetatype.cs
@@ -25,6 +25,27 @@ namespace SwiftRuntimeLibrary {
 
 		public IntPtr Handle { get { return handle; }}
 
+		delegate IntPtr MetadataDelegate ();
+
+		static MetadataDelegate GetMetadataDelegate (DynamicLib dylib, string symbol)
+		{
+			var addr = dylib.FindSymbolAddress (symbol);
+			if (addr == IntPtr.Zero)
+				return null;
+			return (MetadataDelegate)Marshal.GetDelegateForFunctionPointer (addr, typeof (MetadataDelegate));
+		}
+
+		internal static SwiftMetatype? FromAccessor (DynamicLib dylib, string symbol)
+		{
+			var accessor = GetMetadataDelegate (dylib, symbol);
+			if (accessor == null)
+				return null;
+			var mdAddr = accessor ();
+			if (mdAddr == IntPtr.Zero)
+				return null;
+			return new SwiftMetatype (mdAddr);
+		}
+
 		internal static SwiftMetatype? FromDylib (DynamicLib dylib, string metaDescName)
 		{
 			return FromDylib (dylib, metaDescName, 0);

--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -554,6 +554,10 @@ namespace tomwiftytest {
 			}
 
 			var sb = new StringBuilder ();
+			// uncomment this to see the DYLD_LIBRARY_PATH in the output.
+			// Do NOT leave this uncommented as it will fail nearly all the tests
+//			sb.AppendLine ("DYLD_LIBRARY_PATH: " + env ["DYLD_LIBRARY_PATH"]);
+
 			var rv = RunCommandWithLeaks (executable, args, env, sb, workingDirectory: workingDirectory ?? string.Empty);
 
 			if (rv != 0) {

--- a/tests/tom-swifty-test/Makefile
+++ b/tests/tom-swifty-test/Makefile
@@ -17,7 +17,7 @@ check: run-tests
 run-tests: bin/Debug/tom-swifty-test.dll
 	rm -f .failed-stamp
 	rm -Rf bin/devicetests # remove any existing device test output
-	DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):$(SWIFTLIB)/macosx:$(SWIFTGLUEPREFIX)mac$(SWIFTGLUESUFFIX) \
+	DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):/usr/lib/swift:$(SWIFTGLUEPREFIX)mac$(SWIFTGLUESUFFIX) \
 	mono --debug --runtime=v4.0 $(TOP)/packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe bin/Debug/tom-swifty-test.dll --workers=4 --framework=mono-4.0 --nocolor --labels=All --shadowcopy $(FIXTURES) || touch .failed-stamp
 	@# Create an html file and tell MonkeyWrench to upload it (if we're running there)
 	@[[ -z "$$BUILD_REPOSITORY" ]] || \
@@ -29,7 +29,7 @@ build: bin/Debug/tom-swifty-test.dll
 
 run-runtime-library-tests: bin/Debug/tom-swifty-test.dll
 	rm -f .$@-failed-stamp
-	LEAKTEST_DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):$(SWIFTLIB)/macosx:$(SWIFTGLUEPREFIX)mac$(SWIFTGLUESUFFIX) \
+	LEAKTEST_DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):/usr/lib/swift:$(SWIFTGLUEPREFIX)mac$(SWIFTGLUESUFFIX) \
 	$(TOP)/leaktest/bin/Debug/leaktest mono --debug --runtime=v4.0 $(TOP)/packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe bin/Debug/tom-swifty-test.dll --workers=1 --framework=mono-4.0 --nocolor --labels=All --shadowcopy --where=namespace=SwiftRuntimeLibraryTests --inprocess || touch .failed-stamp
 
 bin/Debug/tom-swifty-test.dll: $(shell git ls-files . | grep '[.]cs$$') tom-swifty-test.csproj SwiftRuntimeLibrary.Mac.dll.config

--- a/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftArrayTests.cs
+++ b/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftArrayTests.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using SwiftRuntimeLibrary;
 
 using NUnit.Framework;
+using tomwiftytest;
+using System.Runtime.InteropServices;
 
 namespace SwiftRuntimeLibraryTests {
 	[TestFixture]
@@ -40,7 +42,7 @@ namespace SwiftRuntimeLibraryTests {
 				Assert.GreaterOrEqual (arr.Capacity, 20, "Capacity 2");
 			}
 
-			Assert.Throws<ArgumentOutOfRangeException> (() => new SwiftArray<long> ((long)-1));
+			Assert.Throws<ArgumentOutOfRangeException> (() => new SwiftArray<int> ((long)-1));
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -323,7 +323,8 @@ namespace tomwiftytest {
 				if (postCompileCheck != null)
 					postCompileCheck (tempDirectoryPath);
 
-				var testPathDumper = BuildDumpLibPaths ();
+				// Uncomment to add in a method to dump out lib paths and their contents
+				var testPathDumper = (CSMethod)null; // BuildDumpLibPaths ();
 
 				Tuple<CSNamespace, CSUsingPackages> testClassParts = TestRunningCodeGenerator.CreateTestClass (callingCode, testName, iosExpectedOutput ?? expectedOutput, nameSpace,
 										       testClassName, otherClass, skipReason, platform, enforceUTF8Encoding, optionalMethod: testPathDumper);


### PR DESCRIPTION
Problem: Unit tests were passing in the IDE, but failing in the CLI.
Tracking it down, the issue was due to the DYLD_LIBRARY_PATH being set in the test Makefile in such a way that included the output libraries built alongside the reflector. No swift code that we use is compiled against these libraries and they are incompatible with the system libraries. The solution was to replace the reflector library path with `/usr/lib/swift`.

In the process, I added a ton (metric) of debugging information. This includes:
1. adding in an optional method to the test rig and a method that dumps all the directories in `DYLD_LIBRARY_PATH` and their contents
2. Adding in a SoleMetadataAccessor for types
3. Explicitly searching through `DYLD_LIBRARY_PATH` when doing DlOpen and improving the output on failure
4. Adding code that can get a metadata accessor function by its symbol instead of just using a direct metadata symbol
5. Added `CSShortCircuit` to Dynamo to allow us to write code to include `continue` or `break`

When the code was finally running, one test failed: `SwiftArrayTests.Constructor_Capacity`, which included an range check test for the flavor of constructor that takes an `nint`. This test failed because it was being called in the form `new SwiftArray<long>((long)-1);` Using `mcs` previously, this went to the intended constructor. Now that the code is compiling with `csc` it was now going to `SwiftArray<T>(params T [] items)`, which does not fail the range check. Changed the test to be `new SwiftArray<int>((long)-1)` which now range checks as expected.