### PR TITLE
Special Case NSObject

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1647,7 +1647,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			foreach (var inh in unknownInheritance) {
 				var type = inh.Attribute (kType).Value;
-				if (IsLocalClass (type) || IsGlobalClass (type))
+				if (IsLocalClass (type) || IsGlobalClass (type) || IsNSObject (type))
 					inh.Attribute (kInheritanceKind).Value = kClass;
 				else
 					inh.Attribute (kInheritanceKind).Value = kProtocol;
@@ -1667,6 +1667,11 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					assoc.Add (new XElement (kSuperclass, new XAttribute (kName, className)));
 				}
 			}
+		}
+
+		bool IsNSObject (string typeName)
+		{
+			return typeName == "ObjectiveC.NSObject";
 		}
 
 		bool IsLocalClass (string typeName)


### PR DESCRIPTION
Special case NSObject as a class for inheritance fixing issue [610](https://github.com/xamarin/binding-tools-for-swift/issues/610)

The type `ObjectiveC.NSObject` doesn't live in the type database by that name (technically, there is no `ObjectiveC` module). It gets aliased further down the line, so we special case it here.