### PR TITLE
Adding a check for null in SLType

### DIFF
--- a/Dynamo/Dynamo.SwiftLang/SLType.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLType.cs
@@ -312,7 +312,13 @@ namespace Dynamo.SwiftLang {
 
 		protected override void LLWrite (ICodeWriter writer, object o)
 		{
-			var name = IsMetatype ? (Name + ".Type") : AssociatedTypePath.Any () ? Name + $".{AssociatedTypePath.FirstOrDefault ()}" : Name;
+			var suffix = IsMetatype ? ".Type" : "";
+			string name;
+			if (AssociatedTypePath != null && AssociatedTypePath.Any ()) {
+				name = $"{Name}.{AssociatedTypePath.First ()}{suffix}";
+			} else {
+				name = $"{Name}{suffix}";
+			}
 			writer.Write (name, true);
 		}
 


### PR DESCRIPTION
This PR tackles this issue: https://github.com/xamarin/binding-tools-for-swift/issues/689
by adding in a check for null. 
Running this locally passes all the tests!
Help from: @stephen-hawley 