### PR TITLE
Add the capability to load modules at runtime

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/IModuleLoader.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/IModuleLoader.cs
@@ -14,7 +14,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 	public class NoLoadLoader : IModuleLoader {
 		public NoLoadLoader ()
 		{
-
 		}
 
 		public bool Load (string moduleName, TypeDatabase into)

--- a/SwiftReflector/SwiftInterfaceReflector/IModuleLoader.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/IModuleLoader.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using SwiftReflector.TypeMapping;
+
+namespace SwiftReflector.SwiftInterfaceReflector {
+	public interface IModuleLoader {
+		bool Load (string moduleName, TypeDatabase into);
+	}
+
+	// this is only useful for tests, really.
+	public class NoLoadLoader : IModuleLoader {
+		public NoLoadLoader ()
+		{
+
+		}
+
+		public bool Load (string moduleName, TypeDatabase into)
+		{
+			// only returns true is the module is already loaded
+			return into.ModuleNames.Contains (moduleName);			
+		}
+	}
+}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -179,6 +179,7 @@
     <Compile Include="SwiftInterfaceReflector\ParseException.cs" />
     <Compile Include="SwiftXmlReflection\OperatorDeclaration.cs" />
     <Compile Include="TypeMapping\ModuleDatabase.cs" />
+    <Compile Include="SwiftInterfaceReflector\IModuleLoader.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -44,7 +44,7 @@ namespace XmlReflectionTests {
 			var file = files.FirstOrDefault (name => name.EndsWith (".swiftinterface", StringComparison.Ordinal));
 			if (file == null)
 				Assert.Fail ("no swiftinterface file");
-			reflector = new SwiftInterfaceReflector (typeDatabase);
+			reflector = new SwiftInterfaceReflector (typeDatabase, new NoLoadLoader ());
 			return reflector.Reflect (file);
 		}
 
@@ -261,6 +261,19 @@ public class Bar : Foo, Nifty {
 			Assert.AreEqual (InheritanceKind.Class, inh.InheritanceKind, "wrong inheritance kind from class");
 			inh = cl.Inheritance [1];
 			Assert.AreEqual (InheritanceKind.Protocol, inh.InheritanceKind, "wrong inheritance kind from protocol");
+		}
+
+		[Test]
+		public void WontLoadThisModuleHere ()
+		{
+			var swiftCode = @"
+import AVKit
+public class Bar {
+	public init () { }
+}
+";
+			SwiftInterfaceReflector reflector;
+			Assert.Throws<ParseException> (() => ReflectToModules (swiftCode, "SomeModule", out reflector));
 		}
 	}
 }


### PR DESCRIPTION
Added code to allow the reflector to load module fixing issue [538](https://github.com/xamarin/binding-tools-for-swift/issues/538).

Simple - just added an interface defining one method for loading modules later.
When fully integrated, the calling code will have access to places to look for binding locations to bring in referenced modules (if needed).

Made a basic loader for testing purposes that doesn't actually load anything but returns `true` for any module that we already know about.

The only test I put in ensures that a referenced module that we don't know about fires an error.