### PR TITLE
type alias folding

### DIFF
--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -184,6 +184,7 @@
     <Compile Include="SwiftInterfaceReflector\ObjCSelectorFactory.cs" />
     <Compile Include="SwiftInterfaceReflector\SyntaxDesugaringParser.cs" />
     <Compile Include="SwiftXmlReflection\TypeAliasDeclaration.cs" />
+    <Compile Include="SwiftXmlReflection\TypeAliasFolder.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SwiftReflector.SwiftXmlReflection {
+	public class TypeAliasFolder {
+		Dictionary<string, TypeAliasDeclaration> aliases;
+
+		public TypeAliasFolder (IList<TypeAliasDeclaration> aliases)
+		{
+			this.aliases = new Dictionary<string, TypeAliasDeclaration> ();
+			foreach (var alias in aliases) {
+				this.aliases.Add (AliasKey (alias.TypeSpec), alias);
+			}
+		}
+
+		public TypeSpec FoldAlias (BaseDeclaration context, TypeSpec original)
+		{
+			if (aliases.Count == 0)
+				return original;
+
+			var changed = false;
+			while (true) {
+				original = FoldAlias (context, original, out changed);
+				if (!changed)
+					return original;
+			}
+		}
+
+		TypeSpec FoldAlias (BaseDeclaration context, TypeSpec spec, out bool changed)
+		{
+			switch (spec.Kind) {
+			case TypeSpecKind.Named:
+				return FoldAlias (context, spec as NamedTypeSpec, out changed);
+			case TypeSpecKind.Closure:
+				return FoldAlias (context, spec as ClosureTypeSpec, out changed);
+			case TypeSpecKind.ProtocolList:
+				return FoldAlias (context, spec as ProtocolListTypeSpec, out changed);
+			case TypeSpecKind.Tuple:
+				return FoldAlias (context, spec as TupleTypeSpec, out changed);
+			default:
+				throw new ArgumentOutOfRangeException (nameof (spec));
+			}
+
+		}
+
+		TypeSpec FoldAlias (BaseDeclaration context, TupleTypeSpec spec, out bool changed)
+		{
+			changed = false;
+			TypeSpec [] newContents = spec.Elements.ToArray ();
+			for (int i = 0; i < newContents.Length; i++) {
+				var elemChanged = false;
+				newContents [i] = FoldAlias (context, newContents [i], out elemChanged);
+				changed = changed || elemChanged;
+			}
+			if (changed) {
+				var newTuple = new TupleTypeSpec (newContents);
+				newTuple.Attributes.AddRange (spec.Attributes);
+				return newTuple;
+			}
+			return spec;
+		}
+
+		TypeSpec FoldAlias (BaseDeclaration context, ClosureTypeSpec spec, out bool changed)
+		{
+			var returnChanged = false;
+			var returnSpec = FoldAlias (context, spec.ReturnType, out returnChanged);
+
+			var argsChanged = false;
+			var args = FoldAlias (context, spec.Arguments, out argsChanged);
+
+			changed = returnChanged || argsChanged;
+			if (changed) {
+				var newSpec = new ClosureTypeSpec (args, returnSpec);
+				newSpec.Attributes.AddRange (spec.Attributes);
+				return newSpec;
+			}
+			return spec;
+		}
+
+		TypeSpec FoldAlias (BaseDeclaration context, ProtocolListTypeSpec spec, out bool changed)
+		{
+			changed = false;
+			var protos = new NamedTypeSpec [spec.Protocols.Count];
+
+			var protoChanged = false;
+			var i = 0;
+			foreach (var proto in spec.Protocols.Keys) {
+				protos [i] = FoldAlias (context, proto, out protoChanged) as NamedTypeSpec;
+				changed = changed || protoChanged;
+			}
+			if (changed) {
+				var newProtoList = new ProtocolListTypeSpec (protos);
+				newProtoList.Attributes.AddRange (spec.Attributes);
+				return newProtoList;
+			}
+			return spec;
+		}
+
+		TypeSpec FoldAlias (BaseDeclaration context, NamedTypeSpec spec, out bool changed)
+		{
+			if (!context.IsTypeSpecGenericReference (spec)) {
+				TypeAliasDeclaration decl = null;
+				if (aliases.TryGetValue (spec.Name, out decl)) {
+					changed = true;
+					var newNamedSpec = RemapAliasedTypeSpec (spec, decl);
+					newNamedSpec.Attributes.AddRange (spec.Attributes);
+					return newNamedSpec;
+				} else {
+					return FoldGenerics (context, spec, out changed);
+				}
+			} else {
+				return FoldGenerics (context, spec, out changed);
+			}
+		}
+
+		TypeSpec FoldGenerics (BaseDeclaration context, NamedTypeSpec spec, out bool changed)
+		{
+			changed = false;
+			if (!spec.ContainsGenericParameters)
+				return spec;
+			var genericsChanged = false;
+			var newGenerics = spec.GenericParameters.ToArray ();
+			for (int i = 0; i < newGenerics.Length; i++) {
+				var genericChanged = false;
+				newGenerics [i] = FoldAlias (context, newGenerics [i], out genericChanged);
+				genericsChanged = genericsChanged || genericChanged;
+			}
+			if (genericsChanged) {
+				changed = true;
+				var newNamedSpec = new NamedTypeSpec (spec.Name, newGenerics);
+				newNamedSpec.Attributes.AddRange (spec.Attributes);
+				return newNamedSpec;
+			}
+			return spec;
+		}
+
+		TypeSpec RemapAliasedTypeSpec (NamedTypeSpec source, TypeAliasDeclaration decl)
+		{
+			// OK  - in the Decl, we're going to have something like:
+			// Name = SomeOtherType
+			// or we'll have
+			// Name<gen1, gen2, ...> = SomeOtherType<t1, t2, ...>
+			// The first case is easy. In the second case we need to look
+			// at the t1 and find out where it comes from in Name<...>
+			// and remap it using what was provided in the source.
+			// But of course this get complicated.
+			// You could have something like this:
+			// typealias Foo<T> = UnsafeMutablePointer<(Int, T)>
+			// So we need a map from each generic argument in Foo<T> to
+			// each generic argument in source.
+			// Then we need to build a new TypeSpec using the declaration's target
+			// type substituting in elements from the map.
+			// and it gets more complicated because the thing we're looking at may
+			// be an associated type.
+			//
+			// Here's an example:
+			//public protocol KVPish
+			//{
+			//    associatedtype Key : Hashable
+			//    associatedtype Value
+			//    func contains(a: Key) -> Bool
+			//    func get(a: Key) -> Value
+			//}
+			//
+			//public typealias KPHolder<a: KVPish> = Dictionary<a.Key, a.Value>
+			var genericMap = new Dictionary<string, TypeSpec> ();
+			if (decl.TypeSpec.ContainsGenericParameters) {
+				for (int i = 0; i < decl.TypeSpec.GenericParameters.Count; i++) {
+					// the "parts" here are part of a formal generic declaration
+					// and they HAVE to be named type specs and they themselves
+					// won't ever be generic. They're going to just be a name.
+					// Future Steve: trust me.
+					var part = decl.TypeSpec.GenericParameters [i] as NamedTypeSpec;
+					genericMap.Add (part.Name, source.GenericParameters [i]);
+				}
+			}
+			return RemapTypeSpec (decl.TargetTypeSpec, genericMap);
+		}
+
+		TypeSpec RemapTypeSpec (TypeSpec spec, Dictionary<string, TypeSpec> nameMap)
+		{
+			switch (spec.Kind) {
+			case TypeSpecKind.Closure:
+				return RemapTypeSpec (spec as ClosureTypeSpec, nameMap);
+			case TypeSpecKind.Named:
+				return RemapTypeSpec (spec as NamedTypeSpec, nameMap);
+			case TypeSpecKind.ProtocolList:
+				return RemapTypeSpec (spec as ProtocolListTypeSpec, nameMap);
+			case TypeSpecKind.Tuple:
+				return RemapTypeSpec (spec as TupleTypeSpec, nameMap);
+			default:
+				throw new NotImplementedException ($"Unknown type spec kind {spec.Kind}");
+			}
+		}
+
+		TypeSpec RemapTypeSpec (TupleTypeSpec tuple, Dictionary <string, TypeSpec> nameMap)
+		{
+			var tupleElems = tuple.Elements.ToArray ();
+			for (int i = 0; i < tupleElems.Length; i++) {
+				tupleElems [i] = RemapTypeSpec (tupleElems [i], nameMap);
+			}
+			return new TupleTypeSpec (tupleElems);
+		}
+
+		TypeSpec RemapTypeSpec (ClosureTypeSpec clos, Dictionary<string, TypeSpec> nameMap)
+		{
+			var returnType = RemapTypeSpec (clos.ReturnType, nameMap);
+			var args = RemapTypeSpec (clos.Arguments, nameMap);
+			return new ClosureTypeSpec (args, returnType);
+		}
+
+		TypeSpec RemapTypeSpec (ProtocolListTypeSpec proto, Dictionary<string, TypeSpec> nameMap)
+		{
+			return new ProtocolListTypeSpec (proto.Protocols.Keys.Select (k => RemapTypeSpec (k, nameMap) as NamedTypeSpec));
+		}
+
+		TypeSpec RemapTypeSpec (NamedTypeSpec named, Dictionary <string, TypeSpec> nameMap)
+		{
+			var parts = named.Name.Split ('.');
+			for (int i = 0; i < parts.Length; i++) {
+				TypeSpec replacement;
+				if (nameMap.TryGetValue (parts [i], out replacement)) {
+					parts [i] = replacement.ToString ();
+				}
+			}
+			var newName = parts.InterleaveStrings (".");
+			if (named.ContainsGenericParameters) {
+				var newParams = named.GenericParameters.Select (p => RemapTypeSpec (p, nameMap)).ToArray ();
+				return new NamedTypeSpec (newName, newParams);
+			} else {
+				return new NamedTypeSpec (newName);
+			}
+		}
+
+		static string AliasKey (TypeSpec spec)
+		{
+			if (spec is NamedTypeSpec named)
+				return named.Name;
+			return spec.ToString ();
+		}
+	}
+}

