### PR TITLE
Fix extension issues

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
+++ b/SwiftReflector/SwiftXmlReflection/BaseConstraint.cs
@@ -30,12 +30,13 @@ namespace SwiftReflector.SwiftXmlReflection {
 			var inh = this as InheritanceConstraint;
 			if (inh != null) {
 				return new XElement ("where", new XAttribute ("relationship", "inherits"),
+									new XAttribute ("name", inh.Name),
 									new XAttribute ("from", inh.Inherits));
 			} else {
 				var eq = (EqualityConstraint)this;
 				return new XElement ("where", new XAttribute ("relationship", "equals"),
-									new XAttribute ("firstobject", eq.Type1),
-									new XAttribute ("secondobject", eq.Type2));
+									new XAttribute ("firsttype", eq.Type1),
+									new XAttribute ("secondtype", eq.Type2));
 			}
 		}
 


### PR DESCRIPTION
Fix extension self and generic issues, fixing issue [604](https://github.com/xamarin/binding-tools-for-swift/issues/604)

This is an interesting issue.
The problems we have are:
- self arguments for value types need to be `inout`
- self arguments for extensions on generic types need to be generic
- extension functions need to have generics added to them.

Let's look at the last one first and you need to understand a syntactic quirk of swift extensions. If you are writing an extension on a generic type, you _may not_ include the generic signature. For example:
```Swift
extension Optional<Wrapped> { // syntax error
}
```
and in fact, the generics get added to the extension function itself implicitly.
For example:
```Swift
extension Optional {
   public func tupleOf () -> (Wrapped, Wrapped)? {
      return self.hasValue ? (self.value, self.value) : nil
  }
}
```
and in reality, this gets turned into:
```Swift
public func tupleOf<Wrapped>(inout Optional<Wrapped>) -> (Wrapped, Wrapped)? { /* ... */ }
```
which is how this gets represented by the compiler based reflector.

Fortunately we have this information in the type database and not only do we have the information, we can get the type to generate the right `XElement` for us (except for a couple of bugs in that code that I fixed on the way).

Moving backwards, we need the generics in the `self` type, but again, the type database entity will generate that for us.

Finally, if the type is a value type, we add `inout` to the type.