### PR TITLE
Added a predicate for HasSetter

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -801,11 +801,11 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			AddElementToParentMembers (getFunc);
 			AddObjCSelector (getFunc);
 
-			var setParamList = context.getter_setter_keyword_block ()?.setter_keyword_clause () != null ?
+			var setParamList = HasSetter (context) ?
 				new XElement (kParameterList, new XAttribute (kIndex, "1")) : null;
 
 			if (setParamList != null) {
-				var parmName = context.getter_setter_keyword_block ().setter_keyword_clause ().new_value_name ()?.GetText ()
+				var parmName = context.getter_setter_keyword_block ()?.setter_keyword_clause ().new_value_name ()?.GetText ()
 					?? kNewValue;
 				var newValueParam = new XElement (kParameter, new XAttribute (kIndex, "0"),
 					new XAttribute (kType, resultType), new XAttribute (kPublicName, parmName),
@@ -837,6 +837,16 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			AddElementToParentMembers (prop);
 
 			PushIgnore ();
+		}
+
+		bool HasSetter (Variable_declarationContext context)
+		{
+			// conditions for having a setter:
+			// getter_setter_keyword_block is null (public var foo: Type)
+			// getter_setter_keyword_block is non-null and the getter_setter_keyword_block
+			// has a non-null setter_keyword_clause (public var foo:Type { get; set; }, public foo: Type { set }
+			return context.getter_setter_keyword_block () == null ||
+				context.getter_setter_keyword_block ().setter_keyword_clause () != null;
 		}
 
 		public override void EnterExtension_declaration ([NotNull] Extension_declarationContext context)

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1409,7 +1409,7 @@ public class Foo {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Prop should be get/set not get only")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestPropGetSet (ReflectorMode mode)
 		{
 			var code = @"
@@ -1578,7 +1578,7 @@ public protocol Simple {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "not coming through as a let")]
+		[TestCase (ReflectorMode.Parser, Ignore = "not coming through as a let - apple's bug, not mine: https://bugs.swift.org/browse/SR-13790")]
 		public void TopLevelLet (ReflectorMode mode)
 		{
 			var code = "public let myVar:Int = 42";


### PR DESCRIPTION
Added a (correct) predicate for HasSetter fixing issue [559](https://github.com/xamarin/binding-tools-for-swift/issues/559)

This is due to an incorrect predicate for whether or not a variable has a setter.

Broke this out into its own predicate to keep things tidy and made it correct.
There are two possible forms for a variable declaration:
public var foo: Type // no getter or setter block declared
public var foo: Type { get; set (optionalValueName); } // getter setter block declared

Allegedly, swift does not *semantically* allow set-only variables, but the grammar does allow it. Weird.

Test passes.
Also checked the top-level let just in case this fixes it, but nope, that one's Apple's bug so I put in the URL to the bug report.