### PR TITLE
unstumble device builds

### DIFF
--- a/leaktest/leak-at-exit.c
+++ b/leaktest/leak-at-exit.c
@@ -48,7 +48,7 @@ my__exit (int status)
 	if (errno != ENOENT)
 		fprintf (stdout, "Failed to access done file %s: %s\n", done_file, strerror (errno));
 
-	fprintf (stdout, "Leak check performed\n");
+	fprintf (stderr, "Leak check performed\n");
 
 	system__exit (status);
 }

--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -488,7 +488,7 @@ namespace tomwiftytest {
 					env.Add ("LEAKTEST_STDOUT_PATH", outputFile);
 				} else {
 					foreach (var key in new List<string> (env.Keys)) {
-						if (key.StartsWith ("LEAKTEST", StringComparison.Ordinal))
+						if (key.StartsWith ("LEAK", StringComparison.Ordinal))
 							env.Remove (key);
 					}
 				}

--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -486,6 +486,11 @@ namespace tomwiftytest {
 					// Running with leaks causes additional output to stdout/stderr, so take steps to write the stdout from the test itself to a file to untangle it from leaks' output.
 					outputFile = Path.GetTempFileName ();
 					env.Add ("LEAKTEST_STDOUT_PATH", outputFile);
+				} else {
+					foreach (var key in new List<string> (env.Keys)) {
+						if (key.StartsWith ("LEAKTEST", StringComparison.Ordinal))
+							env.Remove (key);
+					}
 				}
 
 				var rv = ExecAndCollect.RunCommand (executable, args.ToString (), env, output, workingDirectory: workingDirectory ?? string.Empty);

--- a/tests/tom-swifty-test/Makefile
+++ b/tests/tom-swifty-test/Makefile
@@ -6,7 +6,7 @@ all: build run-tests
 	@# has already calculated required variables that contain output from
 	@# the 'run-tests' target, which hadn't executed when the variables were
 	@# evaluated.
-	$(MAKE) -j8 build-device-tests
+	#$(MAKE) -j8 build-device-tests
 
 check: run-tests
 

--- a/tests/tom-swifty-test/Makefile
+++ b/tests/tom-swifty-test/Makefile
@@ -62,6 +62,8 @@ bin/devicetests/$(1)/$(2)/$(4): $$(wildcard devicetests/$(4)/swiftsrc/*.swift)
 	$$(call Q_2,SWIFTC [$(1)/$(2)]) $(SYSTEM_SWIFTC) \
 		-emit-module \
 		-emit-library \
+		-enable-library-evolution \
+		-emit-module-interface \
 		-g \
 		-sdk $$(shell xcrun --sdk "$(5)" --show-sdk-path) \
 		-target $(3) \
@@ -94,6 +96,7 @@ bin/devicetests/$(1)/$(2).framework/$(2): $$(foreach arch,$(3),bin/devicetests/$
 	$$(Q) mkdir -p bin/devicetests/$(1)/$(2).framework/Modules/$(2).swiftmodule
 	$$(Q) $$(foreach arch,$(3),$(CP) bin/devicetests/$(1)/$$(arch)/$(2).swiftdoc bin/devicetests/$(1)/$(2).framework/Modules/$(2).swiftmodule/$$(arch).swiftdoc &&) true
 	$$(Q) $$(foreach arch,$(3),$(CP) bin/devicetests/$(1)/$$(arch)/$(2).swiftmodule bin/devicetests/$(1)/$(2).framework/Modules/$(2).swiftmodule/$$(arch).swiftmodule &&) true
+	$$(Q) $$(foreach arch,$(3),$(CP) bin/devicetests/$(1)/$$(arch)/$(2).swiftinterface bin/devicetests/$(1)/$(2).framework/Modules/$(2).swiftmodule/$$(arch).swiftinterface &&) true
 	$$(call Q_2,LIPO [$(1)]) lipo $$^ -create -output $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -101,7 +101,8 @@ namespace SwiftReflector {
 			CSCodeBlock callingCode = CSCodeBlock.Create (decl, decl1, invoker);
 
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSingleSubscriptGetOnly{type}", otherClass : overCS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSingleSubscriptGetOnly{type}", otherClass : overCS,
+				platform: PlatformName.macOS);
 		}
 
 		[Test]
@@ -284,7 +285,8 @@ namespace SwiftReflector {
 			CSLine invoker = CSFunctionCall.FunctionCallLine ("tester.DoIt", false, new CSIdentifier ("myOver"));
 			CSCodeBlock callingCode = CSCodeBlock .Create (decl, decl1, invoker);
 
-			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSubscriptGetSetOnly{type}", otherClass : overCS);
+			TestRunning.TestAndExecute (swiftCode, callingCode, expected, testName : $"WrapSubscriptGetSetOnly{type}", otherClass : overCS,
+				platform: PlatformName.macOS);
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/SwiftTypeAttributeNameTests.cs
@@ -35,7 +35,8 @@ public class BoringClass🤡 {
 }
 ";
 			var callingCode = PrintTypeName ("BoringClassU0001F921", true);
-			TestRunning.TestAndExecute (swiftCode, callingCode, "2E-42-6F-72-69-6E-67-43-6C-61-73-73-F0-9F-A4-A1\n");
+			TestRunning.TestAndExecute (swiftCode, callingCode, "2E-42-6F-72-69-6E-67-43-6C-61-73-73-F0-9F-A4-A1\n",
+				platform: PlatformName.macOS);
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftDateTests.cs
+++ b/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftDateTests.cs
@@ -27,8 +27,9 @@ public func dateIsNotUsed () { }
 			var clID = new CSIdentifier ("date");
 			var clDecl = CSVariableDeclaration.VarLine (CSSimpleType.Var, clID, new CSFunctionCall ("SwiftDate.SwiftDate_TimeIntervalSince1970", false, CSConstant.Val (0.0)));
 			var printer = CSFunctionCall.ConsoleWriteLine (new CSFunctionCall ($"{clID.Name}.ToNSDate", false));
+			var disposer = CSFunctionCall.FunctionCallLine ($"{clID.Name}.Dispose");
 
-			var callingCode = CSCodeBlock.Create (clDecl, printer);
+			var callingCode = CSCodeBlock.Create (clDecl, printer, disposer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "1970-01-01 00:00:00 +0000\n", testName: $"BasicTest{platform}", platform: platform);
 		}
 	}

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -151,7 +151,6 @@ namespace tomwiftytest {
 			if (enforceUTF8Encoding) {
 				InsertUTF8Assertion (body);
 			}
-			body.AddRange (callingCode);
 			body.Add (CaptureSwiftOutputPostlude (testName));
 
 			CSMethod run = new CSMethod (CSVisibility.Public, CSMethodKind.None, CSSimpleType.Void, new CSIdentifier ("Run"),


### PR DESCRIPTION
Ensure that the right compiler flags are set
Ensure that swift interface files are copied
Deduplicate test code
Don't device test unit tests that conflict.
Took devices tests back off line because of a signing issue, [here](https://github.com/xamarin/binding-tools-for-swift/issues/650).