### PR TITLE
lets do inlines

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -224,10 +224,11 @@ protocol_associated_type_declaration : attributes? access_level_modifier? 'assoc
 	generic_where_clause? ;
 
 
-function_declaration : function_head function_name generic_parameter_clause? function_signature generic_where_clause? ;
+function_declaration : function_head function_name generic_parameter_clause? function_signature generic_where_clause? function_body?;
 
 function_head : attributes? declaration_modifiers? 'func' ;
 function_name : declaration_identifier | operator_name ;
+function_body : OpLBrace dyckSubExpression* OpRBrace ;
 
 operator_name : operator ;
 

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1605,5 +1605,22 @@ case a, b
 			Assert.AreEqual (1, en.Inheritance.Count, "wrong inheritance count");
 			Assert.AreEqual ("Swift.Error", en.Inheritance [0].InheritedTypeName, "wrong inherited name");
 		}
+
+		[TestCase (ReflectorMode.Parser)]
+		public void InlineFunction (ReflectorMode mode)
+		{
+			var code = @"
+@inlinable
+@inline (__always)
+public func sum (a:Int, b:Int) -> Int {
+return a + b
+}
+";
+			var module = ReflectToModules (code, "SomeModule", mode).FirstOrDefault (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "module is null");
+
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "sum");
+			Assert.IsNotNull (fn, "no function");
+		}
 	}
 }


### PR DESCRIPTION
Address issue [642](https://github.com/xamarin/binding-tools-for-swift/issues/642)
Swift has two levels of marking things as inline: `@inline(__always)` and `@inlinable`.
The first is for use within your own module. The second is for cross-module inlining.
In the case of the second, the entire contents of function body will get included in the `.swiftinterface` file.
The parser as it was didn't complain about the extra chaff of the body, but I can't tell you what it thought it was seeing as there was no parser rule to match it that I know of.
Just to be safe, I put in a variation of the Dyck grammar to handle method bodies.
Added a test and it passes.