### PR TITLE
[CI] Uses the correct hash to set the status.

### DIFF
--- a/devops/automation/azure-pipelines.yml
+++ b/devops/automation/azure-pipelines.yml
@@ -221,7 +221,7 @@ jobs:
       TARGET_URL="https://bosstoragemirror.blob.core.windows.net/wrench/binding-tools-for-swift/toolchain/$FILENAME"
       # VSTS does provide a diff build id depending if it is a PR or a CI triggered build, this results in issues when
       # setting the status :/ 
-      COMMIT_ID="$BUILD_BUILDID"
+      COMMIT_ID="$BUILD_SOURCEVERSION"
       echo "Build reason is $BUILD_REASON"
       if [[ "$BUILD_REASON" == "PullRequest" ]]; then
         echo "Setting commit id to $SYSTEM_PULLREQUEST_SOURCECOMMITID"
@@ -272,7 +272,7 @@ jobs:
       fi
       FILENAME="$(basename "$FILE")"
       TARGET_URL="https://bosstoragemirror.blob.core.windows.net/wrench/binding-tools-for-swift/$BUILD_SOURCEBRANCHNAME/$BUILD_SOURCEVERSION/$BUILD_BUILDID/$FILENAME"
-      COMMIT_ID="$BUILD_BUILDID"
+      COMMIT_ID="$BUIlD_SOURCEVERSION"
       echo "Build reason is $BUILD_REASON"
       if [[ "$BUILD_REASON" == "PullRequest" ]]; then
         echo "Setting commit id to $SYSTEM_PULLREQUEST_SOURCECOMMITID"

--- a/devops/automation/azure-pipelines.yml
+++ b/devops/automation/azure-pipelines.yml
@@ -219,7 +219,13 @@ jobs:
       fi
       FILENAME="$(basename "$FILE")"
       TARGET_URL="https://bosstoragemirror.blob.core.windows.net/wrench/binding-tools-for-swift/toolchain/$FILENAME"
-      ./binding-tools-for-swift/devops/automation/add-commit-status.sh --token=$(GitHub.Token) --hash=$BUILD_SOURCEVERSION --state=success --target-url=$TARGET_URL "--description=$FILENAME" --context=Toolchain-Binding-Tools-For-Swift
+      # VSTS does provide a diff build id depending if it is a PR or a CI triggered build, this results in issues when
+      # setting the status :/ 
+      COMMIT_ID="$BUILD_BUILDID"
+      if [ "$BUILD_REASON" = "PullRequest" ]; then
+        COMMIT_ID="$SYSTEM_PULLREQUEST_SOURCECOMMITID"
+      fi
+      ./binding-tools-for-swift/devops/automation/add-commit-status.sh --token=$(GitHub.Token) --hash=$COMMIT_ID --state=success --target-url=$TARGET_URL "--description=$FILENAME" --context=Toolchain-Binding-Tools-For-Swift
     displayName: 'Add Toolchain as GitHub Status'
     workingDirectory: $(System.DefaultWorkingDirectory)
 

--- a/devops/automation/azure-pipelines.yml
+++ b/devops/automation/azure-pipelines.yml
@@ -222,7 +222,9 @@ jobs:
       # VSTS does provide a diff build id depending if it is a PR or a CI triggered build, this results in issues when
       # setting the status :/ 
       COMMIT_ID="$BUILD_BUILDID"
-      if [ "$BUILD_REASON" = "PullRequest" ]; then
+      echo "Build reason is $BUILD_REASON"
+      if [[ "$BUILD_REASON" == "PullRequest" ]]; then
+        echo "Setting commit id to $SYSTEM_PULLREQUEST_SOURCECOMMITID"
         COMMIT_ID="$SYSTEM_PULLREQUEST_SOURCECOMMITID"
       fi
       ./binding-tools-for-swift/devops/automation/add-commit-status.sh --token=$(GitHub.Token) --hash=$COMMIT_ID --state=success --target-url=$TARGET_URL "--description=$FILENAME" --context=Toolchain-Binding-Tools-For-Swift

--- a/devops/automation/azure-pipelines.yml
+++ b/devops/automation/azure-pipelines.yml
@@ -272,5 +272,11 @@ jobs:
       fi
       FILENAME="$(basename "$FILE")"
       TARGET_URL="https://bosstoragemirror.blob.core.windows.net/wrench/binding-tools-for-swift/$BUILD_SOURCEBRANCHNAME/$BUILD_SOURCEVERSION/$BUILD_BUILDID/$FILENAME"
-      ./devops/automation/add-commit-status.sh --token=$(GitHub.Token) --hash=$BUILD_SOURCEVERSION --azdo-state=$AGENT_JOBSTATUS --target-url=$TARGET_URL "--description=$FILENAME" --context=PKG-Binding-Tools-For-Swift
+      COMMIT_ID="$BUILD_BUILDID"
+      echo "Build reason is $BUILD_REASON"
+      if [[ "$BUILD_REASON" == "PullRequest" ]]; then
+        echo "Setting commit id to $SYSTEM_PULLREQUEST_SOURCECOMMITID"
+        COMMIT_ID="$SYSTEM_PULLREQUEST_SOURCECOMMITID"
+      fi
+      ./devops/automation/add-commit-status.sh --token=$(GitHub.Token) --hash=$COMMIT_ID --azdo-state=$AGENT_JOBSTATUS --target-url=$TARGET_URL "--description=$FILENAME" --context=PKG-Binding-Tools-For-Swift
     displayName: 'Add Packages as GitHub Status'


### PR DESCRIPTION
On a pull request, Azure DevOps does not build the exact version of the code that you pushed,
but a version merged with your target branch. This means that the commit
we see in the Buid.Revision is not the one of the last commit of the PR,
which makes the status script to fail in PRs.