### PR TITLE
Read XML into attributes.

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1006,7 +1006,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				return label;
 			}
 
-
 			return null;
 		}
 

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -104,7 +104,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		internal const string kLabel = "Label";
 		internal const string kLiteral = "Literal";
 		internal const string kSeparator = "Separator";
-		internal const string kVersion = "Version";
 		internal const string kSublist = "Sublist";
 		internal const string kValue = "Value";
 
@@ -994,10 +993,19 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				return literal;
 			}
 
-			if (context.Platform_name_platform_version () != null) {
-				var version = new XElement (kAttribute, new XAttribute (kKind, kVersion),
-					new XAttribute (kValue, context.Platform_name_platform_version ().GetText ()));
+			// make the operator look like a label
+			if (context.@operator () != null) {
+				var label = new XElement (kAttributeParameter, new XAttribute (kKind, kLabel),
+					new XAttribute (kValue, context.@operator ().GetText ()));
+				return label;
 			}
+
+			if (context.any_punctuation_for_balanced_token () != null) {
+				var label = new XElement (kAttributeParameter, new XAttribute (kKind, kLabel),
+					new XAttribute (kValue, context.any_punctuation_for_balanced_token ().GetText ()));
+				return label;
+			}
+
 
 			return null;
 		}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -180,6 +180,7 @@
     <Compile Include="SwiftXmlReflection\OperatorDeclaration.cs" />
     <Compile Include="TypeMapping\ModuleDatabase.cs" />
     <Compile Include="SwiftInterfaceReflector\IModuleLoader.cs" />
+    <Compile Include="SwiftXmlReflection\AttributeDeclaration.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/SwiftXmlReflection/AttributeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/AttributeDeclaration.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Dynamo;
+using System.Linq;
+
+namespace SwiftReflector.SwiftXmlReflection {
+	public class AttributeDeclaration {
+		public AttributeDeclaration (string name)
+		{
+			Name = Exceptions.ThrowOnNull (name, nameof (name));
+			Parameters = new List<AttributeParameter> ();
+		}
+
+		public AttributeDeclaration (AttributeDeclaration other)
+			: this (other.Name)
+		{
+			foreach (var parameter in other.Parameters)
+				Parameters.Add (DuplicateOf (parameter));
+		}
+
+		public static AttributeDeclaration FromXElement (XElement elem)
+		{
+			var decl = new AttributeDeclaration (elem.Attribute ("name").Value);
+			var parameters = elem.Element ("attributeparameterlist");
+			if (parameters == null)
+				return decl;
+			FromAttributeParameterList (parameters, decl.Parameters);
+			return decl;
+		}
+
+		internal static void FromAttributeParameterList (XElement parameters, List<AttributeParameter> outlist)
+		{
+			foreach (var parameterElem in parameters.Elements ("attributeparameter")) {
+				var parameter = AttributeParameter.FromXElement (parameterElem);
+				outlist.Add (parameter);
+			}
+		}
+
+		public static AttributeParameter DuplicateOf(AttributeParameter other)
+		{
+			switch (other.Kind) {
+			case AttributeParameterKind.Label:
+				return new AttributeParameterLabel ((AttributeParameterLabel)other);
+			case AttributeParameterKind.Literal:
+				return new AttributeParameterLiteral ((AttributeParameterLiteral)other);
+			case AttributeParameterKind.Sublist:
+				return new AttributeParameterSublist ((AttributeParameterSublist)other);
+			case AttributeParameterKind.Unknown:
+				return new AttributeParameter ();
+			default:
+				throw new ArgumentOutOfRangeException (nameof (other), other.Kind.ToString ());
+			}
+		}
+
+		public string Name { get; private set; }
+		public List<AttributeParameter> Parameters { get; private set; }
+	}
+
+	public class AttributeParameter {
+		public static AttributeParameter FromXElement (XElement elem)
+		{
+			switch (elem.Attribute ("kind").Value) {
+			case "Label":
+				return new AttributeParameterLabel (elem.Attribute ("Value").Value);
+			case "Literal":
+				return new AttributeParameterLiteral (elem.Attribute ("Value").Value);
+			case "Sublist":
+				return AttributeParameterSublist.SublistFromXElement (elem);
+			default:
+				return new AttributeParameter ();
+			}
+		}
+
+		public virtual AttributeParameterKind Kind => AttributeParameterKind.Unknown;
+	}
+
+	public class AttributeParameterLabel : AttributeParameter {
+		public AttributeParameterLabel (string label)
+		{
+			Label = Exceptions.ThrowOnNull (label, nameof (label));
+		}
+
+		public AttributeParameterLabel (AttributeParameterLabel other)
+			: this (other.Label)
+		{
+		}
+
+		public override AttributeParameterKind Kind => AttributeParameterKind.Label;
+		public string Label { get; private set; }
+	}
+
+	public class AttributeParameterLiteral : AttributeParameter {
+		public AttributeParameterLiteral (string literal)
+		{
+			Literal = Exceptions.ThrowOnNull (literal, nameof (literal));
+		}
+
+		public AttributeParameterLiteral (AttributeParameterLiteral other)
+			: this (other.Literal)
+		{
+		}
+
+		public override AttributeParameterKind Kind => AttributeParameterKind.Literal;
+		public string Literal { get; private set; }
+	}
+
+	public class AttributeParameterSublist : AttributeParameter {
+		public AttributeParameterSublist ()
+		{
+			Parameters = new List<AttributeParameter> ();
+		}
+
+		public AttributeParameterSublist (AttributeParameterSublist other)
+			: this ()
+		{
+			Parameters.AddRange (other.Parameters.Select (prm => AttributeDeclaration.DuplicateOf (prm)));
+		}
+
+		public static AttributeParameterSublist SublistFromXElement (XElement elem)
+		{
+			var sublist = new AttributeParameterSublist ();
+			var parameters = elem.Element ("attributeparameterlist");
+			if (parameters == null)
+				return sublist;
+			AttributeDeclaration.FromAttributeParameterList (parameters, sublist.Parameters);
+			return sublist;
+		}
+
+		public override AttributeParameterKind Kind => AttributeParameterKind.Sublist;
+		public List<AttributeParameter> Parameters { get; private set; }
+	}
+}

