### PR TITLE
make the ctors and dtors have the right type

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -2222,7 +2222,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		}
 
 		static string [] ctorDtorNames = new string [] {
-			"init", "init?", "init!", "deinit"
+			kDotCtor, kDotDtor
 		};
 
 		static bool IsCtorDtor (string name)

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1426,6 +1426,27 @@ public class Foo {
 			Assert.AreEqual ("Public var SomeModule.Foo.prop: Swift.Int { get set }", output, "wrong signature");
 		}
 
+		[TestCase (ReflectorMode.Compiler)]
+		[TestCase (ReflectorMode.Parser)]
+		public void TestCtorType (ReflectorMode mode)
+		{
+			var code = @"
+public class Foo {
+	public init () { }
+}
+";
+			var module = ReflectToModules (code, "SomeModule", mode).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+			var cl = module.Classes.Where (c => c.Name == "Foo").FirstOrDefault ();
+			Assert.IsNotNull (cl, "no class");
+			var ctor = cl.AllConstructors ().FirstOrDefault ();
+			Assert.IsNotNull (ctor, "no constructor");
+			var pl = ctor.ParameterLists [0];
+			Assert.AreEqual (1, pl.Count, "wrong number of parameters");
+			var uncurriedType = pl [0].TypeName;
+			Assert.AreEqual ("SomeModule.Foo.Type", uncurriedType, "wrong type");
+		}
+
 
 		[TestCase (ReflectorMode.Compiler)]
 		[TestCase (ReflectorMode.Parser)]


### PR DESCRIPTION
Make sure that the instance type of constructors is the correct name fixing issue [590](https://github.com/xamarin/binding-tools-for-swift/issues/590)

The code was there, but I was looking for "init" variants and "deinit", but at this point I have sugared these names into ".ctor" and ".dtor".

Added a test, it passes.