### PR TITLE
tweak the swift interface grammar

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -271,6 +271,7 @@ dyckExpression :
 	| label_identifier
 	| literal
 	| operator
+	| dotSymbol
 	;
 dyckSubExpression :
 	dyckExpression
@@ -280,6 +281,8 @@ any_other_things_for_dyck_expression :
 	( OpDot | OpComma | OpColon | OpSemi | OpAssign | OpAt | OpPound | OpBackTick | OpQuestion | OpUnder)
 	| arrow_operator
 	;
+
+dotSymbol : '.' declaration_identifier;
 	
 declaration_identifier : Identifier | keyword_as_identifier_in_declarations ;
 

--- a/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/EnumTests.cs
@@ -99,7 +99,6 @@ public enum SomeForce {
 		}
 
 		[Test]
-		[Ignore ("This is not parsing properly - https://github.com/xamarin/binding-tools-for-swift/issues/657")]
 		public void NestedEnum ()
 		{
 			var swiftCode = @"


### PR DESCRIPTION
This change allows tokens of the form `.token` in dyck grammar and fixes issue [657](https://github.com/xamarin/binding-tools-for-swift/issues/657)