### PR TITLE
Fold all the type aliases on the way in

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/AssociatedTypeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/AssociatedTypeDeclaration.cs
@@ -20,7 +20,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public List<NamedTypeSpec> ConformingProtocols { get; private set; }
 
 
-		public static AssociatedTypeDeclaration FromXElement (XElement elem)
+		public static AssociatedTypeDeclaration FromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			var assocType = new AssociatedTypeDeclaration ();
 			assocType.Name = NameAttribute (elem);
@@ -29,17 +29,17 @@ namespace SwiftReflector.SwiftXmlReflection {
 			if (superClassElem != null) {
 				var superClassName = NameAttribute (superClassElem);
 				if (superClassName != null) {
-					assocType.SuperClass = TypeSpecParser.Parse (superClassName);
+					assocType.SuperClass = folder.FoldAlias (null, TypeSpecParser.Parse (superClassName));
 				}
 			}
 			var defaultDefn = elem.Attribute ("defaulttype");
 			if (defaultDefn != null) {
-				assocType.DefaultType = TypeSpecParser.Parse ((string)defaultDefn);
+				assocType.DefaultType = folder.FoldAlias (null, TypeSpecParser.Parse ((string)defaultDefn));
 			}
 			
 			if (elem.Element ("conformingprotocols") != null) {
 				var conforming = from conform in elem.Element ("conformingprotocols").Elements ()
-						 select TypeSpecParser.Parse (NameAttribute (conform)) as NamedTypeSpec;
+						 select folder.FoldAlias (null, TypeSpecParser.Parse (NameAttribute (conform))) as NamedTypeSpec;
 				assocType.ConformingProtocols.AddRange (conforming);
 			}
 

--- a/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
@@ -14,14 +14,14 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 		public ConstraintKind Kind { get; private set; }
 
-		public static BaseConstraint FromXElement (XElement elem)
+		public static BaseConstraint FromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			if (elem == null)
 				return null;
 			if ((string)elem.Attribute ("relationship") == "inherits") {
-				return new InheritanceConstraint ((string)elem.Attribute ("name"), (string)elem.Attribute ("from"));
+				return new InheritanceConstraint ((string)elem.Attribute ("name"), (string)elem.Attribute ("from"), folder);
 			} else {
-				return new EqualityConstraint ((string)elem.Attribute ("firsttype"), (string)elem.Attribute ("secondtype"));
+				return new EqualityConstraint ((string)elem.Attribute ("firsttype"), (string)elem.Attribute ("secondtype"), folder);
 			}
 		}
 
