### PR TITLE
Fix on AnyObject constraint

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -3067,8 +3067,16 @@ namespace SwiftReflector {
 							var ic = bc as InheritanceConstraint;
 							if (ic != null) {
 								var cstype = TypeMapper.MapType (classDecl, ic.InheritsTypeSpec, false);
-								use.AddIfNotPresent (cstype.NameSpace);
-								return new CSIdentifier (cstype.Type);
+								// special cases? Yes, we like special cases.
+								// AnyObject is technically an empty protocol, so we map
+								// it to ISwiftObject.
+								if (cstype.FullName == "SwiftRuntimeLibrary.SwiftAnyObject") {
+									use.AddIfNotPresent (typeof (ISwiftObject));
+									return new CSIdentifier ("ISwiftObject");
+								} else {
+									use.AddIfNotPresent (cstype.NameSpace);
+									return new CSIdentifier (cstype.Type);
+								}
 							} else {
 								throw ErrorHelper.CreateError (ReflectorError.kCompilerBase + 26, "Equality constraints not supported yet.");
 							}

--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -286,8 +286,16 @@ namespace SwiftReflector {
 									var genRef = new CSIdentifier (CSGenericReferenceType.DefaultNamer (depthIndex.Item1, depthIndex.Item2));
 									retval.GenericConstraints.Add (new CSGenericConstraint (genTypeId, new CSIdentifier (genType.ToString ())));
 								} else {
-									packs.AddIfNotPresent (ntb.NameSpace);
-									retval.GenericConstraints.Add (new CSGenericConstraint (genTypeId, new CSIdentifier (ntb.Type)));
+									// special cases? Yes, we like special cases.
+									// AnyObject is technically an empty protocol, so we map
+									// it to ISwiftObject.
+									if (ntb.FullName == "SwiftRuntimeLibrary.SwiftAnyObject") {
+										packs.AddIfNotPresent (typeof (ISwiftObject));
+										retval.GenericConstraints.Add (new CSGenericConstraint (genTypeId, new CSIdentifier ("ISwiftObject")));
+									} else {
+										packs.AddIfNotPresent (ntb.NameSpace);
+										retval.GenericConstraints.Add (new CSGenericConstraint (genTypeId, new CSIdentifier (ntb.Type)));
+									}
 								}
 							} else if (constr is EqualityConstraint eq) {
 								// in swift: f<T, U> (a: T, b: U) where T: SwiftProto, U: T.AssocType

--- a/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
@@ -1268,7 +1268,6 @@ namespace SwiftReflector {
 		}
 
 		[Test]
-		[Ignore ("SwiftInterfaceParser error https://github.com/xamarin/binding-tools-for-swift/issues/620")]
 		public void TestSwiftMessagesWeak ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Fixes a fail on an AnyObject constraint per issue [620](https://github.com/xamarin/binding-tools-for-swift/issues/620)

This is a different issue then the ones we've seen before in that the output from the compiler based reflector is incorrect.
It's has the generic argument, but it misses the constraint.

When we add the constraint in, we have an issue in that C# doesn't like constraining to `SwiftRuntimeLibrary.AnyObject`. This is another weird thing because `Swift.AnyObject` is technically a protocol but it is also *not* a protocol because if you try to inherit from it in Swift you get the error message "Inheritance from non-protocol type 'AnyObject'". Make up your mind, Swift.

Since every class in BTfS implements `ISwiftObject` we can use that for the constraint and that's just fine.

In addition to the class generics, I also put it into method generics (which will also hit properties).

Test passes.