### PR TITLE
adjust finality in class declarations

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -229,9 +229,9 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var attributes = GatherAttributes (context.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
 			var isUnavailable = CheckForUnavailable (attributes);
-			var isFinal = context.final_clause () != null;
 			var isObjC = AttributesContains (context.attributes (), kObjC);
 			var accessibility = ToAccess (context.access_level_modifier ());
+			var isFinal = context.final_clause () != null || accessibility != kOpen;
 			var typeDecl = ToTypeDeclaration (kClass, context.class_name ().GetText (),
 				accessibility, isObjC, isFinal, isDeprecated, isUnavailable, inheritance, generics: null,
 				attributes);


### PR DESCRIPTION
Made sure that only `open` classes should be `isFinal="false"` fixing issue [602](https://github.com/xamarin/binding-tools-for-swift/issues/602).

Even though technically `public` classes are also not final, you can't subclass a `public` class that's in another module.