### PR TITLE
fix up mmp issues.

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -20,6 +20,7 @@ namespace SwiftReflector {
 	[RunWithLeaks]
 	public class NewClassCompilerTests {
 		[Test]
+		[Ignore ("https://github.com/xamarin/binding-tools-for-swift/issues/645")]
 		public void SmokeTest ()
 		{
 			string code = "public final class Bar { }";

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -686,7 +686,14 @@ public static class Console {
 					var output = new StringBuilder ();
 					var responseFile = Path.Combine (workingDirectory, name + ".rsp");
 					File.WriteAllText (responseFile, mmp.ToString ());
-					var rv = ExecAndCollect.RunCommand ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", "--link_flags=-headerpad_max_install_names " + StringUtils.Quote ($"@{responseFile}"), output: output, verbose: true);
+					// The test environment is coming is with PKG_CONFIG_LIBDIR=""
+					// which causes macOS tests to fail. This removes the environment
+					// variable and lets the tests pass.
+					var env = new Dictionary<string, string> () {
+						{ "PKG_CONFIG_LIBDIR", null }
+					};
+					var rv = ExecAndCollect.RunCommand ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", "--link_flags=-headerpad_max_install_names " + StringUtils.Quote ($"@{responseFile}"),
+						env: env, output: output, verbose: true);
 					if (rv != 0) {
 						Console.WriteLine (output);
 						throw new Exception ($"Failed to run mmp, exit code: {rv}");

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -268,7 +268,7 @@ public class Bar : Foo, Nifty {
 		}
 
 		[Test]
-		[Ignore ("Throwing wrong exception ")]
+		[Ignore ("Throwing wrong exception")]
 		public void WontLoadThisModuleHere ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -268,6 +268,7 @@ public class Bar : Foo, Nifty {
 		}
 
 		[Test]
+		[Ignore ("Throwing wrong exception ")]
 		public void WontLoadThisModuleHere ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
Sort out mmp problem, fixing issue [643](https://github.com/xamarin/binding-tools-for-swift/issues/643)

This is partly an exercise in finding an issue and partly an issue in making life better for future engineer.

In this issue, a number of tests were failing running `mmp` which was due to `pkg-config` failing.
It took a while to isolate the issue with pkg-config. This took a while because running the mmp command from a shell worked fine. To manage this, I injected some code to print out all the environment variables and then started up a shell with an empty environment and ran a script with the code. This duplicated the error.
From there it was a matter of finding either enabling variable(s) in my usual shell or disabling variables(s) in the test runtime.

It turned out to be test runtime environment.

I put code in `ExecAndCollect` to dump the environment in addition to the command. This means that the entire output can go into a script if something like this turns up in the future.

In addition, I noticed that there was some chatter in stderr that was interfering with test output. I opened an issue on that [here](https://github.com/xamarin/binding-tools-for-swift/issues/647) and made the decision to only include stderr when the return from executing something was non-0.

There are two remaining failing tests which are ignored with issues opened on them.