--- a/tests/tom-swifty-test/XmlReflectionTests/TypeAliasTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/TypeAliasTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using SwiftReflector.IOUtils;
+using NUnit.Framework;
+using System.IO;
+using tomwiftytest;
+using System.Xml.Linq;
+using System.Collections.Generic;
+using SwiftReflector.SwiftXmlReflection;
+using System.Linq;
+using SwiftReflector;
+using SwiftReflector.SwiftInterfaceReflector;
+using SwiftReflector.TypeMapping;
+
+namespace XmlReflectionTests {
+	public class TypeAliasTests {
+
+		static ModuleDeclaration module;
+		static BaseDeclaration throwAway;
+
+		static BaseDeclaration ThrowAwayContext ()
+		{
+			if (throwAway != null)
+				return throwAway;
+			if (module != null)
+				module = new ModuleDeclaration ("NoName");
+
+			throwAway = new ClassDeclaration () {
+				Name = "AClass",
+				Access = Accessibility.Public,
+				Module = module,
+				Kind = TypeKind.Class
+			};
+			return throwAway;
+		}
+
+		void FoldTest (string testName, BaseDeclaration context, string source, string expected, params TypeAliasDeclaration[] decls)
+		{
+			context = context ?? ThrowAwayContext ();
+			var aliases = new List<TypeAliasDeclaration> ();
+			aliases.AddRange (decls);
+
+			var sourceTypeSpec = TypeSpecParser.Parse (source);
+
+			var folder = new TypeAliasFolder (aliases);
+			var result = folder.FoldAlias (context, sourceTypeSpec);
+			Assert.IsNotNull (result, $"Test {testName} result was null");
+			Assert.AreEqual (expected, result.ToString (), $"Test {testName} type spec mismatch");
+		}
+
+		[Test]
+		public void SimpleFold ()
+		{
+			FoldTest ("SimpleFold", null, "Foo", "Swift.Int",
+				new TypeAliasDeclaration () { TypeName = "Foo", TargetTypeName = "Swift.Int" });
+		}
+
+		[Test]
+		public void DoubleFold ()
+		{
+			FoldTest ("DoubleFold", null, "Foo", "Swift.Int",
+				new TypeAliasDeclaration () { TypeName = "Bar", TargetTypeName = "Swift.Int" },
+				new TypeAliasDeclaration () { TypeName = "Foo", TargetTypeName = "Bar" });
+		}
+
+		[Test]
+		public void CompleteGenericFold ()
+		{
+			FoldTest ("CompleteGenericFold", null, "Foo", "Array<Swift.Int>",
+				new TypeAliasDeclaration () { TypeName = "Foo", TargetTypeName = "Array<Swift.Int>"}
+				);
+		}
+
+
+		[Test]
+		public void ParameterizedGenericFold ()
+		{
+			FoldTest ("ParameterizedGenericFold", null, "Foo<Swift.Int>", "Array<Swift.Int>",
+				new TypeAliasDeclaration () { TypeName = "Foo<T>", TargetTypeName = "Array<T>" }
+				);
+		}
+
+
+		[Test]
+		public void PartialParameterizedGenericFold ()
+		{
+			FoldTest ("PartialParameterizedGenericFold", null, "Foo<Swift.Int>", "Dictionary<Swift.String, Swift.Int>",
+				new TypeAliasDeclaration () { TypeName = "Foo<T>", TargetTypeName = "Dictionary<Swift.String, T>" }
+				);
+		}
+
+		[Test]
+		public void AssociatedTypeFold ()
+		{
+			FoldTest ("AssociatedTypeFold", null, "Foo<Proto>", "Dictionary<Proto.Key, Proto.Value>",
+				new TypeAliasDeclaration () { TypeName = "Foo<T>", TargetTypeName = "Dictionary<T.Key, T.Value>" });
+		}
+	}
+}

