### PR TITLE
Added OperatorDeclaration support

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -200,6 +200,9 @@ namespace SwiftReflector {
 				var allTypesAndTopLevel = moduleDeclaration.AllTypesAndTopLevelDeclarations;
 				TypeMapper.RegisterClasses (allTypesAndTopLevel.OfType<TypeDeclaration> ());
 				declsPerModule.Add (allTypesAndTopLevel);
+				foreach (var op in moduleDeclaration.Operators) {
+					TypeMapper.TypeDatabase.AddOperator (op, moduleDeclaration.Name);
+				}
 			}
 
 			if (errors.AnyErrors)

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -177,6 +177,8 @@
     <Compile Include="FunctionDeclarationWrapperFinder.cs" />
     <Compile Include="SwiftInterfaceReflector\SwiftInterfaceReflector.cs" />
     <Compile Include="SwiftInterfaceReflector\ParseException.cs" />
+    <Compile Include="SwiftXmlReflection\OperatorDeclaration.cs" />
+    <Compile Include="TypeMapping\ModuleDatabase.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
@@ -323,7 +323,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return dst;
 		}
 
-		static OperatorType OperatorTypeFromElement (string type)
+		public static OperatorType OperatorTypeFromElement (string type)
 		{
 			var enumType = OperatorType.None;
 			if (Enum.TryParse (type, out enumType))

--- a/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
@@ -12,6 +12,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		{
 			Declarations = new List<BaseDeclaration> ();
 			Extensions = new List<ExtensionDeclaration> ();
+			Operators = new List<OperatorDeclaration> ();
 		}
 
 		public ModuleDeclaration (string name)
@@ -46,6 +47,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 			foreach (var child in elem.Elements()) {
 				if (child.Name == "extension") {
 					decl.Extensions.Add (ExtensionDeclaration.FromXElement (child, decl));
+				} else if (child.Name == "operator") {
+					decl.Operators.Add (OperatorDeclaration.FromXElement (child, child.Attribute ("moduleName")?.Value));
 				} else {
 					decl.Declarations.Add (BaseDeclaration.FromXElement (child, decl, null));
 				}
@@ -68,6 +71,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public IEnumerable<FunctionDeclaration> TopLevelFunctions { get { return Functions.Where (f => f.Parent == null && f.Access == Accessibility.Public || f.Access == Accessibility.Open); } }
 		public IEnumerable<PropertyDeclaration> TopLevelProperties { get { return Properties.Where (p => p.Parent == null && p.Access == Accessibility.Public || p.Access == Accessibility.Open); } }
 		public List<ExtensionDeclaration> Extensions { get; private set; }
+		public List<OperatorDeclaration> Operators { get; private set; }
 
 
 		public bool IsCompilerCompatibleWith(Version targetCompilerVersion)

--- a/SwiftReflector/SwiftXmlReflection/OperatorDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/OperatorDeclaration.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace SwiftReflector.SwiftXmlReflection {
+	public class OperatorDeclaration {
+		public OperatorDeclaration ()
+		{
+		}
+
+		public string ModuleName { get; private set; }
+		public string Name { get; private set; }
+		public OperatorType OperatorType { get; private set; }
+		public string PrecedenceGroup { get; private set; }
+
+		public XElement ToXElement ()
+		{
+			var xobjects = new List<XObject> ();
+			GatherXObjects (xobjects);
+			XElement typeDecl = new XElement ("operator", xobjects.ToArray ());
+			return typeDecl;
+		}
+
+		void GatherXObjects (List<XObject> xobjects)
+		{
+			xobjects.Add (new XAttribute ("name", Name));
+			if (PrecedenceGroup != null)
+				xobjects.Add (new XAttribute ("precedenceGroup", PrecedenceGroup));
+			xobjects.Add (new XAttribute ("operatorKind", OperatorType.ToString ()));
+		}
+
+		public static OperatorDeclaration FromXElement (XElement elem, string module)
+		{
+			return new OperatorDeclaration () {
+				ModuleName = module ?? elem.Attribute ("moduleName")?.Value ?? "",
+				Name = elem.Attribute ("name").Value,
+				PrecedenceGroup = NullOnNullOrEmpty (elem.Attribute ("precedenceGroup")?.Value),
+				OperatorType = FunctionDeclaration.OperatorTypeFromElement ((string)elem.Attribute ("operatorKind"))
+			};
+		}
+
+		static string NullOnNullOrEmpty (string s)
+		{
+			return String.IsNullOrEmpty (s) ? null : s;
+		}
+	}
+}

--- a/SwiftReflector/TypeMapping/ModuleDatabase.cs
+++ b/SwiftReflector/TypeMapping/ModuleDatabase.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using SwiftReflector.SwiftXmlReflection;
+
+namespace SwiftReflector.TypeMapping {
+	public class ModuleDatabase : Dictionary<string, Entity>{
+		public ModuleDatabase ()
+		{
+			Operators = new List<OperatorDeclaration> ();
+		}
+
+		public List<OperatorDeclaration> Operators { get; private set; }
+	}
+}

--- a/SwiftReflector/TypeMapping/TypeDatabase.cs
+++ b/SwiftReflector/TypeMapping/TypeDatabase.cs
@@ -46,7 +46,7 @@ namespace SwiftReflector.TypeMapping {
 		Dictionary<DotNetName, string> netNamesToSwiftNames = new Dictionary<DotNetName, string> ();
 		Dictionary<string, DotNetName> swiftNamesToNetNames = new Dictionary<string, DotNetName> ();
 
-		Dictionary<string, Dictionary<string, Entity>> modules = new Dictionary<string, Dictionary<string, Entity>> ();
+		Dictionary<string, ModuleDatabase> modules = new Dictionary<string, ModuleDatabase> ();
 
 		public TypeDatabase ()
 		{
@@ -153,9 +153,9 @@ namespace SwiftReflector.TypeMapping {
 				throw new AggregateException (errors.Errors.Select ((v) => v.Exception));
 		}
 
-		Dictionary<string, Entity> EntityCollection (string moduleName)
+		ModuleDatabase EntityCollection (string moduleName)
 		{
-			Dictionary<string, Entity> module = null;
+			ModuleDatabase module = null;
 			modules.TryGetValue (Exceptions.ThrowOnNull (moduleName, nameof(moduleName)), out module);
 			return module;
 		}
@@ -168,6 +168,13 @@ namespace SwiftReflector.TypeMapping {
 			return Enumerable.Empty<Entity> ();
 		}
 
+		public IEnumerable <OperatorDeclaration> OperatorsForModule (string moduleName)
+		{
+			var module = EntityCollection (moduleName);
+			if (module != null)
+				return module.Operators;
+			return Enumerable.Empty<OperatorDeclaration> ();
+		}
 
 		public void Write (string file, IEnumerable<string> modules)
 		{
@@ -179,6 +186,18 @@ namespace SwiftReflector.TypeMapping {
 		public void Write (Stream stm, IEnumerable<string> modules)
 		{
 			Write (stm, modules.Select (s => EntitiesForModule (s)).SelectMany (x => x).Select (entity => entity.ToXElement ()));
+		}
+
+		IEnumerable<XElement> GatherXElements (IEnumerable<string> modules)
+		{
+			foreach (var modName in modules) {
+				foreach (var entity in EntitiesForModule (modName)) {
+					yield return entity.ToXElement ();
+				}
+				foreach (var op in OperatorsForModule (modName)) {
+					yield return op.ToXElement ();
+				}
+			}
 		}
 
 		public void Write (string file, string module)
@@ -211,6 +230,9 @@ namespace SwiftReflector.TypeMapping {
 			foreach (var mod in other.modules.Values) {
 				foreach (var entity in mod.Values) {
 					AddEntity (entity, errors);
+				}
+				foreach (var op in mod.Operators) {
+					AddOperator (op);
 				}
 			}
 			return initialErrorCount != errors.ErrorCount; 
@@ -276,7 +298,25 @@ namespace SwiftReflector.TypeMapping {
 						continue;
 					AddEntity (e, errors);
 				}
+
+				var ops = from op in entityList.Elements ("operator")
+					  select OperatorDeclaration.FromXElement (op, null);
+
+				foreach (var op in ops) {
+					AddOperator (op);
+				}
 			}
+		}
+
+		public void AddOperator (OperatorDeclaration op, string moduleName = null)
+		{
+			moduleName = moduleName ?? op.ModuleName;
+			ModuleDatabase db = null;
+			if (!modules.TryGetValue (moduleName, out db)) {
+				db = new ModuleDatabase ();
+				modules.Add (moduleName, db);
+			}
+			db.Operators.Add (op);
 		}
 
 		void AddEntity (Entity e, ErrorHandling errors)
@@ -301,9 +341,9 @@ namespace SwiftReflector.TypeMapping {
 
 		void AddEntityToModuleCollection (string moduleName, Entity e)
 		{
-			Dictionary<string, Entity> entities = null;
+			ModuleDatabase entities = null;
 			if (!modules.TryGetValue (moduleName, out entities)) {
-				entities = new Dictionary<string, Entity> ();
+				entities = new ModuleDatabase ();
 				modules.Add (moduleName, entities);
 			}
 			entities.Add (e.Type.ToFullyQualifiedName (true), e);

--- a/SwiftVersion.mk
+++ b/SwiftVersion.mk
@@ -2,4 +2,4 @@
 SWIFT_BRANCH=release/5.3-branch-tomswifty
 SWIFT_SCHEME=release/5.3
 # this hash should be the most recent in the above branch
-SWIFT_HASH=28e007252c2ec7217c7d75bd6f111b9c682153e3
+SWIFT_HASH=904741b22f503462189fa24a3f1260435554c9ec

--- a/devops/automation/build-swift.sh
+++ b/devops/automation/build-swift.sh
@@ -117,7 +117,7 @@ git checkout --force "$SWIFT_BRANCH"
 git reset --hard "$SWIFT_HASH"
 
 echo "Updating swift dependencies..."
-./utils/update-checkout --clone --skip-repository swift -j 1 --scheme "$SWIFT_SCHEME"
+./utils/update-checkout --clone --skip-repository swift --skip-repository tensorflow-swift-apis -j 1 --scheme "$SWIFT_SCHEME"
 
 echo "Building swift (not so swiftly, some patience is required)..."
 ./utils/build-script --clean -R --ios --tvos --watchos --extra-cmake-options=-DSWIFT_DARWIN_ENABLE_STABLE_ABI_BIT:BOOL=TRUE

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1425,5 +1425,59 @@ public protocol Simple {
 			Assert.IsTrue (prop.IsLet, "not a let");
 			Assert.IsNull (prop.GetSetter (), "why is there a setter");
 		}
+
+		[Test]
+		public void InfixOperatorDecl ()
+		{
+			var code = @"infix operator *^* : AdditionPrecedence
+extension Int {
+	public static func *^* (lhs: Int, rhs: Int) -> Int {
+		return 2 * lhs + 2 * rhs
+	}
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var opDecl = module.Operators.Where (op => op.Name == "*^*").FirstOrDefault ();
+			Assert.AreEqual ("*^*", opDecl.Name, "name mismatch");
+			Assert.AreEqual ("AdditionPrecedence", opDecl.PrecedenceGroup, "predence group mismatch");
+			Assert.AreEqual (OperatorType.Infix, opDecl.OperatorType, "operator type mismatch");
+		}
+
+		[Test]
+		public void PrefixOperatorDecl ()
+		{
+			var code = @"prefix operator *^^*
+extension Int {
+	public static prefix func *^^* (lhs: Int) -> Int {
+		return 2 * lhs
+	}
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var opDecl = module.Operators.Where (op => op.Name == "*^^*").FirstOrDefault ();
+			Assert.AreEqual ("*^^*", opDecl.Name, "name mismatch");
+			Assert.IsNull (opDecl.PrecedenceGroup, "predence group mismatch");
+			Assert.AreEqual (OperatorType.Prefix, opDecl.OperatorType, "operator type mismatch");
+		}
+
+		[Test]
+		public void PostfixOperatorDecl ()
+		{
+			var code = @"postfix operator *^&^*
+extension Int {
+	public static postfix func *^&^* (lhs: Int) -> Int {
+		return 2 * lhs
+	}
+}
+";
+			var module = ReflectToModules (code, "SomeModule").Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var opDecl = module.Operators.Where (op => op.Name == "*^&^*").FirstOrDefault ();
+			Assert.AreEqual ("*^&^*", opDecl.Name, "name mismatch");
+			Assert.IsNull (opDecl.PrecedenceGroup, "predence group mismatch");
+			Assert.AreEqual (OperatorType.Postfix, opDecl.OperatorType, "operator type mismatch");
+		}
 	}
 }


### PR DESCRIPTION
It turns out that we need `OperatorDeclaration` in the swiftinterface parser.
Ultimately because Past Steve made use of the predicate `isOperator` in the swift reflector which operates on a function and returns true if the function is an operator. swiftinterface files don't have this information directly (and as it turns out neither does the swift reflector, it just looks like it). As a result, we need to be able mimic that behavior. To do so, I'm added `OperatorDeclaration` to the XmlReflection hierarchy, adding it to the swift reflector and putting it into the type database.

I've upgraded the representation of a module database from `Dictionary<string, Entity>` to a class that inherits from `Dictionary<string, Entity>` which contains a list of all operators. It can't be a hash of names onto OperatorDeclaration because you can have infix, prefix, and postfix operators all with the same name. Maybe in the future I'll change it to a `Dictionary<string, List<OperatorDeclaration>>`, but let's be real: the most populous collection of operators is likely to be in libSwiftCore, for which there are about 60 operators. If I can't search that list in well under a millisecond, then I'm doing something terribly wrong and likely need a time-out.

With this information, we should be able to write a predicate (later): "is there an operator in this module named 'xxxx'?

As a design note, I don't really *like* having `OperatorDeclaration` referenced in the TypeDatabase but it's better than having another type that represents all the same information, I guess.