### PR TITLE
desugar types

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -166,7 +166,10 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				var module = new XElement (kModule);
 				currentElement.Push (module);
 
-				var charStream = CharStreams.fromPath (inFile);
+				var desugarer = new SyntaxDesugaringParser (inFile);
+				var desugaredResult = desugarer.Desugar ();
+				var charStream = CharStreams.fromString (desugaredResult);
+
 				var lexer = new SwiftInterfaceLexer (charStream);
 				var tokenStream = new CommonTokenStream (lexer);
 				var parser = new SwiftInterfaceParser (tokenStream);
@@ -723,6 +726,11 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			operators.Add (operatorElement);
 
 			currentElement.Peek ().Add (operatorElement);
+		}
+
+		public override void EnterOptional_type ([NotNull] Optional_typeContext context)
+		{
+			var innerType = context.type ().GetText ();
 		}
 
 		XElement InfixOperator (Infix_operator_declarationContext context)

--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Tree;
+using static SwiftInterfaceParser;
+
+namespace SwiftReflector.SwiftInterfaceReflector {
+	public class SyntaxDesugaringParser : SwiftInterfaceBaseListener {
+		TokenStreamRewriter rewriter;
+		SwiftInterfaceParser parser;
+		ICharStream charStream;
+		SwiftInterfaceLexer lexer;
+
+		public SyntaxDesugaringParser (string inFile)
+		{
+			charStream = CharStreams.fromPath (inFile);
+			lexer = new SwiftInterfaceLexer (charStream);
+			var tokenStream = new CommonTokenStream (lexer);
+
+			rewriter = new TokenStreamRewriter (tokenStream);
+			this.parser = new SwiftInterfaceParser (tokenStream);
+		}
+
+		public string Desugar ()
+		{
+			var walker = new ParseTreeWalker ();
+			walker.Walk (this, parser.swiftinterface ());
+			return rewriter.GetText ();
+		}
+
+		public override void ExitOptional_type ([NotNull] Optional_typeContext context)
+		{
+			var innerType = context.type ().GetText ();
+			var replacementType = $"Swift.Optional<{innerType}>";
+			var startToken = context.Start;
+			var endToken = context.Stop;
+			rewriter.Replace (startToken, endToken, replacementType);
+		}
+
+		public override void ExitArray_type ([NotNull] Array_typeContext context)
+		{
+			var innerType = context.type ().GetText ();
+			var replacementType = $"Swift.Array<{innerType}>";
+			var startToken = context.Start;
+			var endToken = context.Stop;
+			rewriter.Replace (startToken, endToken, replacementType);
+		}
+
+		public override void ExitDictionary_type ([NotNull] Dictionary_typeContext context)
+		{
+			var keyType = context.children [1].GetText ();
+			var valueType = context.children [3].GetText ();
+			var replacementType = $"Swift.Dictionary<{keyType},{valueType}>";
+			var startToken = context.Start;
+			var endToken = context.Stop;
+			rewriter.Replace (startToken, endToken, replacementType);
+		}
+	}
+}
+

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -182,6 +182,7 @@
     <Compile Include="SwiftInterfaceReflector\IModuleLoader.cs" />
     <Compile Include="SwiftXmlReflection\AttributeDeclaration.cs" />
     <Compile Include="SwiftInterfaceReflector\ObjCSelectorFactory.cs" />
+    <Compile Include="SwiftInterfaceReflector\SyntaxDesugaringParser.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -351,18 +351,18 @@ function_type_argument :
 argument_label : label_identifier ;
 
 type : 
-	array_type
-	| dictionary_type
-	| function_type
-	| type_identifier
-	| tuple_type
-	| type OpQuestion
-	| type OpBang
-	| protocol_composition_type
-	| type OpDot 'Type'
-	| type OpDot 'Protocol'
-	| 'Any'
-	| 'Self'
+	array_type # arr_type
+	| dictionary_type # dict_type
+	| function_type # func_type
+	| type_identifier # identifier_type
+	| tuple_type # tup_type
+	| type OpQuestion # optional_type
+	| type OpBang # unwrapped_optional_type
+	| protocol_composition_type # proto_comp_type
+	| type OpDot 'Type' # meta_type
+	| type OpDot 'Protocol' # proto_type
+	| 'Any' # any_type
+	| 'Self' # self_type
 	;
 
 type_annotation : OpColon attributes? inout_clause? type ;
