### PR TITLE
actually do the selectors, thanks, unignore working tests

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -792,6 +792,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			currentElement.Pop ();
 			getFunc.Add (getParamLists);
 			AddElementToParentMembers (getFunc);
+			AddObjCSelector (getFunc);
 
 			var setParamList = context.getter_setter_keyword_block ()?.setter_keyword_clause () != null ?
 				new XElement (kParameterList, new XAttribute (kIndex, "1")) : null;
@@ -814,6 +815,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 				setFunc.Add (setParamLists);
 				AddElementToParentMembers (setFunc);
+				AddObjCSelector (setFunc);
 			}
 
 			var prop = new XElement (kProperty, new XAttribute (kName, context.variable_name ().GetText ()),

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -698,7 +698,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "need to handle optional props/methods")]
+		[TestCase (ReflectorMode.Parser)]
 		public void ObjCOptionalProp (ReflectorMode mode)
 		{
 			string code =
@@ -728,7 +728,7 @@ namespace XmlReflectionTests {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "need to handle optional props/methods")]
+		[TestCase (ReflectorMode.Parser)]
 		public void ObjCOptionalSubsript (ReflectorMode mode)
 		{
 			string code =
@@ -807,7 +807,7 @@ namespace XmlReflectionTests {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "property selector incorrect")]
+		[TestCase (ReflectorMode.Parser)]
 		public void ObjCPropSelector (ReflectorMode mode)
 		{
 			string code =
@@ -835,7 +835,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "property selector incorrect")]
+		[TestCase (ReflectorMode.Parser)]
 		public void ObjCPropSelectorLower (ReflectorMode mode)
 		{
 			string code =


### PR DESCRIPTION
Add selectors to properties fixing issue [556](https://github.com/xamarin/binding-tools-for-swift/issues/556)

Just plain missed this case.
Also found two vaguely related tests that no longer need to be ignored.