### PR TITLE
Old Left-over cruft Breaking Unit Tests

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -105,42 +105,36 @@ namespace SwiftReflector {
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyBool ()
 		{
 			WrapSingleSubscriptGetOnly ("Bool", "bool", "false", "true", "false\ntrue\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyInt ()
 		{
 			WrapSingleSubscriptGetOnly ("Int32", "int", "43", "-40", "43\n-40\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyUInt ()
 		{
 			WrapSingleSubscriptGetOnly ("UInt32", "uint", "(uint)43", "(uint)40", "43\n40\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyDouble ()
 		{
 			WrapSingleSubscriptGetOnly ("Double", "double", "43.0", "40.0", "43.0\n40.0\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyFloat ()
 		{
 			WrapSingleSubscriptGetOnly ("Float", "float", "43.0f", "40.0f", "43.0\n40.0\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSingleSubscriptGetOnlyString ()
 		{
 			WrapSingleSubscriptGetOnly ("String", "SwiftString", "SwiftString.FromString(\"one\")",
@@ -294,42 +288,36 @@ namespace SwiftReflector {
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetBool ()
 		{
 			WrapSubscriptGetSetOnly ("Bool", "bool", "true", "false", "true\nfalse\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetInt ()
 		{
 			WrapSubscriptGetSetOnly ("Int32", "int", "5", "6", "5\n6\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetUInt ()
 		{
 			WrapSubscriptGetSetOnly ("UInt32", "uint", "5", "6", "5\n6\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetFloat ()
 		{
 			WrapSubscriptGetSetOnly ("Float", "float", "5.0f", "6.0", "5.0\n6.0\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetDouble ()
 		{
 			WrapSubscriptGetSetOnly ("Double", "double", "5.0", "6.0", "5.0\n6.0\n");
 		}
 
 		[Test]
-		[TestCase (PlatformName.macOS)]
 		public void WrapSubscriptPropGetSetString ()
 		{
 			WrapSubscriptGetSetOnly ("String", "SwiftString", "SwiftString.FromString(\"hi\")", "\"mom\"", "hi\nmom\n");


### PR DESCRIPTION
Removed old cruft in subscript tests that was failing fixing issue [510](https://github.com/xamarin/binding-tools-for-swift/issues/530)