### PR TITLE
Update for changes in frameworks

### DIFF
--- a/SwiftReflector/IOUtils/SwiftModuleFinder.cs
+++ b/SwiftReflector/IOUtils/SwiftModuleFinder.cs
@@ -276,7 +276,7 @@ namespace SwiftReflector.IOUtils {
 			return Directory.Exists (modulesDir) && Directory.Exists (swiftModuleDir);
 		}
 
-		static bool IsXamarinLayout (string dir, string moduleFileName, string target)
+		public static bool IsXamarinLayout (string dir, string moduleFileName, string target)
 		{
 			string moduleDir = Path.Combine (dir, target.ClangTargetCpu ());
 			string modulePath = Path.Combine (moduleDir, moduleFileName);

--- a/SwiftReflector/MachOHawley.cs
+++ b/SwiftReflector/MachOHawley.cs
@@ -778,17 +778,32 @@ namespace Xamarin {
 				}
 			}
 			public MachO.Platform Platform;
+			public Version Sdk;
+			public bool IsSimulator {
+				get {
+					switch (Platform) {
+					case MachO.Platform.IOSSimulator:
+					case MachO.Platform.TvOSSimulator:
+					case MachO.Platform.WatchOSSimulator:
+						return true;
+					default:
+						return false;
+					}
+				}
+			}
 		}
 
 		public MinOSVersion MinOS {
 			get {
 				uint? version = null;
+				uint? sdk = null;
 				MachO.Platform platform = (MachO.Platform) 0;
 				foreach (var lc in load_commands) {
 					if (lc is VersionMinOSLoadCommand min_lc) {
 						if (version.HasValue)
 							throw new NotSupportedException ("File has multiple minOS load commands.");
 						version = min_lc.version;
+						sdk = min_lc.sdk;
 
 						switch (min_lc.Command) {
 						case MachO.LoadCommands.VersionMinMacOS:
@@ -815,10 +830,12 @@ namespace Xamarin {
 				}
 				if (!version.HasValue)
 					return null;
+				sdk = sdk ?? version;
 
 				return new MinOSVersion {
 					Version = BuildVersionCommand.DeNibble (version.Value),
 					Platform = platform,
+					Sdk = BuildVersionCommand.DeNibble (sdk.Value)
 				};
 			}
 		}

--- a/SwiftReflector/MachOHawley.cs
+++ b/SwiftReflector/MachOHawley.cs
@@ -779,18 +779,6 @@ namespace Xamarin {
 			}
 			public MachO.Platform Platform;
 			public Version Sdk;
-			public bool IsSimulator {
-				get {
-					switch (Platform) {
-					case MachO.Platform.IOSSimulator:
-					case MachO.Platform.TvOSSimulator:
-					case MachO.Platform.WatchOSSimulator:
-						return true;
-					default:
-						return false;
-					}
-				}
-			}
 		}
 
 		public MinOSVersion MinOS {
@@ -825,12 +813,12 @@ namespace Xamarin {
 						if (version.HasValue)
 							throw new NotSupportedException ("File has multiple minOS load commands.");
 						version = build_lc.minos;
+						sdk = build_lc.sdk;
 						platform = build_lc.Platform;
 					}
 				}
 				if (!version.HasValue)
 					return null;
-				sdk = sdk ?? version;
 
 				return new MinOSVersion {
 					Version = BuildVersionCommand.DeNibble (version.Value),

--- a/SwiftReflector/MachOHelpers.cs
+++ b/SwiftReflector/MachOHelpers.cs
@@ -51,8 +51,6 @@ namespace SwiftReflector {
 
 		static string MinOSSdk (MachOFile.MinOSVersion minOS)
 		{
-			if (!minOS.IsSimulator)
-				return minOS.Version.ToString ();
 			var min = minOS.Version < minOS.Sdk ? minOS.Version : minOS.Sdk;
 			return min.ToString ();
 		}

--- a/SwiftReflector/MachOHelpers.cs
+++ b/SwiftReflector/MachOHelpers.cs
@@ -22,9 +22,39 @@ namespace SwiftReflector {
 				var osmin = file.MinOS;
 				if (osmin == null)
 					throw new NotSupportedException ("dylib files without a minimum supported operating system load command are not supported.");
-				targets.Add ($"{arch}-apple-{osmin.OSName}{osmin.Version.ToString ()}");
+				targets.Add ($"{arch}-apple-{TripleOSName(osmin, MinOSSdk (osmin))}");
 			}
 			return targets;
+		}
+
+		static string TripleOSName (MachOFile.MinOSVersion minOS, string version)
+		{
+			switch (minOS.Platform) {
+			case MachO.Platform.IOS:
+				return $"ios{version}";
+			case MachO.Platform.IOSSimulator:
+				return $"ios{version}-simulator";
+			case MachO.Platform.MacOS:
+				return $"macosx{version}";
+			case MachO.Platform.TvOS:
+				return $"tvos{version}";
+			case MachO.Platform.TvOSSimulator:
+				return $"tvos{version}-simulator";
+			case MachO.Platform.WatchOS:
+				return $"watchos{version}";
+			case MachO.Platform.WatchOSSimulator:
+				return $"watchos{version}-simulator";
+			default:
+				throw new ArgumentOutOfRangeException (nameof (minOS));
+			}
+		}
+
+		static string MinOSSdk (MachOFile.MinOSVersion minOS)
+		{
+			if (!minOS.IsSimulator)
+				return minOS.Version.ToString ();
+			var min = minOS.Version < minOS.Sdk ? minOS.Version : minOS.Sdk;
+			return min.ToString ();
 		}
 
 		public static List<string> CommonTargets (List<string> lt, List<string> commonTo)

--- a/SwiftReflector/SwiftCompilerLocation.cs
+++ b/SwiftReflector/SwiftCompilerLocation.cs
@@ -93,14 +93,14 @@ namespace SwiftReflector
 			if (String.IsNullOrEmpty (givenTarget))
 				return "macosx";
 			string [] parts = givenTarget.Split ('-');
-			if (parts.Length != 3) {
+			if (parts.Length != 3 && parts.Length != 4) {
 				throw new Exception ("Expected target to be in the form cpu-apple-os");
 			}
 
 			if (parts [2].StartsWith ("macosx", StringComparison.Ordinal))
 				return "macosx";
 			if (parts [2].StartsWith ("ios", StringComparison.Ordinal)) {
-				if (IsSimulator (parts [0]))
+				if (IsSimulator (parts))
 					return "iphonesimulator";
 				return "iphoneos";
 			}
@@ -108,17 +108,20 @@ namespace SwiftReflector
 				return "appletvos";
 			}
 			if (parts [2].StartsWith ("watchos", StringComparison.Ordinal)) {
-				if (IsSimulator (parts [0]))
+				if (IsSimulator (parts))
 					return "watchsimulator";
 				return "watchos";
 			}
 			return "macosx";
 		}
 
-		static bool IsSimulator (string part)
+		static bool IsSimulator (string[] parts)
 		{
-			return part.StartsWith ("i386", StringComparison.Ordinal) ||
-				   part.StartsWith ("x86_64", StringComparison.Ordinal);
+			if (parts.Length < 4) {
+				return parts[0].StartsWith ("i386", StringComparison.Ordinal) ||
+					   parts[0].StartsWith ("x86_64", StringComparison.Ordinal);
+			}
+			return parts [3].StartsWith ("simulator");
 		}
 	}
 }


### PR DESCRIPTION
I ran into some issues building a device sample so I had to make some modifications to clean that up.

1. the reflection code for the `.swiftinterface` parser strategy didn't understand the `.framework` directory structure. Now it does.
2. the swift compiler now uses an extended target triple which may include the `-simulator`.
3. there are some residual issues with regard to arm64 ([issue](https://github.com/xamarin/binding-tools-for-swift/issues/684))