### PR TITLE
Code now handles target quads

### DIFF
--- a/SwiftReflector/Extensions.cs
+++ b/SwiftReflector/Extensions.cs
@@ -104,6 +104,52 @@ namespace SwiftReflector {
 			throw new ArgumentException ($"Clang target {s} should have 3 or 4 parts", nameof (s));
 		}
 
+		static int IndexOfFirstDigit (string s)
+		{
+			int index = 0;
+			foreach (char c in s) {
+				if (Char.IsDigit (c))
+					return index;
+				index++;
+			}
+			return -1;
+		}
+
+		public static string ClangOSNoVersion (this string s)
+		{
+			var clangTarget = s.DecomposeClangTarget ();
+			var os = clangTarget [2];
+			return OSNoVersion (os);
+		}
+
+		static string OSNoVersion (string s)
+		{
+			var firstNumber = IndexOfFirstDigit (s);
+			return firstNumber < 0 ? s : s.Substring (0, firstNumber);
+		}
+
+		public static string ClangOSVersion (this string s)
+		{
+			var clangTarget = s.DecomposeClangTarget ();
+			var os = clangTarget [2];
+			var firstNumber = IndexOfFirstDigit (os);
+			return os.Substring (firstNumber);
+		}
+
+		public static string MinimumClangVersion (IEnumerable<string> targets)
+		{
+			var osVersion = targets.Select (t => new Version (ClangOSVersion (t))).Min ();
+			return osVersion.ToString ();
+		}
+
+		public static string ClangSubstituteOSVersion (this string s, string replacementVersion)
+		{
+			var clangTarget = s.DecomposeClangTarget ();
+			var os = OSNoVersion (clangTarget [2]) + replacementVersion;
+			clangTarget [2] = os;
+			return clangTarget.InterleaveStrings ("-");
+		}
+
 		public static void Merge<T> (this HashSet<T> to, IEnumerable<T> from)
 		{
 			Exceptions.ThrowOnNull (from, nameof (from));

--- a/SwiftReflector/Importing/TypeAggregator.MacOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.MacOS.cs
@@ -201,6 +201,7 @@ namespace SwiftReflector.Importing {
 			"AppKit.NSStatusItemLength", // not an enum
 			"AppKit.NSSurfaceOrder", // not an enum
 			"AppKit.NSSystemDefinedEvents", // can't find it
+			"AppKit.NSTableViewAnimation",
 			"AppKit.NSTextListMarkerFormats", // can't find it
 			"AppKit.NSTextStorageEditedFlags", // can't find it
 			"AppKit.NSType", // can't find it
@@ -229,6 +230,7 @@ namespace SwiftReflector.Importing {
 			"AVFoundation.AVAudioSessionRouteSharingPolicy", // macOS 10.15+
 			"AVFoundation.AVAudioSessionSetActiveOptions", // macOS 10.15+
 			"AVFoundation.AVAudioSessionSilenceSecondaryAudioHintType", // macOS 10.15+
+			"AVFoundation.AVAudioStereoOrientation", // marked unavailable
 			"AVFoundation.AVCaptureAutoFocusRangeRestriction", // marked unavailable
 			"AVFoundation.AVCaptureAutoFocusSystem", // marked unavailable
 			"AVFoundation.AVCaptureLensStabilizationStatus", // marked unavailable
@@ -251,6 +253,7 @@ namespace SwiftReflector.Importing {
 			"CoreFoundation.OSLogLevel",
 			// CoreGraphics
 			"CoreGraphics.CGPdfTagType",
+			"CoreGraphics.CGConstantColor",
 			// CoreMedia
 			"CoreMedia.CMSampleBufferAttachmentKey",
 			// CoreServices
@@ -289,6 +292,7 @@ namespace SwiftReflector.Importing {
 			"Foundation.NSUrlErrorNetworkUnavailableReason",
 	    		"Foundation.NSUrlSessionDelayedRequestDisposition", // 10.13; swift 4.2+
 			"Foundation.NSUrlSessionWebSocketCloseCode",
+			"Foundation.NSUrlSessionTaskMetricsDomainResolutionProtocol",
 			"Foundation.NSUrlSessionTaskMetricsResourceFetchType", // 10.12; swift 4.2+
 			"Foundation.NSUrlSessionWebSocketMessageType",
 			"Foundation.NSXpcConnectionOptions",
@@ -302,6 +306,8 @@ namespace SwiftReflector.Importing {
 			"ImageCaptureCore.ICExifOrientationType",
 			"ImageCaptureCore.ICReturnCode",
 			"ImageCaptureCore.ICTransportType",
+			// ImageIO
+			"ImageIO.CGImagePropertyTgaCompression",
 			// Intents
 			"Intents.INCallCapability",
 			"Intents.INCallCapabilityOptions",
@@ -339,10 +345,15 @@ namespace SwiftReflector.Importing {
 			"MetalPerformanceShaders.MPSCnnReductionType",
 			"MetalPerformanceShaders.MPSCnnWeightsQuantizationType",
 			// Network
+			"NetworkExtension.NEDnsProtocol",
+			"NetworkExtension.NEDnsSettingsManagerError",
 			"NetworkExtension.NENetworkRuleProtocol", // !! Can't figure out how to correctly map this into swift
 			// the compiler is complaining about the name Protcol, but if you backtick quote it, you get other errors.
 			// OpenGL
 			"OpenGL.CGLErrorCode", // can't find it
+			// PencilKit
+			"PencilKit.PKEraserType",
+			"PencilKit.PKInkType",
 			// Photos
 			"Photos.FigExifCustomRenderedValue", // can't find it
 			"Photos.PHPhotosError",
@@ -361,16 +372,23 @@ namespace SwiftReflector.Importing {
 			"StoreKit.SKCloudServiceAuthorizationStatus", // not on macOS
 			"StoreKit.SKCloudServiceCapability", // not on macOS
 			// VideoToolbox
+			"VideoToolbox.HdrMetadataInsertionMode",
 			"VideoToolbox.VTAlphaChannelMode",
 			// Vision
 			"Vision.VNClassifyImageRequestRevision",
+			"Vision.VNDetectContourRequestRevision",
 			"Vision.VNDetectFaceCaptureQualityRequestRevision",
+			"Vision.VNDetectHumanBodyPoseRequestRevision",
+			"Vision.VNDetectHumanHandPoseRequestRevision",
 			"Vision.VNDetectHumanRectanglesRequestRevision",
+			"Vision.VNDetectTrajectoriesRequestRevision",
 			"Vision.VNGenerateAttentionBasedSaliencyImageRequestRevision",
 			"Vision.VNGenerateImageFeaturePrintRequestRevision",
 			"Vision.VNGenerateObjectnessBasedSaliencyImageRequestRevision",
+			"Vision.VNGenerateOpticalFlowRequestRevision",
 			"Vision.VNRecognizeAnimalsRequestRevision",
 			"Vision.VNRecognizeTextRequestRevision",
+			"Vision.VNStatefulRequestRevision",
 			// WebKit
 			"WebKit.DomCssRuleType", // no longer exists
 			"WebKit.DomCssValueType", // no longer exists
@@ -456,6 +474,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSFontCollectionVisibility", "NSFontCollection.Visibility" },
 			{ "AppKit.NSFontDescriptorSystemDesign", "NSFontDescriptor.SystemDesign" },
 			{ "AppKit.NSFontPanelModeMask", "NSFontPanel.ModeMask" },
+			{ "AppKit.NSFontTextStyle", "NSFont.TextStyle" },
 			{ "AppKit.NSGestureRecognizerState", "NSGestureRecognizer.State" },
 			{ "AppKit.NSGlyphProperty", "NSLayoutManager.GlyphProperty" },
 			{ "AppKit.NSGradientDrawingOptions", "NSGradient.DrawingOptions" },
@@ -471,6 +490,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSImageName", "NSImage.Name" },
 			{ "AppKit.NSImageRepLoadStatus", "NSBitmapImageRep.LoadStatus" },
 			{ "AppKit.NSImageResizingMode", "NSImage.ResizingMode" },
+			{ "AppKit.NSImageSymbolScale", "NSImage.SymbolScale" },
 			{ "AppKit.NSLayoutAttribute", "NSLayoutConstraint.Attribute" },
 			{ "AppKit.NSLayoutConstraintOrientation", "NSLayoutConstraint.Orientation" },
 			{ "AppKit.NSLayoutFormatOptions", "NSLayoutConstraint.FormatOptions" },
@@ -478,6 +498,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSLayoutRelation", "NSLayoutConstraint.Relation" },
 			{ "AppKit.NSLevelIndicatorPlaceholderVisibility", "NSLevelIndicator.PlaceholderVisibility" },
 			{ "AppKit.NSLevelIndicatorStyle", "NSLevelIndicator.Style" },
+			{ "AppKit.NSLineBreakStrategy", "NSParagraphStyle.LineBreakStrategy" },
 			{ "AppKit.NSLineCapStyle", "NSBezierPath.LineCapStyle" },
 			{ "AppKit.NSLineJoinStyle", "NSBezierPath.LineJoinStyle" },
 			{ "AppKit.NSMatrixMode", "NSMatrix.Mode" },
@@ -535,7 +556,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSStatusItemBehavior", "NSStatusItem.Behavior" },
 			{ "AppKit.NSTableColumnResizing", "NSTableColumn.ResizingOptions" },
 			{ "AppKit.NSTableRowActionEdge", "NSTableView.RowActionEdge" },
-			{ "AppKit.NSTableViewAnimation", "NSTableView.AnimationOptions" },
+			{ "AppKit.NSTableViewAnimationOptions", "NSTableView.AnimationOptions" },
 			{ "AppKit.NSTableViewColumnAutoresizingStyle", "NSTableView.ColumnAutoresizingStyle" },
 			{ "AppKit.NSTableViewDraggingDestinationFeedbackStyle", "NSTableView.DraggingDestinationFeedbackStyle" },
 			{ "AppKit.NSTableViewDropOperation", "NSTableView.DropOperation" },
@@ -547,6 +568,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSTabState", "NSTabViewItem.State" },
 			{ "AppKit.NSTabViewBorderType", "NSTabView.TabViewBorderType" },
 			{ "AppKit.NSTabViewControllerTabStyle", "NSTabViewController.TabStyle" },
+			{ "AppKit.NSTableViewStyle", "NSTableView.Style" },
 			{ "AppKit.NSTabViewType", "NSTabView.TabType" },
 			{ "AppKit.NSTextBlockDimension", "NSTextBlock.Dimension" },
 			{ "AppKit.NSTextBlockLayer", "NSTextBlock.Layer" },
@@ -596,6 +618,7 @@ namespace SwiftReflector.Importing {
 			{ "AppKit.NSWindowStyle", "NSWindow.StyleMask" },
 			{ "AppKit.NSWindowTabbingMode", "NSWindow.TabbingMode" },
 			{ "AppKit.NSWindowTitleVisibility", "NSWindow.TitleVisibility" },
+			{ "AppKit.NSWindowToolbarStyle", "NSWindow.ToolbarStyle" },
 			{ "AppKit.NSWindowUserTabbingPreference", "NSWindow.UserTabbingPreference" },
 			{ "AppKit.NSWorkspaceAuthorizationType", "NSWorkspace.AuthorizationType" },
 			{ "AppKit.NSWorkspaceIconCreationOptions", "NSWorkspace.IconCreationOptions" },
@@ -603,13 +626,21 @@ namespace SwiftReflector.Importing {
 			// AuthenticationServices
 			{ "AuthenticationServices.ASAuthorizationScope", "ASAuthorization.Scope" },
 			// AVFoundation
+			{ "AVFoundation.AVAudioRoutingArbitrationCategory", "AVAudioRoutingArbiter.Category" },
 			{ "AVFoundation.AVSampleBufferRequestDirection", "AVSampleBufferRequest.Direction" },
 			{ "AVFoundation.AVSampleBufferRequestMode", "AVSampleBufferRequest.Mode" },
 			{ "AVFoundation.AVSemanticSegmentationMatteType", "AVSemanticSegmentationMatte.MatteType" },
 			// AVKit
 			{ "AVKit.AVRoutePickerViewButtonState", "AVRoutePickerView.ButtonState" },
+			// CoreData
+			{ "CoreData.NSPersistentCloudKitContainerEventResultType", "NSPersistentCloudKitContainerEventResult.ResultType" },
+			{ "CoreData.NSPersistentCloudKitContainerEventType", "NSPersistentCloudKitContainer.EventType" },
+			// CoreMotion
+			{ "CoreMotion.CMDeviceMotionSensorLocation", "CMDeviceMotion.SensorLocation" },
 			// CoreServices
 			{ "CoreServices.LSRoles", "LSRolesMask" },
+			// FileProvider
+			{ "FileProvider.NSFileProviderManagerDisconnectionOptions", "NSFileProviderManager.DisconnectionOptions" },
 			// Foundation
 			{ "Foundation.NSActivityOptions", "ProcessInfo.ActivityOptions" },
 			{ "Foundation.NSAppleEventSendOptions", "NSAppleEventDescriptor.SendOptions" },
@@ -706,6 +737,12 @@ namespace SwiftReflector.Importing {
 			{ "Foundation.NSQualityOfService", "QualityOfService" },
 			{ "Foundation.NSDataReadingOptions", "NSData.ReadingOptions" },
 			{ "Foundation.NSFormattingUnitStyle", "Formatter.UnitStyle" },
+			// GameControler
+			{ "GameController.GCDeviceBatteryState", "GCDeviceBattery.State" },
+			{ "GameController.GCSystemGestureState", "GCControllerElement.SystemGestureState" },
+			{ "GameController.GCTouchState", "GCControllerTouchpad.TouchState" },
+			{ "GameKit.GKAccessPointLocation", "GKAccessPoint.Location" },
+			{ "GameKit.GKLeaderboardType", "GKLeaderboard.LeaderboardType" },
 			// MapKit
 			{ "MapKit.MKLocalSearchCompleterResultType", "MKLocalSearchCompleter.ResultType" },
 			{ "MapKit.MKLocalSearchResultType", "MKLocalSearch.ResultType" },
@@ -724,6 +761,12 @@ namespace SwiftReflector.Importing {
 			{ "QuickLookThumbnailing.QLThumbnailRepresentationType", "QLThumbnailRepresentation.RepresentationType" },
 			// StoreKit
 			{ "StoreKit.SKProductDiscountType", "SKProductDiscount.Type" },
+			// Vision
+			{ "Vision.VNGenerateOpticalFlowRequestComputationAccuracy", "VNGenerateOpticalFlowRequest.ComputationAccuracy" },
+			{ "Vision.VNHumanBodyPoseObservationJointName", "VNHumanBodyPoseObservation.JointName" },
+			{ "Vision.VNHumanBodyPoseObservationJointsGroupName", "VNHumanBodyPoseObservation.JointsGroupName" },
+			{ "Vision.VNHumanHandPoseObservationJointName", "VNHumanHandPoseObservation.JointName" },
+			{ "Vision.VNHumanHandPoseObservationJointsGroupName", "VNHumanHandPoseObservation.JointsGroupName" },
 			// WebKit
 			{ "WebKit.WKContentMode", "WKWebpagePreferences.ContentMode" },
 		};

--- a/SwiftReflector/Importing/TypeAggregator.iOS.cs
+++ b/SwiftReflector/Importing/TypeAggregator.iOS.cs
@@ -14,7 +14,9 @@ namespace SwiftReflector.Importing {
 			"Registrar", // not a namespace
 	    		"Twitter", // not compatible with Swift
 			"CoreAnimation", // not a namespace
+			"MediaSetup", // not a namespace
 			"Microsoft.CodeAnalysis",
+			"MLCompute",
 			"ObjCRuntime", // .NET only
 	    		"System", // not a namespace
 			"System.Drawing", // not a namespace
@@ -53,6 +55,7 @@ namespace SwiftReflector.Importing {
 			"AddressBook.ABSourceProperty", // not an enum
 			"AddressBook.ABSourceType",
 			// ARKit
+			"ARKit.ARAppClipCodeUrlDecodingState",
 			"ARKit.ARPlaneClassificationStatus",
 			// AssetsLibrary
 			"AssetsLibrary.ALAssetsError", // not an enum
@@ -154,6 +157,8 @@ namespace SwiftReflector.Importing {
 			"AVKit.AVPlayerViewControlsStyle", // Mac only
 			// CallKit
 			"CallKit.CXErrorCode", // doesn't exist in Swift
+			// CarPlay
+			"CarPlay.CPMessageListItemType",
 			// CloudKit
 			"CloudKit.CKSubscriptionOptions",
 			// Contacts
@@ -186,6 +191,7 @@ namespace SwiftReflector.Importing {
 			"CoreFoundation.VnodeMonitorKind", // not an enum
 			// CoreGraphics
 	    		"CoreGraphics.CGColorConverterTransformType",
+			"CoreGraphics.CGConstantColor",
 			"CoreGraphics.CGTextEncoding", // Deprecated
 	    		"CoreGraphics.CGImagePixelFormatInfo", // can't find it?
 			"CoreGraphics.CGBitmapFlags", // can't find it
@@ -211,6 +217,7 @@ namespace SwiftReflector.Importing {
 			"CoreMedia.CMSampleBufferError", // doesn't exist
 			"CoreMedia.CMSyncError", // doesn't exist
 			// CoreNFC
+			"CoreNFC.NFCIso15693ResponseFlag",
 			"CoreNFC.NFCNdefStatus", // iOS 13
 			"CoreNFC.NFCTagType", // iOS 13
 			"CoreNFC.VasErrorCode", // iOS 13
@@ -234,6 +241,7 @@ namespace SwiftReflector.Importing {
 			"CoreVideo.CVImageBufferTransferFunction", // not an enum
 			"CoreVideo.CVImageBufferYCbCrMatrix", // not an enum
 			"CoreVideo.CVPixelFormatType", // not an enum
+			"CoreVideo.CVVersatileBayerPattern",
 			// EventKit
 			"EventKit.EKCalendarEventAvailability", // not an enum
 			"EventKit.EKDay", // changed to EKWeekday
@@ -266,6 +274,7 @@ namespace SwiftReflector.Importing {
 			"Foundation.NSUrlSessionWebSocketMessageType",
 	    		"Foundation.NSRunLoopMode",
 			"Foundation.NSTextWritingDirection", // deprecated in 9.0
+			"Foundation.NSUrlSessionTaskMetricsDomainResolutionProtocol",
 			"Foundation.NSXpcConnectionOptions",
 			// GameKit
 			"GameKit.GKAuthenticationType",
@@ -276,7 +285,9 @@ namespace SwiftReflector.Importing {
 			"GameKit.GKSessionMode", // marked unavailable
 			"GameKit.GKVoiceChatServiceError", // marked unavailable
 			// HealthKit
+			"HealthKit.HKAppleEcgAlgorithmVersion",
 			"HealthKit.HKDataTypeIdentifier",
+			"HealthKit.HKFhirRelease",
 			// HomeKit
 			"HomeKit.HMAccessoryCategoryType", // not an enum
 			"HomeKit.HMActionSetType", // not an enum
@@ -292,6 +303,7 @@ namespace SwiftReflector.Importing {
 			"IdentityLookup.ILClassificationAction",
 			// ImageIO
 			"ImageIO.CGImageAuxiliaryDataType", // not an enum
+			"ImageIO.CGImagePropertyTgaCompression",
 			"ImageIO.CGImagePropertyPngFilters", // can't find it
 			// Intents
 			"Intents.INIntentIdentifier", // not an enum
@@ -339,6 +351,7 @@ namespace SwiftReflector.Importing {
 			// Network
 			"Network.NWBrowseResultChange",
 			"Network.NWBrowserState",
+			"Network.NWConnectionGroupState",
 			"Network.NWDataTransferReportState",
 			"Network.NWEndpointType", // not an enum
 			"Network.NWFramerCreateFlags",
@@ -349,12 +362,16 @@ namespace SwiftReflector.Importing {
 			"Network.NWConnectionState", // iOS 12.0 or later
 			"Network.NWInterfaceType", // iOS 12.0 or later
 			"Network.NWListenerState", // iOS 12.0 or later
+			"Network.NWPathUnsatisfiedReason",
 			"Network.NWReportResolutionSource",
 			"Network.NWTxtRecordFindKey",
 			"Network.NWWebSocketCloseCode",
 			"Network.NWWebSocketOpCode",
 			"Network.NWWebSocketResponseStatus",
 			"Network.NWWebSocketVersion",
+			// NetworkExtension
+			"NetworkExtension.NEDnsProtocol",
+			"NetworkExtension.NEDnsSettingsManagerError",
 			// PassKit
 			"PassKit.PKAddSecureElementPassErrorCode",
 			"PassKit.PKErrorCode", // does not exist
@@ -389,6 +406,14 @@ namespace SwiftReflector.Importing {
 			"SystemConfiguration.StatusCode", // not an enum
 			// UIKit
 			"UIKit.UIAccessibilityPostNotification", // method in swift - not needed.
+			"UIKit.UICellAccessoryDisplayedState",
+			"UIKit.UICellAccessoryOutlineDisclosureStyle",
+			"UIKit.UICellAccessoryPlacement",
+			"UIKit.UICellConfigurationDragState",
+			"UIKit.UICellConfigurationDropState",
+			"UIKit.UICollectionLayoutListAppearance",
+			"UIKit.UICollectionLayoutListFooterMode",
+			"UIKit.UICollectionLayoutListHeaderMode",
 	    		"UIKit.UIFontDescriptorAttribute",
 			"UIKit.NSTextEffect",
 	    		"UIKit.UIAccessibilityTrait", // type alias
@@ -396,6 +421,8 @@ namespace SwiftReflector.Importing {
 	    		"UIKit.UIDocumentMenuOrder", // deprecation in 11.0
 			"UIKit.UIKeyboardHidUsage",
 			"UIKit.UILineBreakMode", // deprecated
+			"UIKit.UIListContentTextAlignment",
+			"UIKit.UIListContentTextTransform",
 	    		"UIKit.UIPencilPreferredAction", // 12.1+
 			"UIKit.UIRemoteNotificationType", // deprecated in 8
 	    		"UIKit.UISegmentedControlStyle", // deprecated
@@ -417,6 +444,7 @@ namespace SwiftReflector.Importing {
 			"UIKit.UIUserNotificationActionContext", // deprecated
 			"UIKit.UIWindowSceneSessionRole",
 			// VideoToolbox
+			"VideoToolbox.HdrMetadataInsertionMode",
 			"VideoToolbox.VTAlphaChannelMode",
 			"VideoToolbox.VTStatus",
 			"VideoToolbox.VTProfileLevel",
@@ -441,24 +469,30 @@ namespace SwiftReflector.Importing {
 			"Vision.VNClassifyImageRequestRevision",
 			"Vision.VNCoreMLRequestRevision",
 	    		"Vision.VNDetectBarcodesRequestRevision",
+			"Vision.VNDetectContourRequestRevision",
 			"Vision.VNDetectedObjectObservationRequestRevision",
 			"Vision.VNDetectFaceCaptureQualityRequestRevision",
 	    		"Vision.VNDetectFaceLandmarksRequestRevision",
 			"Vision.VNDetectFaceRectanglesRequestRevision",
 	    		"Vision.VNDetectHorizonRequestRevision",
+			"Vision.VNDetectHumanBodyPoseRequestRevision",
+			"Vision.VNDetectHumanHandPoseRequestRevision",
 			"Vision.VNDetectHumanRectanglesRequestRevision",
 			"Vision.VNDetectRectanglesRequestRevision",
 	    		"Vision.VNDetectTextRectanglesRequestRevision",
+			"Vision.VNDetectTrajectoriesRequestRevision",
 			"Vision.VNFaceObservationRequestRevision",
 			"Vision.VNGenerateAttentionBasedSaliencyImageRequestRevision",
 			"Vision.VNGenerateImageFeaturePrintRequestRevision",
 			"Vision.VNGenerateObjectnessBasedSaliencyImageRequestRevision",
+			"Vision.VNGenerateOpticalFlowRequestRevision",
 	    		"Vision.VNHomographicImageRegistrationRequestRevision",
 			"Vision.VNRecognizeAnimalsRequestRevision",
 			"Vision.VNRecognizedObjectObservationRequestRevision",
 			"Vision.VNRecognizeTextRequestRevision",
 	    		"Vision.VNRectangleObservationRequestRevision",
 			"Vision.VNRequestRevision",
+			"Vision.VNStatefulRequestRevision",
 	    		"Vision.VNTextObservationRequestRevision",
 			"Vision.VNTranslationalImageRegistrationRequestRevision",
 	    		"Vision.VNTrackObjectRequestRevision",
@@ -479,11 +513,15 @@ namespace SwiftReflector.Importing {
 			{ "Accelerate.vImageFlags", "vImage_Flags" },
 			{ "Accelerate.vImageInterpolationMethod", "vImage_InterpolationMethod" },
 			// ARKit
+			{ "ARKit.ARAltitudeSource", "ARGeoAnchor.AltitudeSource" },
 			{ "ARKit.ARCoachingGoal", "ARCoachingOverlayView.Goal" },
 			{ "ARKit.ARCollaborationDataPriority", "ARSession.CollaborationData" },
 			{ "ARKit.AREnvironmentTexturing", "ARWorldTrackingConfiguration.EnvironmentTexturing" },
 			{ "ARKit.ARErrorCode", "ARError.Code" },
 			{ "ARKit.ARFrameSemantics", "ARConfiguration.FrameSemantics" },
+			{ "ARKit.ARGeoTrackingAccuracy", "ARGeoTrackingStatus.Accuracy" },
+			{ "ARKit.ARGeoTrackingState", "ARGeoTrackingStatus.State" },
+			{ "ARKit.ARGeoTrackingStateReason", "ARGeoTrackingStatus.StateReason" },
 			{ "ARKit.ARMatteResolution", "ARMatteGenerator.Resolution" },
 			{ "ARKit.ARHitTestResultType", "ARHitTestResult.ResultType" },
 			{ "ARKit.ARPlaneAnchorAlignment", "ARPlaneAnchor.Alignment" },
@@ -538,6 +576,7 @@ namespace SwiftReflector.Importing {
 			{ "AVFoundation.AVAudioSessionRouteSharingPolicy", "AVAudioSession.RouteSharingPolicy" },
 			{ "AVFoundation.AVAudioSessionSetActiveOptions", "AVAudioSession.SetActiveOptions" },
 			{ "AVFoundation.AVAudioSessionSilenceSecondaryAudioHintType", "AVAudioSession.SilenceSecondaryAudioHintType" },
+			{ "AVFoundation.AVAudioStereoOrientation", "AVAudioSession.StereoOrientation" },
 			{ "AVFoundation.AVCaptureAutoFocusRangeRestriction", "AVCaptureDevice.AutoFocusRangeRestriction" },
 			{ "AVFoundation.AVCaptureAutoFocusSystem", "AVCaptureDevice.Format.AutoFocusSystem" },
 			{ "AVFoundation.AVCaptureDevicePosition", "AVCaptureDevice.Position" },
@@ -589,6 +628,7 @@ namespace SwiftReflector.Importing {
 			{ "CarPlay.CPTripPauseReason", "CPNavigationSession.PauseReason" },
 			// ClassKit
 			{ "ClassKit.CLSErrorCode", "CLSError.Code" },
+			{ "ClassKit.CLSProgressReportingCapabilityKind", "CLSProgressReportingCapability.Kind" },
 			// CloudKit
 			{ "CloudKit.CKApplicationPermissions", "CKContainer_Application_Permissions" },
 			{ "CloudKit.CKApplicationPermissionStatus", "CKContainer_Application_PermissionStatus" },
@@ -612,6 +652,9 @@ namespace SwiftReflector.Importing {
 			{ "Contacts.CNErrorCode", "CNError.Code" },
 			// CoreBluetooth
 			{ "CoreBluetooth.CBCentralManagerFeature", "CBCentralManager.Feature" },
+			// CoreData
+			{ "CoreData.NSPersistentCloudKitContainerEventResultType", "NSPersistentCloudKitContainerEventResult.ResultType" },
+			{ "CoreData.NSPersistentCloudKitContainerEventType", "NSPersistentCloudKitContainer.EventType" },
 			// CoreFoundation
 			{ "CoreFoundation.CFRunLoopExitReason", "CFRunLoopRunResult" },
 			{ "CoreFoundation.CFUrlPathStyle", "CFURLPathStyle" },
@@ -623,6 +666,8 @@ namespace SwiftReflector.Importing {
 			// iOS 13.0 or later: { "CoreMedia.CMClockError", "CMClock.Error" },
 			// iOS 13.0 or later: { "CoreMedia.CMSampleBufferError", "CMSampleBuffer.Error" },
 			// iOS 13.0 or later: { "CoreMedia.CMSyncError", "CMSync.Error" },
+			// CoreMotion
+			{ "CoreMotion.CMDeviceMotionSensorLocation", "CMDeviceMotion.SensorLocation" },
 			// CoreNFC
 			{ "CoreNFC.NFCPollingOption", "NFCTagReaderSession.PollingOption" },
 			// CoreSpotlight
@@ -732,9 +777,15 @@ namespace SwiftReflector.Importing {
 			{ "Foundation.NSStringTransform", "StringTransform" },
 			{ "Foundation.NSOperatingSystemVersion", "OperatingSystemVersion" },
 			{ "Foundation.NSDecimal", "Decimal" },
+			// GameController
+			{ "GameController.GCDeviceBatteryState", "GCDeviceBattery.State" },
+			{ "GameController.GCSystemGestureState", "GCControllerElement.SystemGestureState" },
+			{ "GameController.GCTouchState", "GCControllerTouchpad.TouchState" },
 			// GameKit
+			{ "GameKit.GKAccessPointLocation", "GKAccessPoint.Location" },
 			{ "GameKit.GKLeaderboardPlayerScope", "GKLeaderboard.PlayerScope" },
 			{ "GameKit.GKLeaderboardTimeScope", "GKLeaderboard.TimeScope" },
+			{ "GameKit.GKLeaderboardType", "GKLeaderboard.LeaderboardType" },
 			{ "GameKit.GKMatchSendDataMode", "GKMatch.SendDataMode" },
 			{ "GameKit.GKPhotoSize", "GKPlayer.PhotoSize" },
 			{ "GameKit.GKTurnBasedMatchOutcome", "GKTurnBasedMatch.Outcome" },
@@ -742,12 +793,16 @@ namespace SwiftReflector.Importing {
 			{ "GameKit.GKTurnBasedParticipantStatus", "GKTurnBasedParticipant.Status" },
 			{ "GameKit.GKVoiceChatPlayerState", "GKVoiceChat.PlayerState" },
 			// HealthKit
+			{ "HealthKit.HKElectrocardiogramClassification", "HKElectrocardiogram.Classification" },
+			{ "HealthKit.HKElectrocardiogramLead", "HKElectrocardiogram.Lead" },
+			{ "HealthKit.HKElectrocardiogramSymptomsStatus", "HKElectrocardiogram.SymptomsStatus" },
 			{ "HealthKit.HKErrorCode", "HKError.Code" },
 			{ "HealthKit.HKFhirResourceType", "HKFHIRResourceType" },
 			// HomeKit
 			{ "HomeKit.HMCharacteristicValueAirParticulate", "HMCharacteristicValueAirParticulateSize" },
 			{ "HomeKit.HMCharacteristicValueLockMechanism", "HMCharacteristicValueLockMechanismLastKnownAction" },
 			// Intents
+			{ "Intents.INCarChargingConnectorType", "INCar.ChargingConnectorType" },
 			{ "Intents.INDailyRoutineSituation", "INDailyRoutineRelevanceProvider.Situation" },
 			{ "Intents.INIntentErrorCode", "INIntentError.Code" },
 			{ "Intents.INMediaUserContextSubscriptionStatus", "INMediaUserContext.SubscriptionStatus" },
@@ -863,6 +918,7 @@ namespace SwiftReflector.Importing {
 			{ "Security.SslSessionOption", "SSLSessionOption" },
 			{ "Security.SslSessionState", "SSLSessionState" },
 			// StoreKit
+			{ "StoreKit.SKOverlayPosition", "SKOverlay.Position" },
 			{ "StoreKit.SKProductDiscountPaymentMode", "SKProductDiscount.PaymentMode" },
 			{ "StoreKit.SKProductDiscountType", "SKProductDiscount.Type" },
 			{ "StoreKit.SKProductPeriodUnit", "SKProduct.PeriodUnit" },
@@ -874,6 +930,7 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.NSLayoutAttribute", "NSLayoutConstraint.Attribute" },
 			{ "UIKit.NSLayoutFormatOptions", "NSLayoutConstraint.FormatOptions" },
 			{ "UIKit.NSLayoutRelation", "NSLayoutConstraint.Relation" },
+			{ "UIKit.NSLineBreakStrategy", "NSParagraphStyle.LineBreakStrategy" },
 			{ "UIKit.NSTextLayoutOrientation", "NSLayoutManager.TextLayoutOrientation" },
 			{ "UIKit.NSTextStorageEditActions", "NSTextStorage.EditActions" },
 			{ "UIKit.UIAccessibilityCustomRotorDirection", "UIAccessibilityCustomRotor.Direction" },
@@ -890,6 +947,7 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIBarButtonItemStyle", "UIBarButtonItem.Style" },
 			{ "UIKit.UIBarButtonSystemItem", "UIBarButtonItem.SystemItem" },
 			{ "UIKit.UIBlurEffectStyle", "UIBlurEffect.Style" },
+			{ "UIKit.UIButtonRole", "UIButton.Role" },
 			{ "UIKit.UIButtonType", "UIButton.ButtonType" },
 			{ "UIKit.UICloudSharingPermissionOptions", "UICloudSharingController.PermissionOptions" },
 			{ "UIKit.UICollectionElementCategory", "UICollectionView.ElementCategory" },
@@ -901,6 +959,7 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UICollectionViewScrollDirection", "UICollectionView.ScrollDirection" },
 			{ "UIKit.UICollectionViewScrollPosition", "UICollectionView.ScrollPosition" },
 			{ "UIKit.UICollisionBehaviorMode", "UICollisionBehavior.Mode" },
+			{ "UIKit.UIContextMenuInteractionAppearance", "UIContextMenuInteraction.appearance" },
 			{ "UIKit.UIControlContentHorizontalAlignment", "UIControl.ContentHorizontalAlignment" },
 			{ "UIKit.UIControlContentVerticalAlignment", "UIControl.ContentVerticalAlignment" },
 			{ "UIKit.UIControlEvents", "UIControl.Event" },
@@ -946,10 +1005,14 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIMenuElementState", "UIMenuElement.State" },
 			{ "UIKit.UIMenuIdentifier", "UIMenu.Identifier" },
 			{ "UIKit.UIMenuOptions", "UIMenu.Options" },
+			{ "UIKit.UINavigationItemBackButtonDisplayMode", "UINavigationItem.BackButtonDisplayMode" },
+			{ "UIKit.UIPageControlBackgroundStyle", "UIPageControl.BackgroundStyle" },
+			{ "UIKit.UIPageControlInteractionState", "UIPageControl.InteractionState" },
 			{ "UIKit.UIPageViewControllerNavigationDirection", "UIPageViewController.NavigationDirection" },
 			{ "UIKit.UIPageViewControllerNavigationOrientation", "UIPageViewController.NavigationOrientation" },
 			{ "UIKit.UIPageViewControllerSpineLocation", "UIPageViewController.SpineLocation" },
 			{ "UIKit.UIPageViewControllerTransitionStyle", "UIPageViewController.TransitionStyle" },
+			{ "UIKit.UIPasteboardDetectionPattern", "UIPasteboard.DetectionPattern" },
 			{ "UIKit.UIPreferredPresentationStyle", "NSItemProvider.PreferredPresentationStyle" },
 			{ "UIKit.UIPressPhase", "UIPress.Phase" },
 			{ "UIKit.UIPressType", "UIPress.PressType" },
@@ -971,10 +1034,14 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UISearchBarStyle", "UISearchBar.Style" },
 			{ "UIKit.UISegmentedControlSegment", "UISegmentedControl.Segment" },
 			{ "UIKit.UISplitViewControllerBackgroundStyle", "UISplitViewController.BackgroundStyle" },
+			{ "UIKit.UISplitViewControllerColumn", "UISplitViewController.Column" },
 			{ "UIKit.UISplitViewControllerDisplayMode", "UISplitViewController.DisplayMode" },
 			{ "UIKit.UISplitViewControllerPrimaryEdge", "UISplitViewController.PrimaryEdge" },
+			{ "UIKit.UISplitViewControllerSplitBehavior", "UISplitViewController.SplitBehavior" },
+			{ "UIKit.UISplitViewControllerStyle", "UISplitViewController.Style" },
 			{ "UIKit.UIStackViewAlignment", "UIStackView.Alignment" },
 			{ "UIKit.UIStackViewDistribution", "UIStackView.Distribution" },
+			{ "UIKit.UISwitchStyle", "UISwitch.Style" },
 			{ "UIKit.UISwipeGestureRecognizerDirection", "UISwipeGestureRecognizer.Direction" },
 			{ "UIKit.UISystemAnimation", "UIView.SystemAnimation" },
 			{ "UIKit.UITabBarItemAppearanceStyle", "UITabBarItemAppearance.Style" },
@@ -1020,6 +1087,12 @@ namespace SwiftReflector.Importing {
 			{ "UIKit.UIDocumentBrowserUserInterfaceStyle", "UIDocumentBrowserViewController.BrowserUserInterfaceStyle" },
 			// UserNotifications
 			{ "UserNotifications.UNErrorCode", "UNError.Code" },
+			// Vision
+			{ "Vision.VNGenerateOpticalFlowRequestComputationAccuracy", "VNGenerateOpticalFlowRequest.ComputationAccuracy" },
+			{ "Vision.VNHumanBodyPoseObservationJointName", "VNHumanBodyPoseObservation.JointName" },
+			{ "Vision.VNHumanBodyPoseObservationJointsGroupName", "VNHumanBodyPoseObservation.JointsGroupName" },
+			{ "Vision.VNHumanHandPoseObservationJointName", "VNHumanHandPoseObservation.JointName" },
+			{ "Vision.VNHumanHandPoseObservationJointsGroupName", "VNHumanHandPoseObservation.JointsGroupName" },
 			// WatchConnectivity
 			{ "WatchConnectivity.WCErrorCode", "WCError.Code" },
 			// WatchKit

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -165,6 +165,7 @@ namespace SwiftReflector {
 			ClassCompilerNames compilerNames,
 			List<string> targets,
 			string outputDirectory,
+			string minimumOSVersion = null,
 			string dylibXmlPath = null)
 		{
 			ClassCompilerLocations = SwiftRuntimeLibrary.Exceptions.ThrowOnNull (classCompilerLocations, nameof (classCompilerLocations));
@@ -230,7 +231,7 @@ namespace SwiftReflector {
 					targets,
 					CompilerNames.WrappingModuleName,
 					Options.RetainSwiftWrappers,
-					errors, Verbose, OutputIsFramework, isLibrary);
+					errors, Verbose, OutputIsFramework, minimumOSVersion, isLibrary);
 				if (result == null) {
 					var ex = ErrorHelper.CreateError (ReflectorError.kWrappingBase, $"Failed to wrap module{(moduleNames.Count > 1 ? "s" : "")} {moduleNames.InterleaveCommas ()}.");
 					errors.Add (ex); 
@@ -5309,7 +5310,7 @@ namespace SwiftReflector {
 			string wrappingModuleName,
 			bool retainSwiftWrappers,
 			ErrorHandling errors, bool verbose,
-			bool outputIsFramework, bool isLibrary = false)
+			bool outputIsFramework, string minimumOSVersion = null, bool isLibrary = false)
 		{
 			wrappingModuleName = wrappingModuleName ?? "XamWrapping";
 
@@ -5322,7 +5323,8 @@ namespace SwiftReflector {
 				wrapStuff = wrappingCompiler.CompileWrappers (
 					libraryPaths.ToArray (),
 					modulePaths.ToArray (),
-					moduleDecls, moduleInventory, targets, wrappingModuleName, outputIsFramework, isLibrary);
+					moduleDecls, moduleInventory, targets, wrappingModuleName, outputIsFramework,
+					minimumOSVersion, isLibrary);
 				noWrappersNeeded = wrapStuff.Item1 == null;
 			} catch (Exception e) {
 				errors.Add (e);
@@ -5745,7 +5747,7 @@ namespace SwiftReflector {
 
 		PlatformName PlatformFromTargets (IEnumerable<string> targets)
 		{
-			var osString = targets.Select (target => target.ClangTargetOS ()).Distinct ().ToList ();
+			var osString = targets.Select (target => target.ClangOSNoVersion ()).Distinct ().ToList ();
 			if (osString.Count != 1)
 				throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 53, $"Expecting a unique target but got {osString.InterleaveCommas ()}");
 			if (osString [0].StartsWith ("macos", StringComparison.OrdinalIgnoreCase))

--- a/SwiftReflector/WrappingCompiler.cs
+++ b/SwiftReflector/WrappingCompiler.cs
@@ -41,7 +41,8 @@ namespace SwiftReflector {
 
 		public Tuple<string, HashSet<string>> CompileWrappers (string [] inputLibraryDirectories, string [] inputModuleDirectories,
 			IEnumerable<ModuleDeclaration> modulesToCompile, ModuleInventory modInventory,
-			List<string> targets, string wrappingModuleName, bool outputIsFramework, bool isLibrary = false)
+			List<string> targets, string wrappingModuleName, bool outputIsFramework,
+			string minimumOSVersion = null, bool isLibrary = false)
 		{
 			wrappingModuleName = wrappingModuleName ?? kXamWrapPrefix;
 
@@ -79,6 +80,7 @@ namespace SwiftReflector {
 					// each file goes to a unique output directory.
 					// first compile into the fileProvider, then move to
 					// fileProvider/tar-get-arch
+					var target = minimumOSVersion != null ? targets [i].ClangSubstituteOSVersion (minimumOSVersion) : targets [i];
 					string targetoutdir = Path.Combine (fileProvider.DirectoryPath, targets [i]);
 					targetOutDirs.Add (targetoutdir);
 					Directory.CreateDirectory (targetoutdir);
@@ -87,7 +89,7 @@ namespace SwiftReflector {
 					List<ISwiftModuleLocation> locations = null;
 					if (!isLibrary)
 						locations = SwiftModuleFinder.GatherAllReferencedModules (allReferencedModules,
-												      inputModuleDirectories, targets [i]);
+												      inputModuleDirectories, target);
 
 					try {
 						// We will keep inputModDirs as null if using a dylib
@@ -96,7 +98,7 @@ namespace SwiftReflector {
 							inputModDirs = locations.Select (loc => loc.DirectoryPath).ToArray ();
 						CompileAllFiles (fileProvider, wrappingModuleName, outputLibraryName, outputLibraryPath,
 						                 inputModDirs, inputLibraryDirectories, inModuleNamesList.ToArray (),
-						                 targets [i], outputIsFramework);
+						                 target, outputIsFramework);
 					} catch (Exception e) {
 						throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 66, e, $"Failed to compile the generated swift wrapper code: {e.Message}");
 					} finally {

--- a/tom-swifty/Program.cs
+++ b/tom-swifty/Program.cs
@@ -108,7 +108,8 @@ namespace tomswifty {
 
 					ClassCompilerNames compilerNames = new ClassCompilerNames (options.ModuleName, options.WrappingModuleName);
 					ClassCompilerLocations classCompilerLocations = new ClassCompilerLocations (options.ModulePaths, options.DylibPaths, options.TypeDatabasePaths);
-					var compileErrors = classCompiler.CompileToCSharp (classCompilerLocations, compilerNames, options.Targets, options.OutputDirectory, options.DylibXmlPath);
+					var compileErrors = classCompiler.CompileToCSharp (classCompilerLocations, compilerNames, options.Targets, options.OutputDirectory,
+						minimumOSVersion: options.MinimumOSVersion, dylibXmlPath: options.DylibXmlPath);
 					errors.Add (compileErrors);
 				}
 			} catch (Exception err) {

--- a/tom-swifty/SwiftyOptions.cs
+++ b/tom-swifty/SwiftyOptions.cs
@@ -118,6 +118,7 @@ namespace tomswifty {
 		public List<string> ModulePaths { get; private set; }
 		public List<string> DylibPaths { get; private set; }
 		public List<string> Targets { get; private set; }
+		public string MinimumOSVersion { get; private set; }
 		public string ModuleName { get; set; }
 		public string WrappingModuleName { get; set; }
 		public string OutputDirectory { get; set; }
@@ -268,16 +269,17 @@ namespace tomswifty {
 						List<string> targets = MachOHelpers.TargetsFromDylib (stm);
 
 						Targets = FilterTargetsIfNeeded (targets, libFile);
+						MinimumOSVersion = SwiftReflector.Extensions.MinimumClangVersion (Targets);
 
 						if (Targets.Count > 0) {
 							var targetOS = targets [0].ClangTargetOS ();
-							var targetOSAlpha = new string (targetOS.Where (Char.IsLetter).ToArray ());
+							var targetOSOnly = targets [0].ClangOSNoVersion ();
 
 							if (SwiftGluePath != null) {
 								string path = null;
 								string targetOSPathPart;
-								if (!targetOSToTargetDirectory.TryGetValue (targetOSAlpha, out targetOSPathPart)) {
-									throw new ArgumentException ("Target not found", nameof (targetOSAlpha));
+								if (!targetOSToTargetDirectory.TryGetValue (targetOSOnly, out targetOSPathPart)) {
+									throw new ArgumentException ("Target not found", nameof (targetOSOnly));
 								}
 								// The SwiftGluePath may have a 'FinalProduct' directory inside the path
 								path = Path.Combine (SwiftGluePath, $"{targetOSPathPart}/XamGlue.framework");
@@ -289,8 +291,8 @@ namespace tomswifty {
 							}
 
 							string targetOSLibraryPathPart;
-							if (!targetOSToTargetLibrary.TryGetValue (targetOSAlpha, out targetOSLibraryPathPart)) {
-								throw new ArgumentException ("Target not found", nameof (targetOSAlpha));
+							if (!targetOSToTargetLibrary.TryGetValue (targetOSOnly, out targetOSLibraryPathPart)) {
+								throw new ArgumentException ("Target not found", nameof (targetOSOnly));
 							}
 							// The SwiftLibPath may have a 'swift' directory inside the path
 							var swiftLibPath = SwiftLibPath;
@@ -394,7 +396,6 @@ namespace tomswifty {
 				return targets;
 			}
 		}
-
 	}
 }
 


### PR DESCRIPTION
More recent Xcode introduces an arm64 simulator for Macs with arm processors. This presents a number of new things to look at.

First, the target triple (arch-platform-osandvers) is now an extended target triple: arch-platform-osandvers[-simulator].
I added a bunch of extensions to change that.  It's a mistake to be doing so much string manipulation so I've added an [issue](https://github.com/xamarin/binding-tools-for-swift/issues/692) for that.

Next, the arm64 simulator target when compiled for, say iOS 10.2, reports that it was compiler for iOS 14.4. Lovely. I found the chunk of code in the swift compiler that does that. Apparently the linker doesn't like that, so the compiler forces it to be higher.
This causes a number of problems. The first is that we detect an error if there are multiple mismatched OS targets in a fat framework and we were seeing ios10.2 and ios14.4. So I added code to only look at the OS part for that error and ignore the version. I also made the compilation compile down to the minimum OS version that we're presented with.

Both of these fix this [issue](https://github.com/xamarin/binding-tools-for-swift/issues/683)

Finally, XamGlue is not compatible with an arm64 simulator. That has to do with it being packed as a framework. I've updated the issue I opened [here](https://github.com/xamarin/binding-tools-for-swift/issues/684).

Finally, you'll see a number of changes to the TypeAggregators. These reflect a more current version of the Xamarin frameworks. I know that this doesn't fit in with the rest of this PR, but I made the mistake of doing a `make clean` in the swiftglue directory while I was trying to figure out if I could reasonably fix it and was in a position of having to either downgrade or fix the renamed types. Since fixing the types would need to get done some day and was less onerous, I chose that route.

Tests pass.