### PR TITLE
no colons thanks

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -891,7 +891,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			if (context == null)
 				return null;
-			return GeneralOperator (kInfix, context.@operator (), context.infix_operator_group ()?.GetText () ?? "");
+			return GeneralOperator (kInfix, context.@operator (),
+				context.infix_operator_group ()?.precedence_group_name ()?.GetText () ?? "");
 		}
 
 		XElement PostfixOperator (Postfix_operator_declarationContext context)

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1605,7 +1605,7 @@ public protocol Simple {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Colon coming through on precedence")]
+		[TestCase (ReflectorMode.Parser)]
 		public void InfixOperatorDecl (ReflectorMode mode)
 		{
 			var code = @"infix operator *^* : AdditionPrecedence


### PR DESCRIPTION
Remove colon from precedence group name fixing issue [562](https://github.com/xamarin/binding-tools-for-swift/issues/562)

Didn't go deep enough to get the precedence group name.
Have I mentioned lately that I like the `?.` operator?

Test passes.