### PR TITLE
fix for module loading

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -197,6 +197,7 @@ namespace SwiftReflector {
 
 			var declsPerModule = new List<List<BaseDeclaration>> ();
 			foreach (ModuleDeclaration moduleDeclaration in moduleDeclarations) {
+				TypeMapper.TypeDatabase.ModuleDatabaseForModuleName (moduleDeclaration.Name);
 				var allTypesAndTopLevel = moduleDeclaration.AllTypesAndTopLevelDeclarations;
 				TypeMapper.RegisterClasses (allTypesAndTopLevel.OfType<TypeDeclaration> ());
 				declsPerModule.Add (allTypesAndTopLevel);

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1636,6 +1636,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			var failures = new StringBuilder ();
 			foreach (var module in importModules) {
+				if (module == "XamGlue")
+					continue;
 				if (!moduleLoader.Load (module, typeDatabase)) {
 					if (failures.Length > 0)
 						failures.Append (", ");
@@ -1899,13 +1901,15 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		}
 
 		string ReplaceGlobalName (string nonQualified)
-		{
+		{		
 			foreach (var module in importModules) {
 				var candidateName = $"{module}.{nonQualified}";
 				var entity = typeDatabase.TryGetEntityForSwiftName (candidateName);
 				if (entity != null)
 					return candidateName;
 			}
+			if (nonQualified == "EveryProtocol")
+				return "XamGlue.EveryProtocol";
 			return null;
 		}
 

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1901,7 +1901,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		}
 
 		string ReplaceGlobalName (string nonQualified)
-		{		
+		{
 			foreach (var module in importModules) {
 				var candidateName = $"{module}.{nonQualified}";
 				var entity = typeDatabase.TryGetEntityForSwiftName (candidateName);

--- a/SwiftReflector/TypeMapping/TypeDatabase.cs
+++ b/SwiftReflector/TypeMapping/TypeDatabase.cs
@@ -308,14 +308,20 @@ namespace SwiftReflector.TypeMapping {
 			}
 		}
 
-		public void AddOperator (OperatorDeclaration op, string moduleName = null)
+		public ModuleDatabase ModuleDatabaseForModuleName (string moduleName)
 		{
-			moduleName = moduleName ?? op.ModuleName;
-			ModuleDatabase db = null;
+			ModuleDatabase db;
 			if (!modules.TryGetValue (moduleName, out db)) {
 				db = new ModuleDatabase ();
 				modules.Add (moduleName, db);
 			}
+			return db;
+		}
+
+		public void AddOperator (OperatorDeclaration op, string moduleName = null)
+		{
+			moduleName = moduleName ?? op.ModuleName;
+			ModuleDatabase db = ModuleDatabaseForModuleName (moduleName);
 			db.Operators.Add (op);
 		}
 


### PR DESCRIPTION
Fixes two related issues in module loading fixing issue [641](https://github.com/xamarin/binding-tools-for-swift/issues/641)
The first is that we are instructed to try to load the module "XamGlue" which doesn't generally have any types in it with one exception: `EveryProtocol` which will only get seen as an extension. There are no type database entries for it, so loading always failed. I special cased that out.
I also put in a fallback in the type searching that would return `XamGlue.EveryProtocol` if the type was `EveryProtocol`. This is intentionally done __after__ the rest of the modules have been searched on the off-chance that someone else named a type `EveryProtocol` and to give that type priority.

There was also one other minor but related issue where if a module doesn't export any types of operators then the type database doesn't know anything about the module. I refactored the type database code to have an entry point that can assert the existence of a module even if it has no types in it. In the bottleneck where we add all the types to the type database, I make that assertion.