### PR TITLE
make enums more complete, remove NRE

### DIFF
--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -273,7 +273,7 @@ namespace XmlReflectionTests {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void FuncReturningIntThrows (ReflectorMode mode)
 		{
 			ModuleDeclaration module = ReflectToModules ("public enum MathError : Error {\ncase divZero\n}\n" +
@@ -310,7 +310,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest1 (ReflectorMode mode)
 		{
 			string code = "public enum foo { case a, b, c, d }";
@@ -326,7 +326,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest2 (ReflectorMode mode)
 		{
 			string code = "public enum foo { case a(Int), b(Int), c(Int), d(Int) }";
@@ -346,7 +346,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest3 (ReflectorMode mode)
 		{
 			string code = "public enum foo { case a(UInt), b(Int), c(Int), d(Int) }";
@@ -366,7 +366,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest4 (ReflectorMode mode)
 		{
 			string code = "public enum foo { case a(Int), b, c, d }";
@@ -386,7 +386,7 @@ namespace XmlReflectionTests {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest5 (ReflectorMode mode)
 		{
 			string code = "public enum foo:Int { case a=1, b, c, d }";
@@ -404,7 +404,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest6 (ReflectorMode mode)
 		{
 			string code = "public enum foo:Int { case a, b, c, d }";
@@ -422,7 +422,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumSmokeTest7 (ReflectorMode mode)
 		{
 			string code = "public enum foo { case a(UInt), b(Int), c(Bool), d(Float) }";
@@ -755,7 +755,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "NRE parsing XML")]
+		[TestCase (ReflectorMode.Parser, Ignore = "Unable to find setter, possible grammar error")]
 		public void PropertyVisibility (ReflectorMode mode)
 		{
 			PropertyVisibilityCore ("open", Accessibility.Open, mode);


### PR DESCRIPTION
Fixes an NRE in XML parsing of enums, issue [553](https://github.com/xamarin/binding-tools-for-swift/issues/553).

To look at this, there were two missing pieces in enums: the cases and the raw value type.

For the cases, there are two broad varieties: a raw value enum type and a union enum type, but both of these have the same structure: in the Enter event of each of these, grab the cases and bundle them up into an elements tag and add that to the current enum. Since they can come out of order, if the elements tag already exists in the parent enum, we just add in the contents.

Converting union enums is...funny. This is because the syntax is fairly broad:
`union_style_enum_case : enum_case_name tuple_type? ;`
So you can have a full tuple syntax which is cool and all, except that in most cases it's a single type, but it gets expressed as a single element tuple. In that case, we strip out the parentheses and if there is a label on the type, we strip that too.

The exciting part here is swift allows some really...unusual types as a single tuple including:
```
case foo (())
case bar (bar:())
case baz (((((())))))
case this_is_illegal() // syntax error
```
If the enum is a trivial enum, there will be a raw value as a type alias that we dig out and put into an attribute.

Previously ignored NRE tests pass.