### PR TITLE
Test branch

### DIFF
--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -244,10 +244,11 @@ namespace SwiftReflector {
 
 			var modulesInLibraries = SwiftModuleFinder.FindModuleNames (libraryDirectories, CompilerInfo.Target);
 
-			List<ISwiftModuleLocation> locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries,
-			                                                                                     includeDirectories, CompilerInfo.Target);
+			var locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries, includeDirectories, CompilerInfo.Target)
+				.Select (loc => loc.DirectoryPath).ToList ();
+			locations.AddRange (includeDirectories);
 
-			ReflectWithStrategies (locations.Select (loc => loc.DirectoryPath), libraryDirectories, pathName, extraArgs, moduleNames);
+			ReflectWithStrategies (locations, libraryDirectories, pathName, extraArgs, moduleNames);
 			return Reflector.FromXmlFile (pathName);
 		}
 

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5359,11 +5359,6 @@ namespace SwiftReflector {
 					using (DisposableTempDirectory dir = new DisposableTempDirectory ("wrapreflect", true)) {
 						string outputPath = dir.UniquePath (wrappingModuleName, "reflect", "xml");
 						var mdecl = compiler.ReflectToModules (mods, libs, "", wrappingModuleName).FirstOrDefault ();
-						//var output = compiler.Reflect (mods, libs, outputPath, "", wrappingModuleName);
-						////ModuleDeclaration mdecl = Reflector.FromXmlFile (outputPath) [0];
-						//if (!mdecl.IsCompilerCompatibleWith(CompilerVersion)) {
-						//	throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 48, $"The module {mods [0]} was compiled with the swift compiler version {mdecl.SwiftCompilerVersion}. It is incompatible with the compiler in {SwiftCompilerLocations.SwiftCompilerBin} which is version {CompilerVersion}");
-						//}
 						return new WrappingResult (wrapperModulePath, wrapperLibraryPath, wrapperModuleContents, mdecl, wrappingCompiler.FunctionReferenceCodeMap);
 					}
 				}

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5354,6 +5354,7 @@ namespace SwiftReflector {
 				var targetInfo = ReflectorLocations.GetTargetInfo (targets [0]);
 				using (CustomSwiftCompiler compiler = new CustomSwiftCompiler (targetInfo, null, true)) {
 					compiler.Verbose = verbose;
+					compiler.ReflectionTypeDatabase = TypeMapper.TypeDatabase;
 					var libs = new List<string> (libraryPaths);
 					libs.Add (outputDirectory);
 					using (DisposableTempDirectory dir = new DisposableTempDirectory ("wrapreflect", true)) {

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5358,11 +5358,12 @@ namespace SwiftReflector {
 					libs.Add (outputDirectory);
 					using (DisposableTempDirectory dir = new DisposableTempDirectory ("wrapreflect", true)) {
 						string outputPath = dir.UniquePath (wrappingModuleName, "reflect", "xml");
-						var output = compiler.Reflect (mods, libs, outputPath, "", wrappingModuleName);
-						ModuleDeclaration mdecl = Reflector.FromXmlFile (outputPath) [0];
-						if (!mdecl.IsCompilerCompatibleWith(CompilerVersion)) {
-							throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 48, $"The module {mods [0]} was compiled with the swift compiler version {mdecl.SwiftCompilerVersion}. It is incompatible with the compiler in {SwiftCompilerLocations.SwiftCompilerBin} which is version {CompilerVersion}");
-						}
+						var mdecl = compiler.ReflectToModules (mods, libs, "", wrappingModuleName).FirstOrDefault ();
+						//var output = compiler.Reflect (mods, libs, outputPath, "", wrappingModuleName);
+						////ModuleDeclaration mdecl = Reflector.FromXmlFile (outputPath) [0];
+						//if (!mdecl.IsCompilerCompatibleWith(CompilerVersion)) {
+						//	throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 48, $"The module {mods [0]} was compiled with the swift compiler version {mdecl.SwiftCompilerVersion}. It is incompatible with the compiler in {SwiftCompilerLocations.SwiftCompilerBin} which is version {CompilerVersion}");
+						//}
 						return new WrappingResult (wrapperModulePath, wrapperLibraryPath, wrapperModuleContents, mdecl, wrappingCompiler.FunctionReferenceCodeMap);
 					}
 				}


### PR DESCRIPTION
Code was using the wrong API for reflecting, now using the correct one. Some new tests will fail due to parse errors, this is OK.