### PR TITLE
Tests for extension operators

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1193,7 +1193,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		}
 
 		string [] commonSwiftTypes = {
-			"Double", "Float", "Integer", "String", "Bool",
+			"Double", "Float", "Int", "String", "Bool",
 			"Int64", "Int32", "Int16", "Int8",
 			"UInt64", "Uint32", "UInt16", "UInt8",
 			"Char", "UnsafeMutablePointer", "UnsafePointer",

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -155,5 +155,61 @@ public class Imag {
 			Assert.IsTrue (fn.IsOperator, "not an operator");
 			Assert.AreEqual (OperatorType.Postfix, fn.OperatorType, "wrong operator type");
 		}
+
+		[Test]
+		public void HasExtensionPostfixOperator ()
+		{
+			var swiftCode = @"
+postfix operator *^*
+public extension Int {
+	static postfix func *^* (a: Int) -> Int {
+		return a * 2
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var ext = module.Extensions.FirstOrDefault ();
+			Assert.IsNotNull (ext, "no extensions");
+			var extType = ext.ExtensionOnTypeName;
+			Assert.AreEqual ("Swift.Int", extType, "wrong type");
+			var extFunc = ext.Members [0] as FunctionDeclaration;
+			Assert.IsNotNull (extFunc, "no func");
+			Assert.AreEqual ("*^*", extFunc.Name, "wrong func name");
+			Assert.IsTrue (extFunc.IsOperator, "not an operator");
+			Assert.AreEqual (OperatorType.Postfix, extFunc.OperatorType, "wrong operator type");
+		}
+
+
+		[Test]
+		public void HasExtensionInfixOperator ()
+		{
+			var swiftCode = @"
+infix operator *^*
+public extension Int {
+	static func *^* (lhs: Int, rhs: Int) -> Int {
+		return lhs * 2 + rhs * 2
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var ext = module.Extensions.FirstOrDefault ();
+			Assert.IsNotNull (ext, "no extensions");
+			var extType = ext.ExtensionOnTypeName;
+			Assert.AreEqual ("Swift.Int", extType, "wrong type");
+			var extFunc = ext.Members [0] as FunctionDeclaration;
+			Assert.IsNotNull (extFunc, "no func");
+			Assert.AreEqual ("*^*", extFunc.Name, "wrong func name");
+			Assert.IsTrue (extFunc.IsOperator, "not an operator");
+			Assert.AreEqual (OperatorType.Infix, extFunc.OperatorType, "wrong operator type");
+		}
+
 	}
 }


### PR DESCRIPTION
Thought to my self this morning, "Self, shouldn't you also test operators in extensions?" Yes, yes you should.
Found a bug where I had `Integer` in the extension type table instead of `Int`.