### PR TITLE
Ignore EveryProtocol

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1710,6 +1710,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			foreach (var ext in extensions) {
 				var onType = (string)ext.Attribute (kOnType).Value;
 				var parts = onType.Split ('.');
+				if (parts [0] == "XamGlue")
+					continue;
 				if (parts.Length > 1 && !typeDatabase.ModuleNames.Contains (parts [0])) {
 					moduleLoader.Load (parts [0], typeDatabase);
 				}

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -652,5 +652,66 @@ public class HotDog : Food
 			var callingCode = CSCodeBlock.Create (hotdogDecl, printer);
 			TestRunning.TestAndExecute (swiftCode, callingCode, "Added onions.\n");
 		}
+
+		[Test]
+		public void TestSandwich ()
+		{
+			var swiftCode = @"
+public protocol Filling {
+	var stuff: String { get }
+}
+
+public protocol Bread {
+	var name: String { get }
+	var sliced: Bool { get }
+}
+
+public struct Rye : Bread {
+	public init () { }
+	public var name: String {
+		get { return ""rye""; }
+	}
+	public var sliced:Bool {
+		get { return true }
+	}
+}
+
+public struct Ham : Filling {
+	public init () { }
+	public var stuff: String {
+		get { return ""ham"" }
+	}
+}
+
+public func printSandwich (of: Bread, with: Filling) {
+	print (""\(with.stuff) on \(of.name)"")
+}
+";
+			var altClass = new CSClass (CSVisibility.Public, "WholeWheat");
+			altClass.Inheritance.Add (new CSIdentifier ("IBread"));
+
+			var returnBread = CSReturn.ReturnLine (new CSCastExpression ("SwiftString", CSConstant.Val ("whole wheat")));
+			var nameProp = new CSProperty (new CSSimpleType ("SwiftString"), CSMethodKind.None, new CSIdentifier ("Name"),
+				CSVisibility.Public, CSCodeBlock.Create (returnBread), CSVisibility.Public, null);
+			altClass.Properties.Add (nameProp);
+
+			var returnSliced = CSReturn.ReturnLine (CSConstant.Val (true));
+			var slicedProp = new CSProperty (new CSSimpleType ("bool"), CSMethodKind.None, new CSIdentifier ("Sliced"),
+				CSVisibility.Public, CSCodeBlock.Create (returnSliced), CSVisibility.Public, null);
+			altClass.Properties.Add (slicedProp);
+
+
+			var printIt = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("lefty"));
+
+			var whichHandMethod = new CSMethod (CSVisibility.Public, CSMethodKind.None, CSSimpleType.Void, new CSIdentifier ("WhichHand"), new CSParameterList (),
+							    CSCodeBlock.Create (printIt));
+			altClass.Methods.Add (whichHandMethod);
+
+			var printer = CSFunctionCall.FunctionCallLine ("TopLevelEntities.PrintSandwich",
+				new CSFunctionCall ("WholeWheat", true), new CSFunctionCall ("Ham", true));
+			var callingCode = CSCodeBlock.Create (printer);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "ham on whole wheat\n", otherClass: altClass,
+				generateDeviceTest: false);
+		}
 	}
 }

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -305,7 +305,8 @@ namespace tomwiftytest {
 					    UnicodeMapper unicodeMapper = null, int expectedErrorCount = 0,
 					    Action<string> postCompileCheck = null,
 					    string[] expectedOutputContains = null,
-					    bool enforceUTF8Encoding = false)
+					    bool enforceUTF8Encoding = false,
+					    bool generateDeviceTest = true)
 		{
 			SetInvokingTestNameIfUnset (ref testName, out string nameSpace);
 			string testClassName = "TomTest" + testName;
@@ -374,15 +375,17 @@ namespace tomwiftytest {
 					throw new NotImplementedException (platform.ToString ());
 				}
 
-				File.WriteAllText (Path.Combine (thisTestPathSwift, $"{testClassName}{testName}{nameSuffix}.swift"), swiftPrefix + swiftCode + swiftSuffix);
+				if (generateDeviceTest) {
+					File.WriteAllText (Path.Combine (thisTestPathSwift, $"{testClassName}{testName}{nameSuffix}.swift"), swiftPrefix + swiftCode + swiftSuffix);
 
-				CSFile csTestFile = CSFile.Create (testClassParts.Item2, testClassParts.Item1);
-				var csTestFilePath = Path.Combine (thisTestPath, $"{testClassName}{testName}{nameSuffix}.cs");
-				// Write out the file without csPrefix/csSuffix
-				CodeWriter.WriteToFile (csTestFilePath, csTestFile);
-				if (!string.IsNullOrEmpty (csPrefix) || !string.IsNullOrEmpty (csSuffix)) {
-					// Read the C# code, and prepend/append the csPrefix/csSuffix blobs, then save the modified contents again.
-					File.WriteAllText (csTestFilePath, csPrefix + File.ReadAllText (csTestFilePath) + csSuffix);
+					CSFile csTestFile = CSFile.Create (testClassParts.Item2, testClassParts.Item1);
+					var csTestFilePath = Path.Combine (thisTestPath, $"{testClassName}{testName}{nameSuffix}.cs");
+					// Write out the file without csPrefix/csSuffix
+					CodeWriter.WriteToFile (csTestFilePath, csTestFile);
+					if (!string.IsNullOrEmpty (csPrefix) || !string.IsNullOrEmpty (csSuffix)) {
+						// Read the C# code, and prepend/append the csPrefix/csSuffix blobs, then save the modified contents again.
+						File.WriteAllText (csTestFilePath, csPrefix + File.ReadAllText (csTestFilePath) + csSuffix);
+					}
 				}
 
 				var csFile = TestRunningCodeGenerator.GenerateTestEntry (callingCode, testName, nameSpace, platform, otherClass, enforceUTF8Encoding, testPathDumper);


### PR DESCRIPTION
I promoted a sample to a unit test and ran into an issue where it was trying to handle renaming dynamic self types in function arguments. Problem is that it tries to load XamGlue, which should never get loaded by the type database.
Since this particular operation is meaningless on XamGlue.EveryProtocol, it's OK to just let this go by.

This test generates output in Swift which usually requires special handling in order to run properly on a device test. Since this particular unit test is only meant to ultimately find out why samples aren't running in a shell, the device tests don't matter to me so I added an option to skip generating the unit test because this is faster than writing the special handling for capturing swift output on device and I'm feeling lazy today.