### PR TITLE
Handle unknown module types and global aliases

### DIFF
--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -44,6 +44,8 @@ namespace SwiftReflector {
 
 		public bool Load (string moduleName, TypeDatabase into)
 		{
+			if (moduleName == "Cocoa")
+				moduleName = "AppKit";
 			if (into.ModuleNames.Contains (moduleName))
 				return true;
 			foreach (var location in locations) {
@@ -249,7 +251,7 @@ namespace SwiftReflector {
 			locations.AddRange (includeDirectories);
 
 			ReflectWithStrategies (locations, libraryDirectories, pathName, extraArgs, moduleNames);
-			return Reflector.FromXmlFile (pathName);
+			return Reflector.FromXmlFile (pathName, ReflectionTypeDatabase);
 		}
 
 		public void ReflectWithStrategies (IEnumerable<string> includeDirectories, IEnumerable<string> libraryDirectories,

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1636,7 +1636,12 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			var failures = new StringBuilder ();
 			foreach (var module in importModules) {
+				// XamGlue and RegisterAccess may very well get
+				// used, but we the functions/types exported from these
+				// should never need to be loaded.
 				if (module == "XamGlue")
+					continue;
+				if (module == "RegisterAccess")
 					continue;
 				if (!moduleLoader.Load (module, typeDatabase)) {
 					if (failures.Length > 0)

--- a/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/ModuleDeclaration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using SwiftReflector.TypeMapping;
 
 namespace SwiftReflector.SwiftXmlReflection {
 	public class ModuleDeclaration {
@@ -38,7 +39,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public List<BaseDeclaration> Declarations { get; private set; }
 		public List<TypeAliasDeclaration> TypeAliases { get; private set; }
 
-		public static ModuleDeclaration FromXElement (XElement elem)
+		public static ModuleDeclaration FromXElement (XElement elem, TypeDatabase typeDatabase)
 		{
 			ModuleDeclaration decl = new ModuleDeclaration {
 				Name = (string)elem.Attribute ("name"),
@@ -47,6 +48,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 
 			decl.TypeAliases.AddRange (elem.Descendants ("typealias").Select (al => TypeAliasDeclaration.FromXElement (decl.Name, al)));
 			var folder = new TypeAliasFolder (decl.TypeAliases);
+			folder.AddDatabaseAliases (typeDatabase);
 
 			// non extensions
 			foreach (var child in elem.Elements()) {

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasDeclaration.cs
@@ -63,12 +63,26 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
+		public String ModuleName {
+			get {
+				var spec = TypeSpec as NamedTypeSpec;
+				return spec?.Module;
+			}
+		}
+
+		public XElement ToXElement ()
+		{
+			return new XElement ("typealias", new XAttribute ("name", TypeName),
+				new XAttribute ("type", TargetTypeName));
+		}
+
 		public static TypeAliasDeclaration FromXElement (string moduleName, XElement element)
 		{
-			Exceptions.ThrowOnNull (moduleName, nameof (moduleName));
 			var aliasName = element.Attribute ("name").Value;
-			if (!aliasName.Contains ("."))
+			if (!aliasName.Contains (".")) {
+				Exceptions.ThrowOnNull (moduleName, nameof (moduleName));
 				aliasName = $"{moduleName}.{aliasName}";
+			}
 			return new TypeAliasDeclaration () {
 				Access = TypeDeclaration.AccessibilityFromString ((string)element.Attribute ("accessibility")),
 				TypeName = aliasName,

--- a/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeAliasFolder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SwiftReflector.TypeMapping;
 
 namespace SwiftReflector.SwiftXmlReflection {
 	public class TypeAliasFolder {
@@ -14,6 +15,18 @@ namespace SwiftReflector.SwiftXmlReflection {
 			this.aliases = new Dictionary<string, TypeAliasDeclaration> ();
 			foreach (var alias in aliases) {
 				this.aliases.Add (AliasKey (alias.TypeSpec), alias);
+			}
+		}
+
+		public void AddDatabaseAliases (TypeDatabase typeDatabase)
+		{
+			if (typeDatabase == null)
+				return;
+			foreach (var moduleName in typeDatabase.ModuleNames) {
+				var moduleDB = typeDatabase.ModuleDatabaseForModuleName (moduleName);
+				foreach (var alias in moduleDB.TypeAliases) {
+					this.aliases.Add (AliasKey (alias.TypeSpec), alias);
+				}
 			}
 		}
 

--- a/SwiftReflector/TypeMapping/ModuleDatabase.cs
+++ b/SwiftReflector/TypeMapping/ModuleDatabase.cs
@@ -10,8 +10,10 @@ namespace SwiftReflector.TypeMapping {
 		public ModuleDatabase ()
 		{
 			Operators = new List<OperatorDeclaration> ();
+			TypeAliases = new List<TypeAliasDeclaration> ();
 		}
 
 		public List<OperatorDeclaration> Operators { get; private set; }
+		public List<TypeAliasDeclaration> TypeAliases { get; private set; }
 	}
 }

--- a/bindings/SwiftCore.xml
+++ b/bindings/SwiftCore.xml
@@ -211,5 +211,6 @@
         <operator name="&amp;=" operatorKind="Infix" precedenceGroup="AssignmentPrecedence" moduleName="Swift" />
         <operator name="|=" operatorKind="Infix" precedenceGroup="AssignmentPrecedence" moduleName="Swift" />
         <operator name="^=" operatorKind="Infix" precedenceGroup="AssignmentPrecedence" moduleName="Swift" />
+	<typealias name="Foundation.NSRect" type="CoreGraphics.CGRect" />
     </entities>
 </xamtypedatabase>

--- a/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
@@ -278,7 +278,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("Not loading Cocoa - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void NSImageViewSmokeTest ()
 		{
 			string swiftCode =
@@ -307,7 +306,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("Not loading Cocoa - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void NSImageViewSmokeTest1 ()
 		{
 			string swiftCode =
@@ -328,7 +326,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("Not loading Cocoa - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void NSImageViewSmokeTest2 ()
 		{
 			string swiftCode =
@@ -357,7 +354,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("Not loading Cocoa - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void NSImageViewSmokeTest3 ()
 		{
 			string swiftCode =
@@ -378,7 +374,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("Not loading Cocoa - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void NSImageViewSmokeTest4 ()
 		{
 			string swiftCode =

--- a/tests/tom-swifty-test/SwiftReflector/ProtowitnessTest.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtowitnessTest.cs
@@ -16,7 +16,6 @@ namespace SwiftReflector {
 	public class ProtowitnessTest {
 
 		[Test]
-		[Ignore ("Not loading RegisterAccess - https://github.com/xamarin/binding-tools-for-swift/issues/656")]
 		public void VerifyProtoAccess ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -63,7 +63,7 @@ namespace XmlReflectionTests {
 		{
 			var decls = new List<ModuleDeclaration> ();
 			var doc = ParserToXDocument (directory, moduleName);
-			return Reflector.FromXml (doc);
+			return Reflector.FromXml (doc, typeDatabase);
 		}
 
 		List<ModuleDeclaration> ReflectToModules (string code, string moduleName, ReflectorMode mode = ReflectorMode.Parser)

--- a/tests/tom-swifty-test/XmlReflectionTests/GenerativeTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/GenerativeTests.cs
@@ -42,7 +42,7 @@ namespace XmlReflectionTests {
 		{
 			var decls = new List<ModuleDeclaration> ();
 			var doc = ParserToXDocument (directory, moduleName);
-			return Reflector.FromXml (doc);
+			return Reflector.FromXml (doc, typeDatabase);
 		}
 
 

--- a/tests/tom-swifty-test/XmlReflectionTests/StaticXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/StaticXmlTests.cs
@@ -27,7 +27,7 @@ namespace XmlReflectionTests {
 								"      </module>" +
 								"   </modulelist>" +
 								"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -62,7 +62,7 @@ namespace XmlReflectionTests {
 								"      </module>" +
 								"   </modulelist>" +
 								"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -98,7 +98,7 @@ namespace XmlReflectionTests {
 				"      </module>" +
 				"   </modulelist>" +
 				"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -131,7 +131,7 @@ namespace XmlReflectionTests {
 				"      </module>" +
 				"   </modulelist>" +
 				"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -158,7 +158,7 @@ namespace XmlReflectionTests {
 					 "      </module>" +
 					 "   </modulelist>" +
 					 "</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -182,7 +182,7 @@ namespace XmlReflectionTests {
 				"      </module>" +
 				"   </modulelist>" +
 				"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -205,7 +205,7 @@ namespace XmlReflectionTests {
 				"      </module>" +
 				"   </modulelist>" +
 				"</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -248,7 +248,7 @@ namespace XmlReflectionTests {
 				"				</module>" +
 				"				</modulelist>" +
 				"				</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -294,7 +294,7 @@ namespace XmlReflectionTests {
 				"				</module>" +
 				"				</modulelist>" +
 				"				</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);
@@ -338,7 +338,7 @@ namespace XmlReflectionTests {
 				"				</module>" +
 				"				</modulelist>" +
 				"				</xamreflect>";
-			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText);
+			List<ModuleDeclaration> modules = Reflector.FromXml (xmlText, typeDatabase: null);
 			Assert.NotNull (modules);
 			Assert.AreEqual (1, modules.Count);
 			Assert.AreEqual ("None1", modules [0].Name);

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -50,7 +50,7 @@ namespace XmlReflectionTests {
 
 		List<ModuleDeclaration> ReflectToModules (string code, string moduleName, out SwiftInterfaceReflector reflector)
 		{
-			return Reflector.FromXml (ReflectToXDocument (code, moduleName, out reflector));
+			return Reflector.FromXml (ReflectToXDocument (code, moduleName, out reflector), typeDatabase);
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/XmlReflectionTests/XmlToTLFMappingTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/XmlToTLFMappingTests.cs
@@ -45,7 +45,7 @@ namespace XmlReflectionTests {
 		{
 			var decls = new List<ModuleDeclaration> ();
 			var doc = ParserToXDocument (directory, moduleName);
-			return Reflector.FromXml (doc);
+			return Reflector.FromXml (doc, typeDatabase);
 		}
 
 


### PR DESCRIPTION
This fixes issues with module references that are likely wrong fixing issue [656](https://github.com/xamarin/binding-tools-for-swift/issues/656).

This is the type of issue where peeling one layer reveals and opportunity for heavy-handed refactoring. Fortunately we have the infrastructure in place to handle all of this.

There were 3 actual errors:
1. `Cocoa` doesn't really exist as a namespace AFAICT
2. `RegisterAccess` isn't a namespace that will be used for binding
3. `Foundation.NSRect` doesn't exist as a real type, it's an alias

These are all handled in different ways.
The first we blindly map `Cocoa` to `AppKit`. Should this be something else? Don't know. PRs welcome.
The second is not a namespace that will be used for binding and it exports no types, so we ignore it.
The third. Well.
At present, when a module is read in via reflection, there may be type databases associated with the module. Those get aggregated and any types that match one of those aliases will automagically get mapped to the correct type. This is great, but after the module is read in, the type aliases get thrown away.

No longer. Now the type database for a module will include all its type aliases for future use.
So now the formal process is that when a module is reflected, all of its type aliases and all the type aliases in the type database will get used to remap aliases.

The refactoring for this means:
- having a `TypeAliases` member on the `ModuleDatabase` type
- Adding code to write out the type aliases for a `ModuleDatabase`
- Adding code to read in the type aliases for a `ModuleDatabase`
- Adding code to merge all type databases aliases into the folder
- Refactoring all the code to read in XML reflection to include a `TypeDatabase` so we can get at the aliases

tl;dr - type aliases are now first class entities and handled formally in the process of reflecting on a module.