### PR TITLE
Closures as prop types

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -815,8 +815,9 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			if (setParamList != null) {
 				var parmName = context.getter_setter_keyword_block ()?.setter_keyword_clause ().new_value_name ()?.GetText ()
 					?? kNewValue;
+				var setterType = EscapePossibleClosureType (resultType);
 				var newValueParam = new XElement (kParameter, new XAttribute (kIndex, "0"),
-					new XAttribute (kType, resultType), new XAttribute (kPublicName, parmName),
+					new XAttribute (kType, setterType), new XAttribute (kPublicName, parmName),
 					new XAttribute (kPrivateName, parmName), new XAttribute (kIsVariadic, false));
 				setParamList.Add (newValueParam);
 				var setFunc = ToFunctionDeclaration ("set_" + context.variable_name ().GetText (),
@@ -1926,6 +1927,12 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				}
 			}
 			return false;
+		}
+
+		string EscapePossibleClosureType (string type)
+		{
+			var typeSpec = TypeSpecParser.Parse (type);
+			return typeSpec is ClosureTypeSpec ? "@escaping[] " + type : type;
 		}
 
 		static Dictionary<string, string> accessMap = new Dictionary<string, string> () {

--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -67,6 +67,15 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var endToken = context.Stop;
 			rewriter.Replace (startToken, endToken, replacementType);
 		}
+
+		public override void ExitIdentifier_type ([NotNull] Identifier_typeContext context)
+		{
+			if (context.GetText () == "Swift.Void") {
+				var startToken = context.Start;
+				var endToken = context.Stop;
+				rewriter.Replace (startToken, endToken, "()");
+			}
+		}
 	}
 }
 

--- a/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
@@ -790,7 +790,6 @@ open class SecondClass : FirstClass {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/619")]
 		public void TestClosureProp ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
This corrects an issue with closures as property types fixing issue [619](https://github.com/xamarin/binding-tools-for-swift/issues/619)

This issue was not what I thought it was.
Initially I thought it was because of the the default initializer to the property, but this turned out not to be the case.
Comparing the output of the compiler and the output of the parser, there were two differences:
1. The setter method's type wasn't just a closure. It had the `@escaping` attribute on it, even though this is not in the `.swiftinterface` file. I added the method `EscapePossibleClosureType` which spots the return type as a closure an puts on the attribute
2. The closure return type in the compiler is coming out `()` but the type in the parser is coming through as `Swift.Void`. I used the desugaring parser to change this.

Test now passes.