### PR TITLE
Operator support and tests

### DIFF
--- a/SwiftReflector/TypeMapping/TypeDatabase.cs
+++ b/SwiftReflector/TypeMapping/TypeDatabase.cs
@@ -319,6 +319,18 @@ namespace SwiftReflector.TypeMapping {
 			db.Operators.Add (op);
 		}
 
+		public IEnumerable <OperatorDeclaration> FindOperators (IEnumerable <string> moduleNames)
+		{
+			foreach (var moduleName in moduleNames) {
+				ModuleDatabase db = null;
+				if (!modules.TryGetValue (moduleName, out db))
+					continue;
+				foreach (var op in db.Operators)
+					yield return op;
+			}
+			yield break;
+		}
+
 		void AddEntity (Entity e, ErrorHandling errors)
 		{
 			var swiftName = e.Type.ToFullyQualifiedName (true);

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -10,10 +10,28 @@ using SwiftReflector.SwiftXmlReflection;
 using System.Linq;
 using SwiftReflector;
 using SwiftReflector.SwiftInterfaceReflector;
+using SwiftReflector.TypeMapping;
+using tomwiftytest;
 
 namespace XmlReflectionTests {
 	[TestFixture]
 	public class SwiftInterfaceParserTests {
+
+		static TypeDatabase typeDatabase;
+
+		static SwiftInterfaceParserTests ()
+		{
+			typeDatabase = new TypeDatabase ();
+			foreach (var dbPath in Compiler.kTypeDatabases) {
+				if (!Directory.Exists (dbPath))
+					continue;
+				foreach (var dbFile in Directory.GetFiles (dbPath, "*.xml")) {
+					typeDatabase.Read (dbFile);
+				}
+			}
+		}
+			
+
 		void CompileStringToModule (string code, string moduleName)
 		{
 			Utils.CompileSwift (code, moduleName: moduleName);
@@ -26,7 +44,7 @@ namespace XmlReflectionTests {
 			var file = files.FirstOrDefault (name => name.EndsWith (".swiftinterface", StringComparison.Ordinal));
 			if (file == null)
 				Assert.Fail ("no swiftinterface file");
-			reflector = new SwiftInterfaceReflector ();
+			reflector = new SwiftInterfaceReflector (typeDatabase);
 			return reflector.Reflect (file);
 		}
 
@@ -72,6 +90,70 @@ public func hello ()
 			Assert.AreEqual (2, importModules.Count, "not 2 import modules");
 			Assert.IsNotNull (importModules.FirstOrDefault (s => s == "Swift"), "no Swift import module");
 			Assert.IsNotNull (importModules.FirstOrDefault (s => s == "Foundation"), "no Foundation import module");
+		}
+
+		[Test]
+		public void TypeDatabaseHasOperators ()
+		{
+			var operators = typeDatabase.OperatorsForModule ("Swift");
+			Assert.Less (0, operators.Count (), "no operators");
+		}
+
+		[Test]
+		public void HasGlobalOperator ()
+		{
+			var swiftCode = @"
+import Swift
+public class Imag {
+	public var Real:Float = 0, Imaginary: Float = 0
+
+	public static func == (lhs: Imag, rhs: Imag) -> Bool {
+		return lhs.Real == rhs.Real && lhs.Imaginary == rhs.Imaginary
+	}
+}
+";
+
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var cl = module.Classes.FirstOrDefault (c => c.Name == "Imag");
+			Assert.IsNotNull (cl, "no class");
+
+			var fn = cl.Members.FirstOrDefault (m => m.Name == "==") as FunctionDeclaration;
+			Assert.IsNotNull (fn, "no function");
+
+			Assert.IsTrue (fn.IsOperator, "not an operator");
+			Assert.AreEqual (OperatorType.Infix, fn.OperatorType, "wrong operator type");
+		}
+
+		[Test]
+		public void HasLocalOperator ()
+		{
+			var swiftCode = @"
+postfix operator *^*
+
+public class Imag {
+    public var Real:Float = 0, Imaginary: Float = 0
+    
+    public static postfix func *^* (lhs: Imag) -> Float {
+        return 2 * lhs.Real
+    }
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var cl = module.Classes.FirstOrDefault (c => c.Name == "Imag");
+			Assert.IsNotNull (cl, "no class");
+
+			var fn = cl.Members.FirstOrDefault (m => m.Name == "*^*") as FunctionDeclaration;
+			Assert.IsNotNull (fn, "no function");
+
+			Assert.IsTrue (fn.IsOperator, "not an operator");
+			Assert.AreEqual (OperatorType.Postfix, fn.OperatorType, "wrong operator type");
 		}
 	}
 }


### PR DESCRIPTION
Added operator support for the swiftinterface parser fixing issue [517](https://github.com/xamarin/binding-tools-for-swift/issues/517).

There are some things in here that are going to be non-obvious, but all will be made clear.

When we get a function, we need to know if it is an operator, but we won't know if it's an operator until we have generated all the XML. The reason is this: there are two types of operators: local (in a module) and global. Local operator declarations don't have to appear before they are referenced, so in that case what we do it store all functions that are static attached to a nominal type or are top level functions to look at after the entire file is parsed.

After parsing, we look at all the functions and see if they meet the criteria for being an operator, either local or global, and then modify the function `XElement` to reflect that.

Along the way, I hit a number of minor issues that were preventing the tests from running correctly:
1. no `parameterlists` element in the `property` getter function
2. no `type` in the `property` element
3. extra colon coming through in the property type

Tests as per usual.