### PR TITLE
adjusted grammar to handle a list of variables

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -781,15 +781,12 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void EnterVariable_declaration ([NotNull] Variable_declarationContext context)
 		{
-			var name = UnTick (context.variable_name ().GetText ());
 			var head = context.variable_declaration_head ();
-			var resultType = TrimColon (context.type_annotation ().GetText ());
 			var accessibility = AccessibilityFromModifiers (head.declaration_modifiers ());
 			var attributes = GatherAttributes (head.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
 			var isUnavailable = CheckForUnavailable (attributes);
 			var isStatic = ModifiersContains (head.declaration_modifiers (), kStatic);
-			var hasThrows = false;
 			var isFinal = ModifiersContains (head.declaration_modifiers (), kFinal);
 			var isLet = head.let_clause () != null;
 			var isOptional = ModifiersContains (head.declaration_modifiers (), kOptional);
@@ -797,59 +794,66 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isRequired = ModifiersContains (head.declaration_modifiers (), kRequired);
 			var isProperty = true;
 
-			var getParamList = new XElement (kParameterList, new XAttribute (kIndex, "1"));
-			var getFunc = ToFunctionDeclaration ("get_" + name,
-				resultType, accessibility, isStatic, hasThrows, isFinal, isOptional,
-				isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
-				isUnavailable, isMutating, isRequired, isProperty, attributes);
+			foreach (var tail in context.variable_declaration_tail ()) {
 
-			currentElement.Push (getFunc);
-			var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
-			currentElement.Pop ();
-			getFunc.Add (getParamLists);
-			AddElementToParentMembers (getFunc);
-			AddObjCSelector (getFunc);
+				var name = UnTick (tail.variable_name ().GetText ());
+				var resultType = TrimColon (tail.type_annotation ().GetText ());
+				var hasThrows = false;
 
-			var setParamList = HasSetter (context, isLet) ?
-				new XElement (kParameterList, new XAttribute (kIndex, "1")) : null;
-
-			if (setParamList != null) {
-				var parmName = context.getter_setter_keyword_block ()?.setter_keyword_clause ().new_value_name ()?.GetText ()
-					?? kNewValue;
-				var setterType = EscapePossibleClosureType (resultType);
-				var newValueParam = new XElement (kParameter, new XAttribute (kIndex, "0"),
-					new XAttribute (kType, setterType), new XAttribute (kPublicName, parmName),
-					new XAttribute (kPrivateName, parmName), new XAttribute (kIsVariadic, false));
-				setParamList.Add (newValueParam);
-				var setFunc = ToFunctionDeclaration ("set_" + name,
-					"()", accessibility, isStatic, hasThrows, isFinal, isOptional,
+				var getParamList = new XElement (kParameterList, new XAttribute (kIndex, "1"));
+				var getFunc = ToFunctionDeclaration ("get_" + name,
+					resultType, accessibility, isStatic, hasThrows, isFinal, isOptional,
 					isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
 					isUnavailable, isMutating, isRequired, isProperty, attributes);
 
-				currentElement.Push (setFunc);
-				var setParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), setParamList);
+				currentElement.Push (getFunc);
+				var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
 				currentElement.Pop ();
+				getFunc.Add (getParamLists);
+				AddElementToParentMembers (getFunc);
+				AddObjCSelector (getFunc);
 
-				setFunc.Add (setParamLists);
-				AddElementToParentMembers (setFunc);
-				AddObjCSelector (setFunc);
+				var setParamList = HasSetter (tail, isLet) ?
+					new XElement (kParameterList, new XAttribute (kIndex, "1")) : null;
+
+				if (setParamList != null) {
+					var parmName = tail.getter_setter_keyword_block ()?.setter_keyword_clause ().new_value_name ()?.GetText ()
+						?? kNewValue;
+					var setterType = EscapePossibleClosureType (resultType);
+					var newValueParam = new XElement (kParameter, new XAttribute (kIndex, "0"),
+						new XAttribute (kType, setterType), new XAttribute (kPublicName, parmName),
+						new XAttribute (kPrivateName, parmName), new XAttribute (kIsVariadic, false));
+					setParamList.Add (newValueParam);
+					var setFunc = ToFunctionDeclaration ("set_" + name,
+						"()", accessibility, isStatic, hasThrows, isFinal, isOptional,
+						isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
+						isUnavailable, isMutating, isRequired, isProperty, attributes);
+
+					currentElement.Push (setFunc);
+					var setParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), setParamList);
+					currentElement.Pop ();
+
+					setFunc.Add (setParamLists);
+					AddElementToParentMembers (setFunc);
+					AddObjCSelector (setFunc);
+				}
+
+				var prop = new XElement (kProperty, new XAttribute (kName, name),
+					new XAttribute (nameof (accessibility), accessibility),
+					new XAttribute (kType, resultType),
+					new XAttribute (kStorage, kComputed),
+					new XAttribute (nameof (isStatic), XmlBool (isStatic)),
+					new XAttribute (nameof (isLet), XmlBool (isLet)),
+					new XAttribute (nameof (isDeprecated), XmlBool (isDeprecated)),
+					new XAttribute (nameof (isUnavailable), XmlBool (isUnavailable)),
+					new XAttribute (nameof (isOptional), XmlBool (isOptional)));
+				AddElementToParentMembers (prop);
 			}