--- a/tests/tom-swifty-test/XmlReflectionTests/TypeAliasTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/TypeAliasTests.cs
@@ -98,5 +98,26 @@ namespace XmlReflectionTests {
 			FoldTest ("AssociatedTypeFold", null, "Foo<Proto>", "Dictionary<Proto.Key, Proto.Value>",
 				new TypeAliasDeclaration () { TypeName = "Foo<T>", TargetTypeName = "Dictionary<T.Key, T.Value>" });
 		}
+
+		[Test]
+		public void TupleTest ()
+		{
+			FoldTest ("TupleTest", null, "Foo<Swift.Int, Swift.Bool>", "(Swift.Int, Swift.Bool)",
+				new TypeAliasDeclaration () { TypeName = "Foo<T, U>", TargetTypeName = "(T, U)" });
+		}
+
+		[Test]
+		public void ClosureTest ()
+		{
+			FoldTest ("FoldTest", null, "Foo<(Swift.Int, Swift.Int), Swift.Bool>", "(Swift.Int, Swift.Int) -> Swift.Bool",
+				new TypeAliasDeclaration () { TypeName = "Foo<T, U>", TargetTypeName = "T->U"});
+		}
+
+		[Test]
+		public void ProtoListTest ()
+		{
+			FoldTest ("ClosureTest", null, "Foo", "Codable & Decodable",
+				new TypeAliasDeclaration () { TypeName = "Foo", TargetTypeName = "Codable & Decodable" });
+		}
 	}
 }

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -114,6 +114,7 @@
     <Compile Include="XmlReflectionTests\SwiftInterfaceParserTests.cs" />
     <Compile Include="XmlReflectionTests\XmlComparator.cs" />
     <Compile Include="XmlReflectionTests\ComparatorTests.cs" />