--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -15,6 +15,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		protected BaseDeclaration ()
 		{
 			Generics = new GenericDeclarationCollection ();
+			Attributes = new List<AttributeDeclaration> ();
 		}
 
 		protected BaseDeclaration (BaseDeclaration other)
@@ -25,6 +26,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			Parent = other.Parent;
 			ParentExtension = other.ParentExtension;
 			Generics = new GenericDeclarationCollection ();
+			Attributes = new List<AttributeDeclaration> ();
 		}
 
 		public string Name { get; set; }
@@ -39,6 +41,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				return Generics.Count () > 0;
 			}
 		}
+		public List<AttributeDeclaration> Attributes { get; private set; }
 
 		public bool IsTypeSpecBoundGeneric (TypeSpec sp)
 		{
@@ -499,7 +502,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 				break;
 			}
 			decl.Generics.AddRange (generics);
+			decl.Attributes.AddRange (AttributesFromXElement (elem.Element ("attributes")));
 			return decl;
+		}
+
+		internal static IEnumerable<AttributeDeclaration> AttributesFromXElement (XElement elem)
+		{
+			if (elem == null)
+				return Enumerable.Empty<AttributeDeclaration> ();
+			return elem.Elements ("attribute").Select (attr => AttributeDeclaration.FromXElement (attr));
 		}
 
 		public virtual string ToFullyQualifiedName (bool includeModule = true)

--- a/SwiftReflector/SwiftXmlReflection/Enums.cs
+++ b/SwiftReflector/SwiftXmlReflection/Enums.cs
@@ -70,5 +70,13 @@ namespace SwiftReflector.SwiftXmlReflection {
 		Inherits,
 		Equal
 	}
+
+	public enum AttributeParameterKind {
+		None,
+		Label,
+		Literal,
+		Sublist,
+		Unknown,
+	}
 }
 

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -291,7 +291,7 @@ balanced_token :
 	| OpLBrace balanced_tokens OpRBrace
 	| label_identifier
 	| literal
-	| Platform_name_platform_version
+	| operator
 	| any_punctuation_for_balanced_token
 	;
 
@@ -464,23 +464,6 @@ fragment Identifier_character : [0-9]
 fragment Identifier_characters : Identifier_character+ ;
 
 Implicit_parameter_name : '$' Decimal_digits ;
-
-Platform_name_platform_version : Platform_name WS Platform_version ;
-
-fragment Platform_name : 
-	'iOS'
-	| 'iOSApplicationExtension'
-	| 'macOS'
-	| 'macOSApplicationExtension'
-	| 'watchOS'
-	| 'tvOS'
-	;
-
-fragment Platform_version :
-	Pure_decimal_digits
-	| Pure_decimal_digits OpDot Pure_decimal_digits
-	| Pure_decimal_digits OpDot Pure_decimal_digits OpDot Pure_decimal_digits
-	;
 
 generic_parameter_clause : OpLess generic_parameter_list OpGreater  ;
 generic_parameter_list : generic_parameter (OpComma generic_parameter)*  ;


### PR DESCRIPTION
Added an `AttributeDeclaration` type in order to round-trip attributes.

An attribute in swift is simultaneously overly complicated and inflexible.
The syntax is an @ sign followed by a name followed by an optional argument set off by parens.
What can go in the parens is a seamy, inconsistent set of junk that can included nested lists set off by parentheses, brackets, or braces (as long as they balance).
Examples:
```
@foo
@available(swift *)
@available(iOS 14.*, unavailable, macOS *, available)
@someotherthing(foo: bar, baz: [15 .. 20], "a string because why not")
```
And the contents of the parentheses is determined entirely by the name of the attribute.

So how should we represent this in C#? We get an AttributeDeclaration which has a name and an optional list of parameters.
A parameter is one of a plain AttributeParameter (should never happen), an AttributeParameterLabel (any non-number), an AttributeParameterLiteral (a number), an AttributeParameterSublist.

The XML consumption code is straightforward, although I'm sure it could be better where the right set of attributes/names would make it just read in on its own (cue "old man shouts at clouds" meme).

I added a List<AttributesDeclaration> to the `BaseDeclaration` and therefore attributes are now available on classes, structs, enums, protocols, properties, and functions (take that, anti-inheritance people!).

In addition, the original grammar definition tried to break out a separate rule for platform and version, but it was broken and couldn't handle wild cards, so I got rid of it entirely and got rid of the version parameter. I also made separators and operators get treated as labels. There really isn't any advantage to having those broken out right now (if ever).