-
-			var prop = new XElement (kProperty, new XAttribute (kName, name),
-				new XAttribute (nameof (accessibility), accessibility),
-				new XAttribute (kType, resultType),
-				new XAttribute (kStorage, kComputed),
-				new XAttribute (nameof (isStatic), XmlBool (isStatic)),
-				new XAttribute (nameof (isLet), XmlBool (isLet)),
-				new XAttribute (nameof (isDeprecated), XmlBool (isDeprecated)),
-				new XAttribute (nameof (isUnavailable), XmlBool (isUnavailable)),				
-				new XAttribute (nameof (isOptional), XmlBool (isOptional)));
-			AddElementToParentMembers (prop);
 
 			PushIgnore ();
 		}
 
-		bool HasSetter (Variable_declarationContext context, bool isLet)
+		bool HasSetter (Variable_declaration_tailContext context, bool isLet)
 		{
 			// conditions for having a setter:
 			// getter_setter_keyword_block is null (public var foo: Type)

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -52,9 +52,10 @@ import_kind :
 import_path : import_path_identifier (OpDot import_path_identifier)* ;
 import_path_identifier : declaration_identifier ;
 
-variable_declaration: variable_declaration_head variable_name type_annotation getter_setter_keyword_block? ;
+variable_declaration: variable_declaration_head variable_declaration_tail (OpComma variable_declaration_tail)* ;
 variable_declaration_head : attributes? declaration_modifiers? var_clause
 	| attributes? declaration_modifiers? let_clause ;
+variable_declaration_tail : variable_name type_annotation getter_setter_keyword_block? ;
 variable_name : declaration_identifier ;
 
 var_clause : 'var';

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -121,6 +121,8 @@ public class Imag {
 			var cl = module.Classes.FirstOrDefault (c => c.Name == "Imag");
 			Assert.IsNotNull (cl, "no class");
 
+			Assert.AreEqual (2, cl.AllProperties ().Count, "wrong property count");
+
 			var fn = cl.Members.FirstOrDefault (m => m.Name == "==") as FunctionDeclaration;
 			Assert.IsNotNull (fn, "no function");
 
@@ -148,6 +150,8 @@ public class Imag {
 
 			var cl = module.Classes.FirstOrDefault (c => c.Name == "Imag");
 			Assert.IsNotNull (cl, "no class");
+
+			Assert.AreEqual (2, cl.AllProperties ().Count, "wrong property count");
 
 			var fn = cl.Members.FirstOrDefault (m => m.Name == "*^*") as FunctionDeclaration;
 			Assert.IsNotNull (fn, "no function");


### PR DESCRIPTION
Adjust grammar to handle a list of variables fixing issue [624](https://github.com/xamarin/binding-tools-for-swift/issues/624)

This was a funny issue. I was sure it was a grammar error involving operators, but I was wrong. Instead it was an error in handling lists of variables.

I adjusted the grammar to handle this. To do this I broke up the grammar into a variable_declaration_head (already present) and a variable_declaration_tail. This allowed me to to rewrite the declaration grammar to handle lists easily.

From there, I refactored the variable declaration handler to run a loop over the tails.

Tests adjusted and passing. 