### PR TITLE
Step 2 of phasing out the compiler reflector

### DIFF
--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -46,16 +46,6 @@ namespace tomwiftytest {
 		static string kSystemLib = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/macosx";
 
 		[ThreadStatic]
-		static SwiftCompilerLocation compilerLocation;
-		public static SwiftCompilerLocation CompilerLocation {
-			get {
-				if (compilerLocation == null)
-					compilerLocation = new SwiftCompilerLocation (kSwiftCustomBin, kSwiftCustomLib);
-				return compilerLocation;
-			}
-		}
-
-		[ThreadStatic]
 		static SwiftCompilerLocation systemCompilerLocation;
 		public static SwiftCompilerLocation SystemCompilerLocation {
 			get {

--- a/tests/tom-swifty-test/MachOTests.cs
+++ b/tests/tom-swifty-test/MachOTests.cs
@@ -15,7 +15,7 @@ namespace tomwiftytest {
 	public class MachOTests {
 		public static Stream HelloSwiftAsLibrary (string extraOptions)
 		{
-			return Compiler.CompileStringUsing (null, XCodeCompiler.SwiftcCustom, Compiler.kHelloSwift, extraOptions);
+			return Compiler.CompileStringUsing (null, XCodeCompiler.Swiftc, Compiler.kHelloSwift, extraOptions);
 		}
 
 		[Test]

--- a/tests/tom-swifty-test/SwiftReflector/ClassWrapTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ClassWrapTests.cs
@@ -26,7 +26,7 @@ namespace SwiftReflector {
 			string simpleClass = "public class Garble { public final func finalmethod() { }; public func virtmethod() { } }";
 			using (DisposableTempFile montyLib = new DisposableTempFile ("libXython.dylib", false)) {
 
-				Compiler.CompileStringToFileUsing (null, XCodeCompiler.SwiftcCustom, simpleClass, " -emit-library -module-name Xython", montyLib);
+				Compiler.CompileStringToFileUsing (null, XCodeCompiler.Swiftc, simpleClass, " -emit-library -module-name Xython", montyLib);
 				var errors = new ErrorHandling ();
 				ModuleInventory inventory = ModuleInventory.FromFile (montyLib.Filename, errors);
 				Utils.CheckErrors (errors);

--- a/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
@@ -33,7 +33,7 @@ namespace SwiftReflector {
 		public void SimpleConstructor ()
 		{
 			string swiftcode = "public class None { public init() { } }";
-			using (Stream stm = Compiler.CompileStringUsing (null, XCodeCompiler.SwiftcCustom, swiftcode, "")) {
+			using (Stream stm = Compiler.CompileStringUsing (null, XCodeCompiler.Swiftc, swiftcode, "")) {
 				var errors = new ErrorHandling ();
 				ModuleInventory inventory = ModuleInventory.FromStream (stm, errors);
 				Utils.CheckErrors (errors);

--- a/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
@@ -167,7 +167,7 @@ namespace dlopentest
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
 
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.CompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
 				string output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
@@ -225,7 +225,7 @@ namespace dlopentest
 }}";
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.CompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
 				var output = TestRunning.Execute (temp.DirectoryPath, "TestIt.exe", PlatformName.macOS);
@@ -283,7 +283,7 @@ namespace dlopentest
 }}";
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.CompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
 				var output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
@@ -372,7 +372,7 @@ namespace dlopentest
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
 
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.CompilerLocation.SwiftCompilerLib}");
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}");
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
 				string output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath);

--- a/tests/tom-swifty-test/SwiftReflector/Utils.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Utils.cs
@@ -28,7 +28,7 @@ namespace SwiftReflector {
 
 		public static CustomSwiftCompiler DefaultSwiftCompiler (DisposableTempDirectory provider = null, string target = "x86_64-apple-macosx10.9")
 		{
-			var targetInfo = Compiler.CompilerLocation.GetTargetInfo (target);
+			var targetInfo = Compiler.SystemCompilerLocation.GetTargetInfo (target);
 			return new CustomSwiftCompiler (targetInfo, provider, false);
 		}
 
@@ -77,7 +77,7 @@ namespace SwiftReflector {
 		public static NewClassCompiler DefaultCSharpCompiler (UnicodeMapper unicodeMapper = null)
 		{
 			ClassCompilerOptions compilerOptions = new ClassCompilerOptions (targetPlatformIs64Bit : true, verbose : false, retainReflectedXmlOutput : true, retainSwiftWrappers : true);
-			return new NewClassCompiler (Compiler.CompilerLocation, compilerOptions, unicodeMapper ?? UnicodeMapper.Default);
+			return new NewClassCompiler (Compiler.SystemCompilerLocation, compilerOptions, unicodeMapper ?? UnicodeMapper.Default);
 		}
 
 		public static string CompileToCSharp (DisposableTempDirectory provider, string outputDirectory = null, string moduleName = "Xython", string target = "x86_64-apple-macosx10.9", IEnumerable<string> additionalTypeDatabases = null, bool separateProcess = false, UnicodeMapper unicodeMapper = null, int expectedErrorCount = -1)
@@ -96,8 +96,8 @@ namespace SwiftReflector {
 				var args = new StringBuilder ();
 				args.Append ($"--debug ");
 				args.Append ($"{Path.Combine (Path.GetDirectoryName (ncc.GetType ().Assembly.Location), "tom-swifty.exe")} ");
-				args.Append ($"--swift-bin-path={StringUtils.Quote (Compiler.CompilerLocation.SwiftCompilerBin)} ");
-				args.Append ($"--swift-lib-path={StringUtils.Quote (Path.GetDirectoryName (Compiler.CompilerLocation.SwiftCompilerLib))} ");
+				args.Append ($"--swift-bin-path={StringUtils.Quote (Compiler.SystemCompilerLocation.SwiftCompilerBin)} ");
+				args.Append ($"--swift-lib-path={StringUtils.Quote (Path.GetDirectoryName (Compiler.SystemCompilerLocation.SwiftCompilerLib))} ");
 				args.Append ($"--retain-xml-reflection ");
 				foreach (var db in typeDatabases)
 					args.Append ($"--type-database-path={StringUtils.Quote (db)} ");

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -713,7 +713,7 @@ public static class Console {
 					swift_stdlib_tool.Append ($"--scan-folder {StringUtils.Quote (Path.Combine (appPath, "Contents", "MonoBundle"))} ");
 					swift_stdlib_tool.Append ($"--scan-folder {StringUtils.Quote (Path.Combine (appPath, "Contents", "Frameworks"))} ");
 					swift_stdlib_tool.Append ($"--platform macosx ");
-					swift_stdlib_tool.Append ($"--source-libraries {StringUtils.Quote (Compiler.CompilerLocation.SwiftCompilerLib)} ");
+					swift_stdlib_tool.Append ($"--source-libraries {StringUtils.Quote (Compiler.SystemCompilerLocation.SwiftCompilerLib)} ");
 					output.Clear ();
 					rv = ExecAndCollect.RunCommand ("xcrun", swift_stdlib_tool.ToString (), output: output, verbose: true);
 					if (rv != 0) {

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -42,17 +42,6 @@ namespace XmlReflectionTests {
 			Utils.CompileSwift (code, moduleName: moduleName);
 		}
 
-		Stream ReflectToXml (string code, string moduleName)
-		{
-			CustomSwiftCompiler compiler = Utils.CompileSwift (code, moduleName: moduleName);
-			return compiler.ReflectToStream (null, null, null, moduleName);
-		}
-
-		XDocument ReflectToXDocument (string code, string moduleName)
-		{
-			return XDocument.Load (ReflectToXml (code, moduleName));
-		}
-
 		XDocument ParserToXDocument (string directory, string moduleName)
 		{
 			var parser = new SwiftInterfaceReflector (typeDatabase, new NoLoadLoader ());
@@ -87,12 +76,6 @@ namespace XmlReflectionTests {
 		public void HelloModuleTest ()
 		{
 			CompileStringToModule (Compiler.kHelloSwift, "MyModule");
-		}
-
-		[Test]
-		public void HelloXmlTest ()
-		{
-			ReflectToXml (Compiler.kHelloSwift, "MyModule");
 		}
 
 

--- a/tests/tom-swifty-test/dynamo/SwiftLangTests.cs
+++ b/tests/tom-swifty-test/dynamo/SwiftLangTests.cs
@@ -21,7 +21,7 @@ namespace dynamotests {
 			SLFunc func = new SLFunc (Visibility.Public, type, new SLIdentifier ("simpleFunc"), null, block);
 
 			string code = CodeWriter.WriteToString (func);
-			Compiler.CompileStringUsing (null, XCodeCompiler.SwiftcCustom, code, null);
+			Compiler.CompileStringUsing (null, XCodeCompiler.Swiftc, code, null);
 		}
 
 		[Test]
@@ -53,7 +53,7 @@ namespace dynamotests {
 		{
 			SLLine line = SLDeclaration.LetLine ("foo", SLSimpleType.Int, SLConstant.Val (5), Visibility.Public);
 			string code = CodeWriter.WriteToString (line);
-			Compiler.CompileStringUsing (null, XCodeCompiler.SwiftcCustom, code, null);
+			Compiler.CompileStringUsing (null, XCodeCompiler.Swiftc, code, null);
 		}
 
 
@@ -63,7 +63,7 @@ namespace dynamotests {
 			SLLine line = isLet ? SLDeclaration.LetLine ("foo", type, value, vis)
 				: SLDeclaration.VarLine ("foo", type, value, vis);
 			string code = CodeWriter.WriteToString (line);
-			Compiler.CompileStringUsing (null, XCodeCompiler.SwiftcCustom, code, null);
+			Compiler.CompileStringUsing (null, XCodeCompiler.Swiftc, code, null);
 		}
 
 		[Test]


### PR DESCRIPTION
Removed references to the custom swift compiler and stripped dead code and declarations.