### PR TITLE
handle default initializers

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -257,13 +257,30 @@ parameter_clause : OpLParen OpRParen | OpLParen parameter_list OpRParen ;
 parameter_list : parameter (OpComma parameter)* ;
 
 parameter : 
-	external_parameter_name? local_parameter_name type_annotation
+	external_parameter_name? local_parameter_name type_annotation defaultInitializer?
 	| external_parameter_name? local_parameter_name type_annotation range_operator
 	;
 external_parameter_name : label_identifier ;
 local_parameter_name : label_identifier ;
 
+defaultInitializer : '=' dyckExpression+ ;
+dyckExpression : 
+	 OpLParen dyckSubExpression* OpRParen
+	| OpLBracket dyckSubExpression* OpRBracket
+	| OpLBrace dyckSubExpression* OpRBrace
+	| label_identifier
+	| literal
+	| operator
+	;
+dyckSubExpression :
+	dyckExpression
+	| any_other_things_for_dyck_expression;
 
+any_other_things_for_dyck_expression :	
+	( OpDot | OpComma | OpColon | OpSemi | OpAssign | OpAt | OpPound | OpBackTick | OpQuestion | OpUnder)
+	| arrow_operator
+	;
+	
 declaration_identifier : Identifier | keyword_as_identifier_in_declarations ;
 
 type_inheritance_clause :


### PR DESCRIPTION
Fix inability to handle default argument values fixing issue [627](https://github.com/xamarin/binding-tools-for-swift/issues/627)

The problem here is that the contents of a default argument value can be nearly the entire swift language. We are very much trying to **not** parser the entire swift language.

Let's give an example to show the scope of the problem:
```
public func someFunc(a: (Int)->Int = { y in return y * 2 }, x: Int) -> Int {
    return a(x)
}
```
The argument type is a closure and the default value is an implementation of that closure. When you look at the generated swift interface file, the default closure is present in its entirety, so we are responsible for parsing it.

Great.

Turns out that since we don't care at all what are in default values we can change the problem domain from "parse any valid swift expression" to anything that parses a superset of that language and not too much.

Enter the Dyck language which is essentially a language that consists of either tokens or tokens within balanced brackets.

In this case define a top level `dykeExpression` which consists of a few simple swift types or a bracketed sub-expression. The reason for this is that the `any_other_things_for_dyck_expression` appears in the main expression list, it will include a `,` which will then bleed into all the following parameters.
