### PR TITLE
Allow reflection to be done as a strategy.

### DIFF
--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -140,5 +140,11 @@ namespace SwiftReflector {
 		ImplFunction,
 		DirectMethodReference,
 	}
+
+	public enum ReflectionStrategy {
+		None,
+		Compiler,
+		Parser,
+	}
 }
 

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5457,6 +5457,7 @@ namespace SwiftReflector {
 					var targetInfo = ReflectorLocations.GetTargetInfo (bestTarget);
 					using (CustomSwiftCompiler compiler = new CustomSwiftCompiler (targetInfo, provider, false)) {
 						compiler.Verbose = Verbose;
+						compiler.ReflectionTypeDatabase = TypeMapper.TypeDatabase;
 
 						var decls = compiler.ReflectToModules (
 							moduleDirectories.ToArray (), moduleDirectories.ToArray (),
@@ -5512,6 +5513,7 @@ namespace SwiftReflector {
 				using (TempDirectoryFilenameProvider provider = new TempDirectoryFilenameProvider (null, true)) {
 					using (CustomSwiftCompiler compiler = new CustomSwiftCompiler (ReflectorLocations.GetTargetInfo (null), provider, false)) {
 						compiler.Verbose = Verbose;
+						compiler.ReflectionTypeDatabase = TypeMapper.TypeDatabase;
 
 						var decls = compiler.ReflectToModules (moduleSeachPaths, null, "-f XamGlue", moduleName);
 						if (decls.Count != 1) {


### PR DESCRIPTION
These changes allow for primary and secondary reflection strategies.

I've set the ordering to be compiler then parser since the parser is generating a few (hundred) errors right now.
I figured I would sort those out one class of error at a time before activating this.