### PR TITLE
Ensure that Error comes through as a protocol

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1305,6 +1305,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		bool TypeIsNotProtocol (string type)
 		{
+			// special case this - the type database as this as "other"
+			// which is technically not a protocol, but it is a protocol.
 			if (type == "Swift.Error")
 				return false;
 			var parts = type.Split ('.');

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1305,6 +1305,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		bool TypeIsNotProtocol (string type)
 		{
+			if (type == "Swift.Error")
+				return false;
 			var parts = type.Split ('.');
 			if (parts.Length == 1)
 				return true; // generic


### PR DESCRIPTION
Force Swift.Error to be a protocol fixing issue [600](https://github.com/xamarin/binding-tools-for-swift/issues/600)

This is ham-handed and I can't decide whose fault it is: Apple's or mine (probably mine).

The Error protocol isn't different from every other protocol in Swift. It is **syntactically** a protocol but its representation isn't an existential container, unlike every other protocol with no associated types in the whole dang language.

When I saw this, I assumed that it was not an actual protocol and represented it as "other".

So if you look it up in our type database, it's type is more-or-less "other".

This bypasses the lookup up and special cases it to get the inheritance in place.

There are no tests coming on line because while this is a bug, it was a benign one as it didn't actually affect any existing test (all the exception tests pass).