### PR TITLE
Unify the exceptions in the API.

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/ParseException.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/ParseException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+namespace SwiftReflector.SwiftInterfaceReflector {
+	public class ParseException : Exception {
+		public ParseException ()
+		{
+		}
+
+		public ParseException (string message)
+		    : base (message)
+		{
+		}
+
+		public ParseException (string message, Exception inner)
+		    : base (message, inner)
+		{
+		}
+	}
+}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -176,6 +176,7 @@
     <Compile Include="SwiftXmlReflection\GenericReferenceAssociatedTypeProtocol.cs" />
     <Compile Include="FunctionDeclarationWrapperFinder.cs" />
     <Compile Include="SwiftInterfaceReflector\SwiftInterfaceReflector.cs" />
+    <Compile Include="SwiftInterfaceReflector\ParseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Unified the exceptions thrown by the swiftinterface parser fixing issue [524](https://github.com/xamarin/binding-tools-for-swift/issues/524)

The goal of this is to make integration into the main code base easier. The notion being that we intend to use the swiftinterface parser as the frontline parser and if it fails, fall back to the compiler based parser. This is easier if have one exception coming out of the API. Note that I still throw `ArgumentNullException` because if you pass in null into the main API, you get everything you deserve.