+    <Compile Include="XmlReflectionTests\TypeAliasTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
A good way to think about this is that swift type aliases are a kind of limited macro preprocessor.

There are two general classes of type aliases, parameterless and parametered:
```
typealias Foo = SomeOtherType // no parameters
typealias Bar<T, U> = SomeOtherType<OtherGeneric<T>, U.Bar> // parametered
```

In either case, the source pattern is a `NamedTypeSpec` and the target pattern is also a `TypeSpec`.

The general pattern we do is this:
Based on the `TypeSpec` kind, Fold it and see if there were changes.
If there were no changes, return the folded value.
If there were changes, attempt to fold again.
- To fold a tuple type spec, fold each of the elements and report that it changed if any of the pieces changed.
- To fold a closure type spec, fold its arguments and its return value and report that it changed if either of those changed.
- To fold a protocol list type spec, fold each of the elements and report that it changed if any of the elements changed.
- To fold a named type spec, if the name is in the map, remap the name marking it changed. Otherwise fold each of the generic parameters and report if any of them changed.

Remapping works like this:
Given the name of a type alias (based on named type spec), create a map from each of its generic arguments names to the supplied generic arguments in the type spec.
Then take the target type spec and rebuild it using the map.
Again, decompose the various type specs trying to get down to a named type spec. For names, blow them apart separated by '.' and attempt to do macro substitution on the parts, then reassemble into a new name.

Unlike the previous one, we don't care about whether something changed or not. We're making a new pattern no matter what, so we're willing to pay this extra price because referential equality should never be an issue here nor do we have to worry about attributes.

Notes:
You don't need to worry about recursive or mutually recursive type aliases. Yes, I checked because the first thing that came to my mind was "can I build a Y combinator using a typealias?" Swift doesn't let these happen.
The left hand of the type alias, when it is generic, will only ever have simple names as the generic parameters. One way to think of it is that the left hand side is a generic declaration and the right hand side is a (possibly) generic definition. So no, `typealias Foo<(T, U)> = Swift.Dictionary<T, U>` is, in fact, illegal.

Test, oh yes, we have tests.