### PR TITLE
Added isUnavailable and isDeprecated

### DIFF
--- a/SwiftReflector/Extensions.cs
+++ b/SwiftReflector/Extensions.cs
@@ -72,9 +72,9 @@ namespace SwiftReflector {
 
 			if (parts [shortestIndex].Length == 0) {
 				var missingPart = new string [] { "cpu", "platform", "os", "os" } [shortestIndex];
-				throw new ArgumentException ($"target (cpu-platform-os) has an empty {missingPart} component.", nameof (s));
+				throw new ArgumentException ($"target (cpu-platform-os) has an empty {missingPart} component.");
 			}
-																				  new string [] { "cpu", "platform", "os" } [shortest]));
+																			
 			return parts;
 		}
 

--- a/SwiftReflector/Extensions.cs
+++ b/SwiftReflector/Extensions.cs
@@ -62,14 +62,26 @@ namespace SwiftReflector {
 			if (String.IsNullOrEmpty (s))
 				throw new ArgumentNullException (nameof (s));
 			string [] parts = s.Split ('-');
-			if (parts.Length != 3)
+			// catalyst adds cpu-platform-ios-macabi
+			if (parts.Length != 3 && parts.Length != 4)
 				throw new ArgumentOutOfRangeException (nameof (s), s, "target should be in the form cpu-platform-os");
-			int shortest = parts [0].Length < Math.Min (parts [1].Length, parts [2].Length) ? 0
-			                        : (parts [1].Length < Math.Min (parts [0].Length, parts [1].Length) ? 1 : 2);
-			if (parts [shortest].Length == 0)
-				throw new ArgumentOutOfRangeException (nameof (s), s, String.Format ("target (cpu-platform-os) has an empty {0} component.",
+
+			var shortestIndex = parts.Length == 3 ?
+				IndexOfMin (parts [0].Length, parts [1].Length, parts [2].Length) :
+				IndexOfMin (parts [0].Length, parts [1].Length, parts [2].Length, parts [3].Length);
+
+			if (parts [shortestIndex].Length == 0) {
+				var missingPart = new string [] { "cpu", "platform", "os", "os" } [shortestIndex];
+				throw new ArgumentException ($"target (cpu-platform-os) has an empty {missingPart} component.", nameof (s));
+			}
 																				  new string [] { "cpu", "platform", "os" } [shortest]));
 			return parts;
+		}
+
+		static int IndexOfMin (params int [] values)
+		{
+			var min = values.Min ();
+			return Array.IndexOf (values, min);
 		}
 
 		public static string ClangTargetCpu (this string s)
@@ -84,7 +96,12 @@ namespace SwiftReflector {
 
 		public static string ClangTargetOS (this string s)
 		{
-			return s.DecomposeClangTarget () [2];
+			var clangTarget = s.DecomposeClangTarget ();
+			if (clangTarget.Length == 3)
+				return clangTarget [2];
+			if (clangTarget.Length == 4)
+				return $"{clangTarget [2]}-{clangTarget [3]}";
+			throw new ArgumentException ($"Clang target {s} should have 3 or 4 parts", nameof (s));
 		}
 
 		public static void Merge<T> (this HashSet<T> to, IEnumerable<T> from)

--- a/SwiftReflector/SwiftInterfaceReflector/ObjCSelectorFactory.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/ObjCSelectorFactory.cs
@@ -168,7 +168,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				return null;
 			var sb = new StringBuilder ();
 			foreach (var piece in parameters) {
-				sb.Append (piece.Attribute (SwiftInterfaceReflector.kValue));
+				sb.Append (piece.Attribute (SwiftInterfaceReflector.kValue)?.Value ?? "");
 			}
 			return sb.ToString ();
 		}

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1312,12 +1312,14 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				return true;
 			case "iOS":
 			case "iOSApplicationExtension":
-				return currentPlatform.StartsWith ("ios", StringComparison.Ordinal);
+				return currentPlatform.StartsWith ("ios", StringComparison.Ordinal) &&
+					!currentPlatform.StartsWith ("ios-macabi", StringComparison.Ordinal);
 			case "macOS":
 			case "macOSApplicationExtension":
+				return currentPlatform.StartsWith ("macos", StringComparison.Ordinal);
 			case "macCatalyst":
 			case "macCatalystExtension":
-				return currentPlatform.StartsWith ("macos", StringComparison.Ordinal);
+				return currentPlatform.StartsWith ("ios-macabi", StringComparison.Ordinal);
 			case "watchOS":
 			case "watchOSApplicationExtension":
 				return currentPlatform.StartsWith ("watch", StringComparison.Ordinal);


### PR DESCRIPTION
Added calculations for `isUnavailable` and `isDeprecated` fixing issue [519](https://github.com/xamarin/binding-tools-for-swift/issues/519).

I handled `isUnavailable` and `isDeprecated` wrong in the swift reflector and it should go away, but we have code that depends on it, so here we are. In the reflector, these values are taken from the compiler and there is apparently a lot more work that needs to have to figure them out and they only represent a snapshot of what is happening for the compiler settings currently.

In reality, there is a lot more information. The best explanation I found of the `@available` attribute is [here](https://nshipster.com/available/), but I'll sum up.

There are two versions of `@available`, longhand and shorthand. Shorthand looks like this:
```
@available(platform vers[, platform vers]*, *)
```
So if you see this:
```
@available(macOS 10.0, iOS 12.2.1, *)
```
it is exactly equivalent to this:
```
@available(macOS, introduced: 10.0)
@available(iOS, introduces: 12.2.1)
```

Longhand looks like this:
```
@available(platform[, keyword: arg][, unavailable])
```
where `keyword` is one of `introduced`, `deprecated`, `obsoleted`, `message` `renamed`. The last two take a string. The rest take an optional version number.

Deprecated is pretty easy. If it's longhand and the OS matches and it contains deprecated and the version number isn't present or the version number is less than or equal to the OS version setting.

Unavailable is trickier. If the attribute contains `unavailable` and the OS matches then it's unavailable or it's not available.
It's available if it was introduced before the OS version specified, but we have to check for both shorthand and longhand.

A lot of this code does a lot of digging in and parsing and making assumptions about the layout of things and frankly it gives me the screaming heebie-jeebies. One such area is getting a `Version` from the attribute which may or may not be present. There are assumptions such as when in shorthand, you will always see a comma after the version since the last element of shorthand has to be ", *". For longhand, you will see either `key: version,` or `key, otherkey` or `key` (where this is the last element of the list). So we look for the index of the first `:` after the key. If there we hit a comma first or reach the end of tags, then we use Version 0.0, which means since the beginning of time which is good enough.

In the process, I found an error in two unit tests with ObjC selectors and the caseness of the `Public` `Private` labels and they were minor so I just fixed them here since they were preventing the tests that I wrote from passing.