@@ -487,7 +487,7 @@ arrow_operator : '->' ;
 range_operator : '...' ;
 
 
-WS : [ \n\r\t\u000B\u000C\u0000]+ -> skip ;
+WS : [ \n\r\t\u000B\u000C\u0000]+ -> channel(HIDDEN) ;
 
 OpPlus : '+' ;
 OpMinus : '-' ;

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -260,14 +260,15 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Need to desugar dictionaries")]
+		[TestCase (ReflectorMode.Parser)]
 		public void FuncReturningDictionary (ReflectorMode mode)
 		{
 			ModuleDeclaration module = ReflectToModules ("public func returnDict()->[Int:Float] { return [Int:Float](); }", "SomeModule", mode)
 				.Find (m => m.Name == "SomeModule");
 			Assert.NotNull (module, "not module");
 			FunctionDeclaration func = module.Functions.FirstOrDefault (f => f.Name == "returnDict");
-			Assert.AreEqual ("Swift.Dictionary<Swift.Int, Swift.Float>", func.ReturnTypeName, "wrong type");
+			var returnType = func.ReturnTypeName.Replace (" ", "");
+			Assert.AreEqual ("Swift.Dictionary<Swift.Int,Swift.Float>", returnType, "wrong type");
 		}
 
 
@@ -287,7 +288,7 @@ namespace XmlReflectionTests {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Need to desugar optionals")]
+		[TestCase (ReflectorMode.Parser)]
 		public void FuncReturningIntOption (ReflectorMode mode)
 		{
 			ModuleDeclaration module = ReflectToModules ("public func returnIntOpt()->Int? { return 3; }", "SomeModule", mode)

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -601,5 +601,56 @@ public class Foo : NSObject {
 			Assert.IsTrue (cl.IsDeprecated, "not deprecated");
 			Assert.IsFalse (cl.IsUnavailable, "available");
 		}
+
+		[Test]
+		public void OptionalType ()
+		{
+			string code = @"
+public func foo (a: Bool) -> Int? {
+    return a ? 42 : nil
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			var retType = fn.ReturnTypeName;
+			Assert.AreEqual ("Swift.Optional<Swift.Int>", retType, "wrong return");
+		}
+
+		[Test]
+		public void DictionaryType ()
+		{
+			string code = @"
+public func foo () -> [Int:Int] {
+    return Dictionary<Int, Int>()
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			var retType = fn.ReturnTypeName;
+			Assert.AreEqual ("Swift.Dictionary<Swift.Int,Swift.Int>", retType, "wrong return");
+		}
+
+		[Test]
+		public void ArrayType ()
+		{
+			string code = @"
+public func foo () -> [Int] {
+    return Array<Int>()
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			var retType = fn.ReturnTypeName;
+			Assert.AreEqual ("Swift.Array<Swift.Int>", retType, "wrong return");
+		}
 	}
 }


### PR DESCRIPTION
Desugar arrays, dictionaries, and optionals fixing issue [552](https://github.com/xamarin/binding-tools-for-swift/issues/552)

This is actually really cool. It's akin to driving in a nail with an extremely big hammer, but (1) it's actually really easy to do this in antlr and (2) it's really the only reasonable 100% solution. Anything else is substantially harder.

What do we do? We write another listener. Antlr has the facility to replace tokens in a stream. So conceptually, when we're in a rule that has recognized say `SomeType?` we can replace the set of token for that with the text `Swift.Optional<SomeType>`. Then we get the text from the replacement and use that for the main parse instead of the original file.

The only other solution is to write an extension method the base context type which gets the text desugared if it needs desugaring and make sure we use that *always* instead of the `GetText()` method. If performance turns out to be an issue, I may switch to this, but honestly, it runs pretty quickly.

Ultimately, this is something that still may need to be done for `typealias` in order to get that to work properly.

Weird things:
previously, I skipped white space in the stream. This can't be done anymore because rewriting the string removes the white space. Instead, it gets directed to a hidden channel which gets used when rewriting the stream.

It's kind of a hassle to identify the individual cases for a parse rule that has many sub rules, especially since C# doesn't have discriminated unions. The way around this is to tag the cases with a `# name` and then antlr magically makes a listener for that rule.

Tests as per usual.
