### PR TITLE
allow enums and structs to have protocol inheritance

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -250,6 +250,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void EnterStruct_declaration ([NotNull] Struct_declarationContext context)
 		{
+			var inheritance = GatherInheritance (context.type_inheritance_clause (), forceProtocolInheritance: true);
 			var attributes = GatherAttributes (context.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
 			var isUnavailable = CheckForUnavailable (attributes);
@@ -257,7 +258,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isObjC = AttributesContains (context.attributes (), kObjC);
 			var accessibility = ToAccess (context.access_level_modifier ());
 			var typeDecl = ToTypeDeclaration (kStruct, context.struct_name ().GetText (),
-				accessibility, isObjC, isFinal, isDeprecated, isUnavailable, inherits: null, generics: null,
+				accessibility, isObjC, isFinal, isDeprecated, isUnavailable, inheritance, generics: null,
 				attributes);
 			var generics = HandleGenerics (context.generic_parameter_clause (), context.generic_where_clause ());
 			if (generics != null)
@@ -277,6 +278,9 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void EnterEnum_declaration ([NotNull] Enum_declarationContext context)
 		{
+			var inheritanceClause = context.union_style_enum ()?.type_inheritance_clause () ??
+				context.raw_value_style_enum ()?.type_inheritance_clause ();
+			var inheritance = GatherInheritance (inheritanceClause, forceProtocolInheritance: true);
 			var attributes = GatherAttributes (context.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
 			var isUnavailable = CheckForUnavailable (attributes);
@@ -284,7 +288,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isObjC = AttributesContains (context.attributes (), kObjC);
 			var accessibility = ToAccess (context.access_level_modifier ());
 			var typeDecl = ToTypeDeclaration (kEnum, EnumName (context),
-				accessibility, isObjC, isFinal, isDeprecated, isUnavailable, inherits: null, generics: null,
+				accessibility, isObjC, isFinal, isDeprecated, isUnavailable, inheritance, generics: null,
 				attributes);
 			var generics = HandleGenerics (EnumGenericParameters (context), EnumGenericWhere (context));
 			if (generics != null)

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1695,5 +1695,23 @@ public func sum (a: Int!, b: Int!) -> Int! {
 			Assert.IsNotNull (func, "no func");
 			Assert.AreEqual ("Swift.Optional<Swift.Int>", func.ReturnTypeName);
 		}
+
+
+		[TestCase (ReflectorMode.Compiler)]
+		[TestCase (ReflectorMode.Parser)]
+		public void EnumProtocolConformance (ReflectorMode mode)
+		{
+			var code = @"
+public enum E : Error {
+case a, b
+}
+";
+			var module = ReflectToModules (code, "SomeModule", mode).FirstOrDefault (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var en = module.Enums.FirstOrDefault (e => e.Name == "E");
+			Assert.IsNotNull (en, "no enum");
+			Assert.AreEqual (1, en.Inheritance.Count, "wrong inheritance count");
+			Assert.AreEqual ("Swift.Error", en.Inheritance [0].InheritedTypeName, "wrong inherited name");
+		}
 	}
 }


### PR DESCRIPTION
Made structs and enums have inheritance fixing issue [570](https://github.com/xamarin/binding-tools-for-swift/issues/570).

This was just plain oversight on my part. The capability was there, I just wasn't exercising it.