### PR TITLE
Remove arm64 from consideration

### DIFF
--- a/SwiftReflector/Extensions.cs
+++ b/SwiftReflector/Extensions.cs
@@ -150,6 +150,18 @@ namespace SwiftReflector {
 			return clangTarget.InterleaveStrings ("-");
 		}
 
+		public static bool ClangTargetIsSimulator (this string s)
+		{
+			var parts = s.DecomposeClangTarget ();
+			if (parts.Length == 4 && parts [3] == "simulator")
+				return true;
+			var osNoVersion = OSNoVersion (parts [2]);
+			if (osNoVersion == "macosx")
+				return false;
+			var cpu = parts [0];
+			return cpu == "i386" || cpu == "x86-64";
+		}
+
 		public static void Merge<T> (this HashSet<T> to, IEnumerable<T> from)
 		{
 			Exceptions.ThrowOnNull (from, nameof (from));

--- a/tests/tom-swifty-test/SwiftReflector/ClangTargetTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ClangTargetTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using SwiftReflector;
+using NUnit.Framework;
+
+namespace SwiftReflector {
+
+	[TestFixture]
+	public class ClangTargetTests {
+		[TestCase ("armv7-apple-ios10.3", false)]
+		[TestCase ("armv7s-apple-ios10.3", false)]
+		[TestCase ("arm64-apple-ios10.3", false)]
+		[TestCase ("i386-apple-ios10.3-simulator", true)]
+		[TestCase ("x86_64-apple-macosx10.9", false)]
+		[TestCase ("x86_64-apple-ios10.3-simulator", true)]
+		[TestCase ("armv7k-apple-watchos3.2", false)]
+		[TestCase ("i386-apple-watchos3.2-simulator", true)]
+		public void SimulatorTests (string target, bool expected)
+		{
+			Assert.AreEqual (expected, target.ClangTargetIsSimulator (), $"wrong simulator state for {target}");
+		}
+	}
+}

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -117,6 +117,7 @@
     <Compile Include="XmlReflectionTests\ComparatorTests.cs" />
     <Compile Include="XmlReflectionTests\TypeAliasTests.cs" />
     <Compile Include="DylibBinderTests\ReferenceStructTests.cs" />
+    <Compile Include="SwiftReflector\ClangTargetTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
If we get an arm64 simulator, remove it from the target list.

Added tests for the predicates, which pass.