### PR TITLE
Added generated parser into main reflector project

### DIFF
--- a/SwiftReflector/.gitignore
+++ b/SwiftReflector/.gitignore
@@ -1,2 +1,3 @@
 Downloaded
+SwiftInterfaceReflector/GeneratedParser
 

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -188,7 +188,7 @@
     <Folder Include="SwiftInterfaceReflector\" />
   </ItemGroup>
   <Target Name="GeneratedCSParser" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="SwiftInterfaceReflector\GeneratedParser\SwuftUnterfaceBaseListener.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceLexer.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceListener.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceParser.cs">
-    <Exec Command="make --directory=../swiftinterfaceparser" />
+    <Exec Command="make" WorkingDirectory="../swiftinterfaceparser" />
   </Target>
 
   <ItemGroup>

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -46,6 +46,9 @@
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>..\packages\Mono.Cecil.0.10.3\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
+    <Reference Include="Antlr4.Runtime.Standard">
+      <HintPath>..\packages\Antlr4.Runtime.Standard.4.9.1\lib\netstandard2.0\Antlr4.Runtime.Standard.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="..\..\common\MachO.cs" />
@@ -182,6 +185,17 @@
     <Folder Include="TypeMapping\" />
     <Folder Include="Demangling\" />
     <Folder Include="Importing\" />
+    <Folder Include="SwiftInterfaceReflector\" />
+  </ItemGroup>
+  <Target Name="GeneratedCSParser" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="SwiftInterfaceReflector\GeneratedParser\SwuftUnterfaceBaseListener.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceLexer.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceListener.cs;SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceParser.cs">
+    <Exec Command="make --directory=../swiftinterfaceparser" />
+  </Target>
+
+  <ItemGroup>
+	<Compile Include="SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceBaseListener.cs" />
+	<Compile Include="SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceListener.cs" />
+	<Compile Include="SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceLexer.cs" />
+	<Compile Include="SwiftInterfaceReflector\GeneratedParser\SwiftInterfaceParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SwiftRuntimeLibrary\SwiftRuntimeLibrary.csproj">

--- a/SwiftReflector/packages.config
+++ b/SwiftReflector/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr4.Runtime.Standard" version="4.9.1" targetFramework="net472" />
   <package id="Mono.Cecil" version="0.10.3" targetFramework="net45" />
 </packages>

--- a/swiftinterfaceparser/Makefile
+++ b/swiftinterfaceparser/Makefile
@@ -7,13 +7,13 @@ GRAMMAR=SwiftInterface.g4
 
 CSOUTDIR=CSParser
 JAVAOUTDIR=JavaParser
+CSFINALOUTPUT=../SwiftReflector/SwiftInterfaceReflector/GeneratedParser
 
 JDK_VERSION=$(shell ls /usr/local/Cellar/openjdk | sort -V | tail -n 1)
 JDK_PATH="/usr/local/Cellar/openjdk/$(JDK_VERSION)"
 JAVA_HOME=$(JDK_PATH)
 
-all: $(ANTLRJAR) grammar
-
+all: $(ANTLRJAR) cs
 
 # download antlr on demand
 $(ANTLRJAR):
@@ -27,11 +27,21 @@ grammar: $(GRAMMAR) $(JAVAOUTDIR)
 	$(ANTLR) -o $(JAVAOUTDIR) $(GRAMMAR)
 	javac -classpath $(CLASSPATH) $(JAVAOUTDIR)/*.java
 
+cs: grammar $(CSOUTDIR) $(CSFINALOUTPUT)
+	$(ANTLR) -Dlanguage=CSharp -o $(CSOUTDIR) $(GRAMMAR)
+	cp $(CSOUTDIR)/*.cs $(CSFINALOUTPUT)
+
 $(JAVAOUTDIR):
 	mkdir $@
 
+$(CSOUTDIR):
+	mkdir $@
+
+$(CSFINALOUTPUT):
+	mkdir $@
+
 clean:
-	rm -rf *.tokens *.interp $(JAVAOUTDIR)
+	rm -rf *.tokens *.interp $(JAVAOUTDIR) $(CSOUTDIR) $(CSFINALOUTPUT)/*.cs
 
 squeakyclean: clean
 	rm -rf antlr

--- a/swiftinterfaceparser/Makefile
+++ b/swiftinterfaceparser/Makefile
@@ -38,7 +38,7 @@ $(CSOUTDIR):
 	mkdir $@
 
 $(CSFINALOUTPUT):
-	mkdir $@
+	mkdir -p $@
 
 clean:
 	rm -rf *.tokens *.interp $(JAVAOUTDIR) $(CSOUTDIR) $(CSFINALOUTPUT)/*.cs


### PR DESCRIPTION
This PR extends the Makefile to generate C# code and copy it into the main project.
I altered the CS project to execute the Makefile to generate the parser files and include them for compilation.
I also added in the antlr runtime NuGet package.