@@ -70,11 +70,13 @@ namespace SwiftReflector.SwiftXmlReflection {
 	}
 
 	public class InheritanceConstraint : BaseConstraint {
-		public InheritanceConstraint (string name, string inheritsTypeSpecString)
+		public InheritanceConstraint (string name, string inheritsTypeSpecString, TypeAliasFolder folder = null)
 			: base (ConstraintKind.Inherits)
 		{
 			Name = Exceptions.ThrowOnNull (name, nameof (name));
 			Inherits = inheritsTypeSpecString;
+			if (folder != null)
+				InheritsTypeSpec = folder.FoldAlias (null, InheritsTypeSpec);
 		}
 
 		public InheritanceConstraint (string name, TypeSpec inheritsTypeSpecString)
@@ -115,11 +117,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 	}
 
 	public class EqualityConstraint : BaseConstraint {
-		public EqualityConstraint (string type1, string type2)
+		public EqualityConstraint (string type1, string type2, TypeAliasFolder folder = null)
 			: base (ConstraintKind.Equal)
 		{
 			Type1 = type1;
 			Type2 = type2;
+			if (folder != null) {
+				Type1Spec = folder.FoldAlias (null, Type1Spec);
+				Type2Spec = folder.FoldAlias (null, Type2Spec);
+			}
 		}
 		string type1Str;
 		TypeSpec type1Spec;

--- a/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseDeclaration.cs
@@ -480,19 +480,19 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 
 
-		public static BaseDeclaration FromXElement (XElement elem, ModuleDeclaration module, BaseDeclaration parent)
+		public static BaseDeclaration FromXElement (TypeAliasFolder folder, XElement elem, ModuleDeclaration module, BaseDeclaration parent)
 		{
-			var generics = GenericDeclaration.FromXElement (elem.Element ("genericparameters"));
+			var generics = GenericDeclaration.FromXElement (folder, elem.Element ("genericparameters"));
 			BaseDeclaration decl = null;
 			switch (elem.Name.ToString ()) {
 			case "func":
-				decl = FunctionDeclaration.FuncFromXElement (elem, module, parent);
+				decl = FunctionDeclaration.FuncFromXElement (folder, elem, module, parent);
 				break;
 			case "typedeclaration":
-				decl = TypeDeclaration.TypeFromXElement (elem, module, parent);
+				decl = TypeDeclaration.TypeFromXElement (folder, elem, module, parent);
 				break;
 			case "property":
-				decl = PropertyDeclaration.PropFromXElement (elem, module, parent);
+				decl = PropertyDeclaration.PropFromXElement (folder, elem, module, parent);
 				break;
 			default:
 				decl = new BaseDeclaration {

--- a/SwiftReflector/SwiftXmlReflection/ExtensionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ExtensionDeclaration.cs
@@ -65,14 +65,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 			xobjects.Add (new XElement ("inherits", inherits.ToArray ()));
 		}
 
-		public static ExtensionDeclaration FromXElement (XElement elem, ModuleDeclaration module)
+		public static ExtensionDeclaration FromXElement (TypeAliasFolder folder, XElement elem, ModuleDeclaration module)
 		{
 			var decl = new ExtensionDeclaration ();
 			decl.Module = module;
 			decl.ExtensionOnTypeName = (string)elem.Attribute ("onType");
+			decl.ExtensionOnType = folder.FoldAlias (null, decl.ExtensionOnType);
 			if (elem.Element ("members") != null) {
 				var members = from mem in elem.Element ("members").Elements ()
-					      select Member.FromXElement (mem, module, null) as Member;
+					      select Member.FromXElement (folder, mem, module, null) as Member;
 				decl.Members.AddRange (members);
 				foreach (var member in decl.Members) {
 					member.ParentExtension = decl;
@@ -80,7 +81,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 			if (elem.Element ("inherits") != null) {
 				var inherits = from inherit in elem.Element ("inherits").Elements ()
-					       select SwiftReflector.SwiftXmlReflection.Inheritance.FromXElement (inherit) as Inheritance;
+					       select SwiftReflector.SwiftXmlReflection.Inheritance.FromXElement (folder, inherit) as Inheritance;
 				decl.Inheritance.AddRange (inherits);
 			}
 			return decl;

--- a/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
@@ -221,7 +221,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 
 
-		public static FunctionDeclaration FuncFromXElement (XElement elem, ModuleDeclaration module, BaseDeclaration parent)
+		public static FunctionDeclaration FuncFromXElement (TypeAliasFolder folder, XElement elem, ModuleDeclaration module, BaseDeclaration parent)
 		{
 			FunctionDeclaration decl = new FunctionDeclaration {
 				Name = (string)elem.Attribute ("name"),
@@ -241,7 +241,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 				IsRequired = elem.BoolAttribute ("isRequired"),
 				IsConvenienceInit = elem.BoolAttribute ("isConvenienceInit")
 			};
-			decl.ParameterLists.AddRange (ParameterItem.ParameterListListFromXElement (elem.Element ("parameterlists")));
+			decl.ReturnTypeSpec = folder.FoldAlias (parent, decl.ReturnTypeSpec);
+			decl.ParameterLists.AddRange (ParameterItem.ParameterListListFromXElement (folder, elem.Element ("parameterlists")));
 			if (decl.IsProperty && (decl.IsSetter || decl.IsSubscriptSetter)) {
 				decl.ParameterLists [decl.ParameterLists.Count - 1] =
 						MassageLastPropertySetterParameterList (decl.ParameterLists.Last ());

--- a/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/GenericDeclaration.cs
@@ -99,14 +99,14 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		}
 
-		public static List<GenericDeclaration> FromXElement (XElement generic)
+		public static List<GenericDeclaration> FromXElement (TypeAliasFolder folder, XElement generic)
 		{
 			List<GenericDeclaration> decls = new List<GenericDeclaration> ();
 			if (generic == null)
 				return decls;
 			decls.AddRange (from decl in generic.Descendants ("param") select new GenericDeclaration ((string)decl.Attribute ("name")));
 
-			var constraints = from constr in generic.Descendants ("where") select BaseConstraint.FromXElement (constr);
+			var constraints = from constr in generic.Descendants ("where") select BaseConstraint.FromXElement (folder, constr);
 			foreach (BaseConstraint constr in constraints) {
 				GenericDeclaration decl = FindGenericDeclFor (constr, decls);
 				if (decl != null)

--- a/SwiftReflector/SwiftXmlReflection/Inheritance.cs
+++ b/SwiftReflector/SwiftXmlReflection/Inheritance.cs
@@ -34,12 +34,14 @@ namespace SwiftReflector.SwiftXmlReflection {
 		}
 		public TypeSpec InheritedTypeSpec { get; private set; }
 
-		public static Inheritance FromXElement (XElement elem)
+		public static Inheritance FromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			string typeName = (string)elem.Attribute ("type");
 			string inheritanceKindStr = (string)elem.Attribute ("inheritanceKind");
 			InheritanceKind kind = ToInheritanceKind (inheritanceKindStr);
-			return new Inheritance (typeName, kind);
+			var inheritance = new Inheritance (typeName, kind);
+			inheritance.InheritedTypeSpec = folder.FoldAlias (null, inheritance.InheritedTypeSpec);
+			return inheritance;
 		}
 
 		public XElement ToXElement ()

--- a/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
@@ -45,16 +45,17 @@ namespace SwiftReflector.SwiftXmlReflection {
 				SwiftCompilerVersion = new Version((string)elem.Attribute("swiftVersion") ?? "3.1")
 			};
 
-			decl.TypeAliases.AddRange (elem.Descendants ("typealias").Select (al => TypeAliasDeclaration.FromXElement (al)));
+			decl.TypeAliases.AddRange (elem.Descendants ("typealias").Select (al => TypeAliasDeclaration.FromXElement (decl.Name, al)));
+			var folder = new TypeAliasFolder (decl.TypeAliases);
 
 			// non extensions
 			foreach (var child in elem.Elements()) {
 				if (child.Name == "extension") {
-					decl.Extensions.Add (ExtensionDeclaration.FromXElement (child, decl));
+					decl.Extensions.Add (ExtensionDeclaration.FromXElement (folder, child, decl));
 				} else if (child.Name == "operator") {
 					decl.Operators.Add (OperatorDeclaration.FromXElement (child, child.Attribute ("moduleName")?.Value));
 				} else {
-					decl.Declarations.Add (BaseDeclaration.FromXElement (child, decl, null));
+					decl.Declarations.Add (BaseDeclaration.FromXElement (folder, child, decl, null));
 				}
 			}
 			return decl;

--- a/SwiftReflector/SwiftXmlReflection/ParameterItem.cs
+++ b/SwiftReflector/SwiftXmlReflection/ParameterItem.cs
@@ -69,24 +69,24 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		#endregion
 
-		public static List<List<ParameterItem>> ParameterListListFromXElement (XElement elem)
+		public static List<List<ParameterItem>> ParameterListListFromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			var plists = from plelem in elem.Elements ("parameterlist")
 				     orderby (int)plelem.Attribute ("index")
-				     select ParameterListFromXElement (plelem);
+				     select ParameterListFromXElement (folder, plelem);
 			return plists.ToList ();
 		}
 
-		public static List<ParameterItem> ParameterListFromXElement (XElement elem)
+		public static List<ParameterItem> ParameterListFromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			var indexed = from pelem in elem.Elements ("parameter")
 				      orderby (int)pelem.Attribute ("index")
-				      select ParameterItem.FromXElement (pelem);
+				      select ParameterItem.FromXElement (folder, pelem);
 
 			return indexed.ToList ();
 		}
 
-		public static ParameterItem FromXElement (XElement elem)
+		public static ParameterItem FromXElement (TypeAliasFolder folder, XElement elem)
 		{
 			ParameterItem pi = new ParameterItem {
 				PublicName = (string)elem.Attribute ("publicName"),
@@ -95,6 +95,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				IsVariadic = elem.BoolAttribute ("isVariadic"),
 			};
 			pi.IsInOut = pi.TypeSpec.IsInOut;
+			pi.TypeSpec = folder.FoldAlias (null, pi.TypeSpec);
 			return pi;
 		}
 

--- a/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
@@ -84,9 +84,9 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		public static PropertyDeclaration PropFromXElement (XElement elem, ModuleDeclaration module, BaseDeclaration parent)
+		public static PropertyDeclaration PropFromXElement (TypeAliasFolder folder, XElement elem, ModuleDeclaration module, BaseDeclaration parent)
 		{
-			return new PropertyDeclaration {
+			var property = new PropertyDeclaration {
 				Name = (string)elem.Attribute ("name"),
 				Module = module,
 				Parent = parent,
@@ -100,6 +100,10 @@ namespace SwiftReflector.SwiftXmlReflection {
 				IsOptional = elem.BoolAttribute("isOptional")
 
 			};
+
+			property.TypeSpec = folder.FoldAlias (parent, property.TypeSpec);
+
+			return property;
 		}
 
 		protected override XElement MakeXElement ()

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
@@ -63,11 +63,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		public static TypeAliasDeclaration FromXElement (XElement element)
+		public static TypeAliasDeclaration FromXElement (string moduleName, XElement element)
 		{
+			Exceptions.ThrowOnNull (moduleName, nameof (moduleName));
+			var aliasName = element.Attribute ("name").Value;
+			if (!aliasName.Contains ("."))
+				aliasName = $"{moduleName}.{aliasName}";
 			return new TypeAliasDeclaration () {
 				Access = TypeDeclaration.AccessibilityFromString ((string)element.Attribute ("accessibility")),
-				TypeName = element.Attribute ("name").Value,
+				TypeName = aliasName,
 				TargetTypeName = element.Attribute ("type").Value
 			};
 		}

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
@@ -102,7 +102,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 		TypeSpec FoldAlias (BaseDeclaration context, NamedTypeSpec spec, out bool changed)
 		{
-			if (!context.IsTypeSpecGenericReference (spec)) {
+			if (context == null || !context.IsTypeSpecGenericReference (spec)) {
 				TypeAliasDeclaration decl = null;
 				if (aliases.TryGetValue (spec.Name, out decl)) {
 					changed = true;

--- a/SwiftReflector/TypeMapping/TypeDatabase.cs
+++ b/SwiftReflector/TypeMapping/TypeDatabase.cs
@@ -374,7 +374,8 @@ namespace SwiftReflector.TypeMapping {
 				return null;
 			}
 			var module = MakeModuleForName (moduleName, theModules);
-			var decl = TypeDeclaration.FromXElement (typeDeclElement, module, null) as TypeDeclaration;
+			var folder = new TypeAliasFolder (module.TypeAliases);
+			var decl = TypeDeclaration.FromXElement (folder, typeDeclElement, module, null) as TypeDeclaration;
 			if (decl == null) {
 				errors.Add (new ReflectorError (ErrorHelper.CreateError (ReflectorError.kTypeMapBase + 8, "Incorrect type declaration in entity.")));
 				return null;

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -454,7 +454,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Need to desugar typealiases")]
+		[TestCase (ReflectorMode.Parser/*, Ignore = "Need to desugar typealiases"*/)]
 		public void TypeAliasTest (ReflectorMode mode)
 		{
 			string code = "public typealias Foo = OpaquePointer\n" +
@@ -1675,7 +1675,7 @@ public func sum (a: Foo, b: Foo) -> Foo {
 			Assert.AreEqual (1, module.TypeAliases.Count, "wrong number of typealiases");
 			var alias = module.TypeAliases [0];
 			Assert.AreEqual (Accessibility.Public, alias.Access, "wrong access");
-			Assert.AreEqual ("Foo", alias.TypeName, "wrong typealias name");
+			Assert.AreEqual ("SomeModule.Foo", alias.TypeName, "wrong typealias name");
 			Assert.AreEqual ("Swift.Int", alias.TargetTypeName, "wrong typealias target");
 		}
 	}

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -454,7 +454,7 @@ namespace XmlReflectionTests {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser/*, Ignore = "Need to desugar typealiases"*/)]
+		[TestCase (ReflectorMode.Parser)]
 		public void TypeAliasTest (ReflectorMode mode)
 		{
 			string code = "public typealias Foo = OpaquePointer\n" +


### PR DESCRIPTION
This PR pulls in the TypeAliasFolder into the XML reading process fixing issue [518](https://github.com/xamarin/binding-tools-for-swift/issues/518).

What's happening? TypeSpecs are coming in that are really typealiases. We don't see that in the swift reflector because they get desugared.
The swiftinterface parser now generates information about the typealiases but is ill-suited to do a reasonable amount of structural surgery on the types without the parser getting dramatically more heavyweight.

Instead, while we're parsing the XML representation, wherever we see a member that is assigned from a `TypeSpec` we run it through the folder.

A couple notes:
1 - will this incur a performance hit? In the typical case not really. typealiases are not a heavily used language feature IME, but since we look at every single `TypeSpec`, the typical case (no alias) is going to be the cost of a hash lookup.
2 - in one or two cases, we parse, fold, ToString and parse again. This is a moderate cost for this, but I'm not particularly worried about it.
3 - the swift compiler turns typealias in use into fully qualified names, so if you have 
```
typealias Foo = SomeOtherModule.SomeType
public func foo() -> Foo
```
that will get turned into `public func foo() -> ThisModule.Foo`, so on parse, I add the module in to the name of the typealias. I had to adjust a unit test for this.

Existing tests pass, disignored the previously failing test.