### PR TITLE
Well That Was Easy

### DIFF
--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1717,7 +1717,7 @@ public func sum (a: Int!, b: Int!) -> Int! {
 
 
 		[TestCase (ReflectorMode.Compiler)]
-		[TestCase (ReflectorMode.Parser, Ignore = "SwiftInterfaceParserFailure https://github.com/xamarin/binding-tools-for-swift/issues/617")]
+		[TestCase (ReflectorMode.Parser)]
 		public void EnumProtocolConformance (ReflectorMode mode)
 		{
 			var code = @"


### PR DESCRIPTION
Checked on this test looking into issue [617](https://github.com/xamarin/binding-tools-for-swift/issues/617).

Turns out I fixed it in the error protocol special casing.