### PR TITLE
Now doing class inheritance correctly.

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -39,6 +39,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		List<XElement> extensions = new List<XElement> ();
 		Dictionary<string, string> moduleFlags = new Dictionary<string, string> ();
 		List<string> nominalTypes = new List<string> ();
+		List<string> classes = new List<string> ();
+		List<XElement> unknownInheritance = new List<XElement> ();
 		string moduleName;
 		TypeDatabase typeDatabase;
 
@@ -88,6 +90,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 				PatchPossibleOperators ();
 				PatchExtensionShortNames ();
+				PatchPossibleBadInheritance ();
 
 				module.Add (new XAttribute ("name", moduleName));
 				SetLanguageVersion (module);
@@ -847,6 +850,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				var elem = new XElement ("inherit", new XAttribute ("type", list.type_identifier ().GetText ()),
 					new XAttribute (nameof (inheritanceKind), inheritanceKind));
 				inheritance.Add (elem);
+				if (inheritanceKind == "unknown")
+					unknownInheritance.Add (elem);
 				list = list.type_inheritance_list ();
 			}
 
@@ -908,6 +913,25 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					func.Item2.SetAttributeValue (nameof (operatorKind), operatorKind.ToString ());
 				}
 			}
+		}
+
+		void PatchPossibleBadInheritance ()
+		{
+			foreach (var inh in unknownInheritance) {
+				var type = inh.Attribute ("type").Value;
+				if (IsLocalClass (type) || IsGlobalClass (type))
+					inh.Attribute ("inheritanceKind").Value = "class";
+			}
+		}
+
+		bool IsLocalClass (string typeName)
+		{
+			return classes.Contains (typeName);
+		}
+
+		bool IsGlobalClass (string typeName)
+		{
+			return typeDatabase.EntityForSwiftName (typeName) != null;
 		}
 
 		void PatchExtensionShortNames ()
@@ -1189,6 +1213,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		void RegisterNominal (XElement elem)
 		{
+			var isClass = elem.Attribute ("kind").Value == "class";
 			var builder = new StringBuilder ();
 			while (elem != null) {
 				if (builder.Length > 0)
@@ -1197,7 +1222,10 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				builder.Insert (0, namePart);
 				elem = elem.Parent;
 			}
-			nominalTypes.Add (builder.ToString ());
+			var typeName = builder.ToString ();
+			nominalTypes.Add (typeName);
+			if (isClass)
+				classes.Add (typeName);
 		}
 
 		void AddAssociatedTypeToCurrentElement (XElement elem)

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -931,7 +931,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		bool IsGlobalClass (string typeName)
 		{
-			return typeDatabase.EntityForSwiftName (typeName) != null;
+			return typeDatabase.EntityForSwiftName (typeName)?.EntityType == EntityType.Class;
 		}
 
 		void PatchExtensionShortNames ()

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -211,5 +211,56 @@ public extension Int {
 			Assert.AreEqual (OperatorType.Infix, extFunc.OperatorType, "wrong operator type");
 		}
 
+		[Test]
+		public void InheritanceKindIsClass ()
+		{
+			var swiftCode = @"
+public class Foo {
+	public init () { }
+}
+
+public class Bar : Foo {
+	public override init () { }
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var cl = module.Classes.Where (c => c.Name == "Bar").FirstOrDefault ();
+			Assert.IsNotNull (cl, "no class");
+			Assert.AreEqual (1, cl.Inheritance.Count, "wrong amount of inheritance");
+			var inh = cl.Inheritance [0];
+			Assert.AreEqual (InheritanceKind.Class, inh.InheritanceKind, "wrong inheritance kind");
+		}
+
+		[Test]
+		public void CompoundInheritanceKindIsClass ()
+		{
+			var swiftCode = @"
+public protocol Nifty { }
+
+public class Foo {
+	public init () { }
+}
+
+public class Bar : Foo, Nifty {
+	public override init () { }
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (swiftCode, "SomeModule", out reflector).FirstOrDefault (m => m.Name == "SomeModule");
+
+			Assert.IsNotNull (module, "no module");
+
+			var cl = module.Classes.Where (c => c.Name == "Bar").FirstOrDefault ();
+			Assert.IsNotNull (cl, "no class");
+			Assert.AreEqual (2, cl.Inheritance.Count, "wrong amount of inheritance");
+			var inh = cl.Inheritance [0];
+			Assert.AreEqual (InheritanceKind.Class, inh.InheritanceKind, "wrong inheritance kind from class");
+			inh = cl.Inheritance [1];
+			Assert.AreEqual (InheritanceKind.Protocol, inh.InheritanceKind, "wrong inheritance kind from protocol");
+		}
 	}
 }


### PR DESCRIPTION
Now correcting class inheritance, fixing but [521](https://github.com/xamarin/binding-tools-for-swift/issues/521).

This is another case of "when we needed the answer to a question, the information might not be there yet".

We need to distinguish between class and protocol inheritance for classes. The first element in an inheritance list **might** be a class, but may not know at the point when we encounter the inheritance.  To handle this, we store the fully qualified names of all the classes we encounter and all the inheritance nodes that are ambiguous. After the parse, we loop through the ambiguous nodes and try to find them either locally or globally as classes. If they're classes, set the inheritance to class, otherwise assume that it's a protocol.

Test as per usual.