### PR TITLE
Add typealias support

### DIFF
--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -183,6 +183,7 @@
     <Compile Include="SwiftXmlReflection\AttributeDeclaration.cs" />
     <Compile Include="SwiftInterfaceReflector\ObjCSelectorFactory.cs" />
     <Compile Include="SwiftInterfaceReflector\SyntaxDesugaringParser.cs" />
+    <Compile Include="SwiftXmlReflection\TypeAliasDeclaration.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
@@ -13,6 +13,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			Declarations = new List<BaseDeclaration> ();
 			Extensions = new List<ExtensionDeclaration> ();
 			Operators = new List<OperatorDeclaration> ();
+			TypeAliases = new List<TypeAliasDeclaration> ();
 		}
 
 		public ModuleDeclaration (string name)
@@ -35,6 +36,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 
 		public List<BaseDeclaration> Declarations { get; private set; }
+		public List<TypeAliasDeclaration> TypeAliases { get; private set; }
 
 		public static ModuleDeclaration FromXElement (XElement elem)
 		{
@@ -42,6 +44,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 				Name = (string)elem.Attribute ("name"),
 				SwiftCompilerVersion = new Version((string)elem.Attribute("swiftVersion") ?? "3.1")
 			};
+
+			decl.TypeAliases.AddRange (elem.Descendants ("typealias").Select (al => TypeAliasDeclaration.FromXElement (al)));
 
 			// non extensions
 			foreach (var child in elem.Elements()) {

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Xml.Linq;
+using Dynamo;
+using ObjCRuntime;
+using SwiftReflector.ExceptionTools;
+
+namespace SwiftReflector.SwiftXmlReflection {
+	public class TypeAliasDeclaration {
+		public TypeAliasDeclaration ()
+		{
+		}
+
+		public Accessibility Access { get; private set; }
+
+		string typeName;
+		public string TypeName {
+			get { return typeName; }
+			set {
+				typeName = Exceptions.ThrowOnNull (value, nameof (value));
+				if (typeName.IndexOf (':') >= 0)
+					throw ErrorHelper.CreateError (ReflectorError.kReflectionErrorBase + 12, $"typealias {value} has a generic constraint which is not supported");
+				try {
+					typeSpec = TypeSpecParser.Parse (typeName);
+				} catch (RuntimeException ex) {
+					throw ErrorHelper.CreateError (ReflectorError.kReflectionErrorBase + 11, $"Unable to parse typealias name '{value}': {ex.Message}");
+				}
+			}
+		}
+
+		TypeSpec typeSpec;
+		public TypeSpec TypeSpec {
+			get { return typeSpec; }
+			set {
+				Exceptions.ThrowOnNull (value, nameof (value));
+				typeSpec = value;
+				typeName = value.ToString ();
+			}
+		}
+
+		string targetTypeName;
+		public string TargetTypeName {
+			get { return targetTypeName; }
+			set {
+				targetTypeName = Exceptions.ThrowOnNull (value, nameof (value));
+				try {
+					targetTypeSpec = TypeSpecParser.Parse (targetTypeName);
+				} catch (RuntimeException ex) {
+					throw ErrorHelper.CreateError (ReflectorError.kReflectionErrorBase + 11, $"Unable to parse typealias target name '{value}': {ex.Message}");
+				}
+			}
+		}
+
+		TypeSpec targetTypeSpec;
+		public TypeSpec TargetTypeSpec {
+			get { return targetTypeSpec; }
+			set {
+				Exceptions.ThrowOnNull (value, nameof (value));
+				targetTypeSpec = value;
+				targetTypeName = value.ToString ();
+			}
+		}
+
+		public static TypeAliasDeclaration FromXElement (XElement element)
+		{
+			return new TypeAliasDeclaration () {
+				Access = TypeDeclaration.AccessibilityFromString ((string)element.Attribute ("accessibility")),
+				TypeName = element.Attribute ("name").Value,
+				TargetTypeName = element.Attribute ("type").Value
+			};
+		}
+	}
+}

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1660,5 +1660,23 @@ extension Int {
 			Assert.IsNull (opDecl.PrecedenceGroup, "predence group mismatch");
 			Assert.AreEqual (OperatorType.Postfix, opDecl.OperatorType, "operator type mismatch");
 		}
+
+		[Test]
+		public void TypeAliasSmokeTest ()
+		{
+			var code = @"
+public typealias Foo = Int
+public func sum (a: Foo, b: Foo) -> Foo {
+    return a + b
+}
+";
+			var module = ReflectToModules (code, "SomeModule", ReflectorMode.Parser).FirstOrDefault (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			Assert.AreEqual (1, module.TypeAliases.Count, "wrong number of typealiases");
+			var alias = module.TypeAliases [0];
+			Assert.AreEqual (Accessibility.Public, alias.Access, "wrong access");
+			Assert.AreEqual ("Foo", alias.TypeName, "wrong typealias name");
+			Assert.AreEqual ("Swift.Int", alias.TargetTypeName, "wrong typealias target");
+		}
 	}
 }


### PR DESCRIPTION
Added type alias extraction and representation.

Notes:
this will take care of type aliases of the form:
`typealias Foo<generic> = SomeOtherType<generic>`
but it will *not* handle:
`typealias Foo<generic:SomeProtocol> = SomeOtherType<generic>`

This is because the `TypeSpec` data type, up until now, has never needed to represent the inheritance syntax because we don't put inheritance in type specs ever. We're going to punt on that for now and maybe consider adding it later with the proviso that it only gets used in type aliases so it's safe to ignore in the rest of the code base. In practice, we probably won't need it either, but type aliases can get complicated since they can reference each other as long as there are no cycles. Added an issue for that [here](https://github.com/xamarin/binding-tools-for-swift/issues/575).

If there are type aliases, we create the following XML structure:
```
<typealiases>
    <typealias name="spec" accessibility="Public" type="target spec" />
</typealiases>
```
This will only be generated by the swiftinterface parser and never by the reflector. Why? Because the reflector has already desugared the typealiases and in thinking about the best way to desugar these, it seemed like the best time would be when we had better manipulable data structures like `TypeSpec`. The reason being that we need to handle garbage like this:
```
typealias GarbagePointer<thing> = UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<thing>>>
```
And having a reasonably easy to remap data structure like `TypeSpec` goes a long way to removing that pain.

The intent is that the aliases will get used after each function/property gets parser it desugaring them. Once the module is read, they are no longer needed, so buh-bye. We should never need to write them.
Why does swift desugar them in the interface? Beats me. There's probably a good reason.

Added a simple smoke test.