### PR TITLE
Fixing mismatched parameter names

### DIFF
--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -188,7 +188,7 @@ namespace SwiftReflector {
 				locations.DisposeAll ();
 			}
 			ThrowOnCompilerVersionMismatch (output, moduleNames);
-			using (var stm = new FileStream (output, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+			using (var stm = new FileStream (pathName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
 				return XDocument.Load (stm);
 			}
 		}

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -984,7 +984,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Parameter is coming back '_' should be blank")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestNotRequiredParamName (ReflectorMode mode)
 		{
 			string code = "public func foo(_ seen:Int) { }\n";
@@ -1084,7 +1084,7 @@ public class Container {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "not handling convenience modifier")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestConvenienceCtor (ReflectorMode mode)
 		{
 			var code = @"
@@ -1337,7 +1337,7 @@ public protocol HoldsThing {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "incorrect '-' on arg a")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestTLFuncOneArgSamePubPrivReturnsInt (ReflectorMode mode)
 		{
 			var code = @"public func SomeFunc (a: Int) -> Int { return a; }";
@@ -1376,7 +1376,7 @@ public protocol HoldsThing {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "incorrect '-' on arg a and b")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestTLFuncTwoArgSamePubPrivReturnsInt (ReflectorMode mode)
 		{
 			var code = @"public func SomeFunc (a: Int, b: Int) -> Int { return a + b; }";


### PR DESCRIPTION
Fix parameter naming, correcting issue [551](https://github.com/xamarin/binding-tools-for-swift/issues/551)

Oh, boy do I hate swift parameter naming.
Background:
swift lets you name parameters in 3 different ways:
```
a b: type
_ b: type
a: type
```
If there was no explicit public name (third case), I was putting in "_" which is wrong.
In my world, I keep the public names and private names like this per case:
1. "a" "b"
2. "" "b"
3. "a" "a"

Where it gets "funny" is for subscripts which have implicitly empty public argument names and for some reason (really, don't ask me), I want them to be "_". *facepalm*

This brings 4 tests online.

