### PR TITLE
adjust static and instance requirement

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -567,10 +567,9 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			if (generics != null)
 				functionDecl.Add (generics);
 
-			currentElement.Push (functionDecl);
 
-			if (isStatic || !IsInInstance ())
-				functions.Add (new Tuple<Function_declarationContext, XElement> (context, functionDecl));
+			functions.Add (new Tuple<Function_declarationContext, XElement> (context, functionDecl));
+			currentElement.Push (functionDecl);
 		}
 
 		public override void ExitFunction_declaration ([NotNull] Function_declarationContext context)
@@ -2077,8 +2076,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		OperatorType LocalOperatorType (Function_declarationContext context)
 		{
 			var head = context.function_head ();
-			if (!ModifiersContains (head.declaration_modifiers (), kStatic))
-				return OperatorType.None;
 
 
 			// if the function declaration contains prefix 

--- a/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
@@ -268,7 +268,6 @@ public prefix func %--% (left:IntRep2) -> IntRep2 {
 
 
 		[Test]
-//		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void EnumInfixOpTest ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OperatorTests.cs
@@ -23,7 +23,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void OperatorSmokeTest0 ()
 		{
 			var swiftCode =
@@ -42,7 +41,6 @@ namespace SwiftReflector {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void OperatorSmokeTest1 ()
 		{
 			var swiftCode =
@@ -60,7 +58,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void OperatorSmokeTest2 ()
 		{
 			var swiftCode =
@@ -79,7 +76,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void OperatorSmokeTest3 ()
 		{
 			var swiftCode =
@@ -98,7 +94,6 @@ namespace SwiftReflector {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void OperatorCompositionNoInvoke ()
 		{
 			var swiftCode =
@@ -166,7 +161,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void MultiplicationConflict ()
 		{
 			var swiftCode =
@@ -189,7 +183,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void StructInfixOpTest ()
 		{
 			var swiftCode = @"
@@ -219,7 +212,6 @@ public func %^^% (left:IntRep, right: IntRep) -> IntRep {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void StructPrefixOpTest ()
 		{
 			var swiftCode = @"
@@ -248,7 +240,6 @@ public prefix func %++% (left:IntRep1) -> IntRep1 {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void StructPostfixOpTest ()
 		{
 			var swiftCode = @"
@@ -277,7 +268,7 @@ public prefix func %--% (left:IntRep2) -> IntRep2 {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
+//		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void EnumInfixOpTest ()
 		{
 			var swiftCode = @"
@@ -319,7 +310,6 @@ public func ^++^ (left: IntOrFloat, right: IntOrFloat) -> IntOrFloat {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void SimpleEnumInfixOpTest ()
 		{
 			var swiftCode = @"
@@ -348,7 +338,6 @@ public prefix func ^-^(val: CompassPoints) -> CompassPoints {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void SimpleEnumPostfixOpTest ()
 		{
 			var swiftCode = @"
@@ -379,7 +368,6 @@ public postfix func ^+^(val: CompassPoints1) -> CompassPoints1 {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void SuperSimpleEnumTest ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/UnicodeTests.cs
@@ -160,7 +160,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/618")]
 		public void UnicodeInOperatorName ()
 		{
 			string swiftCode =


### PR DESCRIPTION
Adjust the rules of detecting operators fixing issue [618](https://github.com/xamarin/binding-tools-for-swift/issues/618)
A number of operator tests were failing.
This was due to functions being misidentified as not being operators.
I had code that was enforcing that operator function implementations should be static and not instance. Neither of these are necessarily the case. Oops.

I moved the call of `currentElement.Push` to the end of the method because it really needs to be there. Anything else that looks at the top of the stack will see a function and not the enclosing type or module. This was getting in the way of debugging this as it was causing a different false negative.

12 failing tests now pass.