### PR TITLE
workaround for maximal munch

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -564,7 +564,7 @@ keyword_as_identifier_in_labels : 'Any' | 'Protocol' | 'Self' | 'Type'
 operator : operator_angles | Operator ;
 
 // 8 consecutive '>' in an operator ought to be enough for anyone
-operator_angles : '>' '>' | '>' '>' '>' | '>' '>' '>' '>' '>' |
+operator_angles : '>' | '>' '>' | '>' '>' '>' | '>' '>' '>' '>' '>' |
 	'>' '>' '>' '>' '>' '>' | '>' '>' '>' '>' '>' '>' '>' |
 	'>' '>' '>' '>' '>' '>' '>' '>' ;
 

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -467,7 +467,7 @@ fragment Identifier_characters : Identifier_character+ ;
 
 Implicit_parameter_name : '$' Decimal_digits ;
 
-generic_parameter_clause : OpLess generic_parameter_list OpGreater  ;
+generic_parameter_clause : OpLess generic_parameter_list opGreater  ;
 generic_parameter_list : generic_parameter (OpComma generic_parameter)*  ;
 generic_parameter : type_name
 	| type_name OpColon type_identifier
@@ -481,13 +481,13 @@ requirement : conformance_requirement | same_type_requirement  ;
 conformance_requirement : type_identifier ':' type_identifier | type_identifier ':' protocol_composition_type  ;
 same_type_requirement : type_identifier OpEqEq type  ;
 
-generic_argument_clause : OpLess generic_argument_list OpGreater ;
+generic_argument_clause : OpLess generic_argument_list opGreater ;
 generic_argument_list : generic_argument (',' generic_argument)* ;
 generic_argument : type ;
 
+opGreater : '>';
 arrow_operator : '->' ;
 range_operator : '...' ;
-
 
 WS : [ \n\r\t\u000B\u000C\u0000]+ -> channel(HIDDEN) ;
 
@@ -497,7 +497,7 @@ OpAssign : '=' ;
 OpAmp : '&' ;
 OpQuestion : '?' ;
 OpLess : '<' ;
-OpGreater : '>' ;
+//OpGreater : '>' ;
 OpBang : '!' ;
 OpDot : '.' ;
 OpComma : ',' ;
@@ -561,14 +561,20 @@ keyword_as_identifier_in_labels : 'Any' | 'Protocol' | 'Self' | 'Type'
 	| 'where' | 'while' | 'willSet' | 'x86_64'
 	;
  
-operator : Operator ;
+operator : operator_angles | Operator ;
 
+// 8 consecutive '>' in an operator ought to be enough for anyone
+operator_angles : '>' '>' | '>' '>' '>' | '>' '>' '>' '>' '>' |
+	'>' '>' '>' '>' '>' '>' | '>' '>' '>' '>' '>' '>' '>' |
+	'>' '>' '>' '>' '>' '>' '>' '>' ;
 
 Operator :
 	OperatorHead OperatorCharacters?
+	| OperatorHeadGreater OperatorFollowNoGreater
+	| OperatorHeadGreater OperatorFollowNoGreater OperatorFollow+
 	| DotOperatorHead DotOperatorFollow+;
 
-OperatorHead :
+fragment OperatorHeadGreater :
 	('/' | '=' | '-' | '+' | '!' | '*' | '%' | '&' | '|' | '<' | '>' | '^' | '~' | '?')
 	| [\u00A1-\u00A7]
 	| [\u00A9\u00AB] | [\u00AC\u00AE]
@@ -580,7 +586,36 @@ OperatorHead :
 	| [\u3001-\u3003] | [\u3008-\u3020] | [\u3030]
 	;
 
