### PR TITLE
let's do generics incorrectly, just like the reflector.

### DIFF
--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1455,7 +1455,7 @@ public class Foo {
 		}
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "missing class generic in signature")]
+		[TestCase (ReflectorMode.Parser)]
 		public void TestGenericMethodInGenericClass (ReflectorMode mode)
 		{
 			var code = @"


### PR DESCRIPTION
For some reason, the reflector puts the parent's generics into the member declarations.
There is a larger issue as to whether this is correct or not and should probably be addressed as such, but in the meantime we can emulate that behaviors.

Test now passes.