### PR TITLE
Let's variadic!

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1176,6 +1176,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var replacementPublicName = isSubscript ? "" : privateName;
 			var publicName = NoUnderscore (context.external_parameter_name ()?.GetText () ?? replacementPublicName);
 			var isVariadic = context.range_operator () != null;
+			if (isVariadic)
+				type = $"Swift.Array<{type}>";
 			var isEscaping = AttributesContains (typeAnnotation.attributes (), kEscaping);
 			var isAutoClosure = AttributesContains (typeAnnotation.attributes (), kAutoClosure);
 			var typeBuilder = new StringBuilder ();

--- a/tests/tom-swifty-test/SwiftReflector/ArrayTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ArrayTests.cs
@@ -292,7 +292,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/621")]
 		public void TestVariadicParameters ()
 		{
 			string swiftCode = @"public func intsAsArray (a:Int32 ... ) -> [Int32] {
@@ -312,7 +311,6 @@ return a
 
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/621")]
 		public void TestVariadiacInClass ()
 		{
 			string swiftCode = @"public class VarArr {
@@ -338,7 +336,6 @@ return a
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/621")]
 		public void TestVariadiacInOpenClass ()
 		{
 			string swiftCode = @"open class OpenVarArr {


### PR DESCRIPTION
Handle variadics correctly, fixing issue [621](https://github.com/xamarin/binding-tools-for-swift/issues/621)

In this case, I was pulling out the variadic flag correctly, but not splatting the type.

To splat a variadic type is to replace the sugared type `T ...` with it's equivalent `[T]` or `Swift.Array<T>`. This would be an unsafe transformation if this were allowed in swift:
```
public func foo (a: inout SomeType ...)
{
}
```
But `inout` is not allowed in variadic types, so yay!

Tests now pass.