### PR TITLE
Fixed hang with associated types

### DIFF
--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1250,7 +1250,7 @@ public protocol HoldsThing {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "Hang on parse")]
+		[TestCase (ReflectorMode.Parser)]
 		public void AssocTypeSuper (ReflectorMode mode)
 		{
 			var code = @"


### PR DESCRIPTION
Fixed hang in parsing associated types (infinite loops are infinite, yo) fixing issue [558](https://github.com/xamarin/binding-tools-for-swift/issues/558)

There were two issues, one masking the other.
The first is that the code to gather conformances was using the wrong value on which to iterate. Easy.
The second is that there are separate properties for class inheritance vs protocol conformance and like classes, we won't know until we've parsed the entire file. Fortunately, that work was done for me already (thanks, Past Steve!). What I do is stack up all the associated type declarations with conformances then at the end if the first element is a class, we remove it and move it to a superclass element.