### PR TITLE
minor grammar tweak

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -363,6 +363,7 @@ type :
 	| type OpDot 'Protocol' # proto_type
 	| 'Any' # any_type
 	| 'Self' # self_type
+	| 'Self' OpDot type_identifier # self_long
 	;
 
 type_annotation : OpColon attributes? inout_clause? type ;

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1178,7 +1178,7 @@ public protocol HoldsThing {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "grammar error for associated types")]
+		[TestCase (ReflectorMode.Parser/*, Ignore = "grammar error for associated types"*/)]
 		public void AssocTypeTimesTwo (ReflectorMode mode)
 		{
 			var code = @"

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1178,7 +1178,7 @@ public protocol HoldsThing {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser/*, Ignore = "grammar error for associated types"*/)]
+		[TestCase (ReflectorMode.Parser)]
 		public void AssocTypeTimesTwo (ReflectorMode mode)
 		{
 			var code = @"


### PR DESCRIPTION
There was an issue parsing protocol declarations with associated types fixing issue [557](https://github.com/xamarin/binding-tools-for-swift/issues/557).

I thought this was in issue in the grammar of associated types themselves, but no, that looks good.
It turns out that the grammar issue was in the `type` grammar. In this particular case the type that was choking on was `Self.Thing1`. If you look at the grammar for `type` it will only accept `Self` on its own even though it looks like it should accept it in the `type_identifier` pattern. Easy enough, just add `'Self' OpDot type_identifier` and we're good to go.