-OperatorCharacters : OperatorFollow+;
+
+fragment OperatorHead :
+	('/' | '=' | '-' | '+' | '!' | '*' | '%' | '&' | '|' | '<' | '^' | '~' | '?')
+	| [\u00A1-\u00A7]
+	| [\u00A9\u00AB] | [\u00AC\u00AE]
+	| [\u00B0-\u00B1\u00B6\u00BB\u00BF\u00D7\u00F7]
+	| [\u2016-\u2017\u2020-\u2027] | [\u2030-\u203E]
+	| [\u2041-\u2053] | [\u2055-\u205E]
+	| [\u2190-\u23FF] | [\u2500-\u2775]
+	| [\u2794-\u2BFF] | [\u2E00-\u2E7F]
+	| [\u3001-\u3003] | [\u3008-\u3020] | [\u3030]
+	;
+
+fragment OperatorCharacters : OperatorFollow+;
+
+fragment OperatorFollowNoGreater :
+	('/' | '=' | '-' | '+' | '!' | '*' | '%' | '&' | '|' | '<' | '^' | '~' | '?')
+	| [\u00A1-\u00A7]
+	| [\u00A9\u00AB] | [\u00AC\u00AE]
+	| [\u00B0-\u00B1\u00B6\u00BB\u00BF\u00D7\u00F7]
+	| [\u0300–\u036F]
+	| [\u1DC0-\u1DFF] | [\u20D0-\u20FF]
+	| [\u2016-\u2017\u2020-\u2027] | [\u2030-\u203E]
+	| [\u2041-\u2053] | [\u2055-\u205E]
+	| [\u2190-\u23FF] | [\u2500-\u2775]
+	| [\u2794-\u2BFF] | [\u2E00-\u2E7F]
+	| [\u3001-\u3003] | [\u3008-\u3020] | [\u3030]
+	| [\ufe00-\ufe0f] | [\ufe20-\ufe2f]
+	| [\u{e0100}-\u{e01ef}]
+	;
 
 fragment OperatorFollow :
 	('/' | '=' | '-' | '+' | '!' | '*' | '%' | '&' | '|' | '<' | '>' | '^' | '~' | '?')
@@ -606,4 +641,3 @@ OpEqEq : '==' ;
 
 
 Comment_line: '//' ~[\r\n]* ;
-


### PR DESCRIPTION
The maximal munch problem is a well known issue in parsing that is seen in languages like C and C++ whereby the lexer makes the choice to match on the longest token that it finds.
This creates ambiguities.
In our case, if you have the following expression
```
a: UnsafeMutablePointer<Swift.Optional<Swift.Int>>
```
The lexer will see the following tokens:
- `a`
- `:`
- `UnsafeMutablePointer`
- `<`
- `Swift`
- `.`
- `Optional`
- `<`
- `Swift`
- `.`
- `Int`
- `>>`

And it's the last one that's the problem. The lexer thinks that `>>` is an operator and not two separate `>` tokens.

The trick is to convince the lexer that `>` is a single token.
How do we do this?
First some background.
Antlr has a convention that a rule that starts with a lower case letter is a parser rule and that a rule that starts with an upper case letter is a lexer rule.
By the time parser rules are run, the lexer rules have already run.
When you see the lexer modifier `fragment` it means that the lexer rule is not actually a rule, but a macro that gets substituted into other lexer rules.

First, I made `OpGreater` a parser rule `opGreater` which changes how it gets used.
Second, I modifier the Operator lexer rule to *never* generate a `>>` token. You can have, say, an operator named `>=>`. We can do this the following modified rules:
```
Operator :
	OperatorHead OperatorCharacters?
	| OperatorHeadGreater OperatorFollowNoGreater
	| OperatorHeadGreater OperatorFollowNoGreater OperatorFollow+
	| DotOperatorHead DotOperatorFollow+;
```
The lexer rule `OperatorHead OperatorCharacters?` will never generate a token that starts with `>`. And the next two rules can generate tokens that start with `>` but will never be followed by `>`.

The final piece is that I redefine the `operator` parser rule to match an operator or any combination of `>` tokens up to 8 (figuring that if someone defines an operator `>>>>>>>>>` in Swift, they have bigger problems to deal with and I'm not qualified to help them with that.

Why does this work? Because we've pushed the ambiguity out of the lexer and into the parser. In theory, this will match an operator in the form `public operator > > { /* ... */ }` with the space between them and treat them like `>>`. In practice we'll never see this because this is not a legal operator name and we'll never see it.
