### PR TITLE
Unwrapped optionals

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -40,6 +40,15 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			rewriter.Replace (startToken, endToken, replacementType);
 		}
 
+		public override void ExitUnwrapped_optional_type ([NotNull] Unwrapped_optional_typeContext context)
+		{
+			var innerType = context.type ().GetText ();
+			var replacementType = $"Swift.Optional<{innerType}>";
+			var startToken = context.Start;
+			var endToken = context.Stop;
+			rewriter.Replace (startToken, endToken, replacementType);
+		}
+
 		public override void ExitArray_type ([NotNull] Array_typeContext context)
 		{
 			var innerType = context.type ().GetText ();

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1678,5 +1678,22 @@ public func sum (a: Foo, b: Foo) -> Foo {
 			Assert.AreEqual ("SomeModule.Foo", alias.TypeName, "wrong typealias name");
 			Assert.AreEqual ("Swift.Int", alias.TargetTypeName, "wrong typealias target");
 		}
+
+		[TestCase (ReflectorMode.Compiler)]
+		[TestCase (ReflectorMode.Parser)]
+		public void UnwrappedOptionalTest (ReflectorMode mode)
+		{
+			var code = @"
+public func sum (a: Int!, b: Int!) -> Int! {
+	return a + b
+}
+
+";
+			var module = ReflectToModules (code, "SomeModule", mode).FirstOrDefault (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var func = module.Functions.Where (fn => fn.Name == "sum").FirstOrDefault ();
+			Assert.IsNotNull (func, "no func");
+			Assert.AreEqual ("Swift.Optional<Swift.Int>", func.ReturnTypeName);
+		}
 	}
 }


### PR DESCRIPTION
I wasn't sure if we needed to desugar implicitly unwrapped optionals. The answer is yes. Yes we do. This fixes issue [566](https://github.com/xamarin/binding-tools-for-swift/issues/566).