### PR TITLE
Added representation for a compilation target

### DIFF
--- a/SwiftReflector/CompilationTarget.cs
+++ b/SwiftReflector/CompilationTarget.cs
@@ -1,0 +1,91 @@
+﻿using System;
+namespace SwiftReflector {
+	public class CompilationTarget {
+		public CompilationTarget (PlatformName os, TargetCpu cpu, TargetEnvironment environment,
+			Version minimumOSVersion, TargetManufacturer manufacturer = TargetManufacturer.Apple)
+		{
+			if (os == PlatformName.None)
+				throw new ArgumentOutOfRangeException (nameof (os));
+			OperatingSystem = os;
+			Cpu = cpu;
+			Environment = environment;
+			if (minimumOSVersion == null)
+				throw new ArgumentNullException (nameof (minimumOSVersion));
+			MinimumOSVersion = minimumOSVersion;
+			Manufacturer = manufacturer;
+		}
+
+		public PlatformName OperatingSystem {
+			get; private set;
+		}
+
+		public TargetCpu Cpu {
+			get; private set;
+		}
+
+		public TargetEnvironment Environment {
+			get; private set;
+		}
+
+		public TargetManufacturer Manufacturer {
+			get; private set;
+		}
+
+		public Version MinimumOSVersion {
+			get; private set;
+		}
+
+		public bool SameIgnoreOSVersion (CompilationTarget other)
+		{
+			return other.OperatingSystem == OperatingSystem && other.Cpu == Cpu &&
+				other.Environment == Environment && other.Manufacturer == Manufacturer;
+		}
+
+		public CompilationTarget WithMinimumOSVersion (Version version)
+		{
+			if (version == MinimumOSVersion)
+				return this;
+			return new CompilationTarget (this.OperatingSystem, this.Cpu,
+				this.Environment, version, this.Manufacturer);
+		}
+
+		public override string ToString ()
+		{
+			var environment = Environment == TargetEnvironment.Device ? "" : "-simulator";
+			return $"{CpuToString ()}-{ManufacturerToString ()}-{OperatingSystemToString ()}{MinimumOSVersion}{environment}";
+		}
+
+		string CpuToString ()
+		{
+			switch (Cpu) {
+			case TargetCpu.Arm64: return "arm64";
+			case TargetCpu.Armv7: return "armv7";
+			case TargetCpu.Armv7s: return "armv7s";
+			case TargetCpu.I386: return "i386";
+			case TargetCpu.X86_64: return "x86_64";
+			default:
+				throw new ArgumentOutOfRangeException (nameof (Cpu));
+			}
+		}
+
+		string ManufacturerToString ()
+		{
+			switch (Manufacturer) {
+			case TargetManufacturer.Apple: return "apple";
+			default: throw new ArgumentOutOfRangeException (nameof (Manufacturer));
+			}
+		}
+
+		string OperatingSystemToString ()
+		{
+			switch (OperatingSystem) {
+			case PlatformName.iOS: return "ios";
+			case PlatformName.macOS: return "macosx";
+			case PlatformName.tvOS: return "tvos";
+			case PlatformName.watchOS: return "watchos";
+			default:
+				throw new ArgumentOutOfRangeException (nameof (OperatingSystem));
+			}
+		}
+	}
+}

--- a/SwiftReflector/CompilationTarget.cs
+++ b/SwiftReflector/CompilationTarget.cs
@@ -59,7 +59,9 @@ namespace SwiftReflector {
 		{
 			switch (Cpu) {
 			case TargetCpu.Arm64: return "arm64";
+			case TargetCpu.Arm64_32: return "arm64_32";
 			case TargetCpu.Armv7: return "armv7";
+			case TargetCpu.Arm7vk: return "armv7k";
 			case TargetCpu.Armv7s: return "armv7s";
 			case TargetCpu.I386: return "i386";
 			case TargetCpu.X86_64: return "x86_64";

--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -154,6 +154,8 @@ namespace SwiftReflector {
 		Arm64,
 		Armv7,
 		Armv7s,
+		Arm7vk,
+		Arm64_32,
 		I386,
 		X86_64,
 	}

--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -149,5 +149,22 @@ namespace SwiftReflector {
 		Compiler,
 		Parser,
 	}
+
+	public enum TargetCpu {
+		Arm64,
+		Armv7,
+		Armv7s,
+		I386,
+		X86_64,
+	}
+
+	public enum TargetManufacturer {
+		Apple,
+	}
+
+	public enum TargetEnvironment {
+		Device,
+		Simulator,
+	}
 }
 

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -185,6 +185,7 @@
     <Compile Include="SwiftInterfaceReflector\SyntaxDesugaringParser.cs" />
     <Compile Include="SwiftXmlReflection\TypeAliasDeclaration.cs" />
     <Compile Include="SwiftXmlReflection\TypeAliasFolder.cs" />
+    <Compile Include="CompilationTarget.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace SwiftReflector {
+	[TestFixture]
+	public class CompilationTargetTests {
+		[Test]
+		public void MacOSTest ()
+		{
+			var target = new CompilationTarget (PlatformName.macOS, TargetCpu.X86_64,
+				TargetEnvironment.Device, new Version ("14.3"));
+			Assert.AreEqual ("x86_64-apple-macosx14.3", target.ToString ());
+		}
+
+		[Test]
+		public void CantHaveNullTarget ()
+		{
+			Assert.Throws (typeof (ArgumentNullException), () => new CompilationTarget (PlatformName.iOS, TargetCpu.Arm64,
+				TargetEnvironment.Simulator, null));
+		}
+
+		[Test]
+		public void CantHaveNonePlatform ()
+		{
+			Assert.Throws (typeof (ArgumentOutOfRangeException), () => new CompilationTarget (PlatformName.None, TargetCpu.Arm64,
+					    TargetEnvironment.Simulator, null));
+		}
+
+		[Test]
+		public void SimulatorOnWatchOS ()
+		{
+			var target = new CompilationTarget (PlatformName.watchOS, TargetCpu.I386,
+				TargetEnvironment.Simulator, new Version ("3.2"));
+			Assert.AreEqual ("i386-apple-watchos3.2-simulator", target.ToString ());
+		}
+	}
+}

--- a/tests/tom-swifty-test/tom-swifty-test.csproj
+++ b/tests/tom-swifty-test/tom-swifty-test.csproj
@@ -118,6 +118,7 @@
     <Compile Include="XmlReflectionTests\TypeAliasTests.cs" />
     <Compile Include="DylibBinderTests\ReferenceStructTests.cs" />
     <Compile Include="SwiftReflector\ClangTargetTests.cs" />
+    <Compile Include="SwiftReflector\CompilationTargetTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
This is a simple representation of a compilation target.
These will be built from xcframeworks and frameworks, eventually.

Am I missing a CPU that we care about?