### PR TITLE
First cut at framework representations

### DIFF
--- a/SwiftReflector/CompilationTarget.cs
+++ b/SwiftReflector/CompilationTarget.cs
@@ -55,7 +55,13 @@ namespace SwiftReflector {
 			return $"{CpuToString ()}-{ManufacturerToString ()}-{OperatingSystemToString ()}{MinimumOSVersion}{environment}";
 		}
 
-		string CpuToString ()
+		public string EnvironmentToString ()
+		{
+			// do NOT call this in ToString - this is for displaying exceptions
+			return Environment == TargetEnvironment.Device ? "device" : "simulator";
+		}
+
+		public string CpuToString ()
 		{
 			switch (Cpu) {
 			case TargetCpu.Arm64: return "arm64";
@@ -70,7 +76,7 @@ namespace SwiftReflector {
 			}
 		}
 
-		string ManufacturerToString ()
+		public string ManufacturerToString ()
 		{
 			switch (Manufacturer) {
 			case TargetManufacturer.Apple: return "apple";
@@ -78,7 +84,7 @@ namespace SwiftReflector {
 			}
 		}
 
-		string OperatingSystemToString ()
+		public string OperatingSystemToString ()
 		{
 			switch (OperatingSystem) {
 			case PlatformName.iOS: return "ios";
@@ -87,6 +93,23 @@ namespace SwiftReflector {
 			case PlatformName.watchOS: return "watchos";
 			default:
 				throw new ArgumentOutOfRangeException (nameof (OperatingSystem));
+			}
+		}
+
+		public override int GetHashCode ()
+		{
+			// lazy, expensive, but terse.
+			return ToString ().GetHashCode ();
+		}
+
+		public override bool Equals (object obj)
+		{
+			if (obj is CompilationTarget other) {
+				return other.Cpu == Cpu && other.Manufacturer == Manufacturer &&
+					other.OperatingSystem == OperatingSystem && other.MinimumOSVersion == MinimumOSVersion &&
+					other.Environment == Environment;
+			} else {
+				return false;
 			}
 		}
 	}

--- a/SwiftReflector/CompilationTargetCollection.cs
+++ b/SwiftReflector/CompilationTargetCollection.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SwiftReflector {
+        public class CompilationTargetCollection : IList<CompilationTarget> {
+                List<CompilationTarget> compilationTargets = new List<CompilationTarget> ();
+
+                public CompilationTargetCollection ()
+                {
+                }
+
+                public CompilationTarget this [int index] { get => compilationTargets [index]; set => compilationTargets [index] = value; }
+
+                public int Count => compilationTargets.Count;
+
+                public bool IsReadOnly => false;
+
+                void TargetMismatchCheck (CompilationTarget item)
+                {
+                        if (IsTargetMismatched (item)) {
+                                // if IsTargetMismatched returns true, there must be a first item.
+                                var first = this [0];
+                                var feedback = $"{first.ManufacturerToString ()}, {first.OperatingSystemToString ()}, {first.EnvironmentToString ()}";
+                                throw new NotSupportedException ($"Item {item} does not match collection ({feedback})");
+                        }
+                }
+
+                public void Add (CompilationTarget item)
+                {
+                        TargetMismatchCheck (item);
+                        // we're not using a HashSet here because this collection is probably going to contain
+                        // 4 items max, so I'm not worried about the speed
+                        if (Contains (item))
+                                return;
+                        compilationTargets.Add (item);
+                }
+
+                public void Clear ()
+                {
+                        compilationTargets.Clear ();
+                }
+
+                public bool Contains (CompilationTarget item)
+                {
+                        return compilationTargets.Contains (item);
+                }
+
+                public void CopyTo (CompilationTarget [] array, int arrayIndex)
+                {
+                        compilationTargets.CopyTo (array, arrayIndex);
+                }
+
+                public IEnumerator<CompilationTarget> GetEnumerator ()
+                {
+                        return compilationTargets.GetEnumerator ();
+                }
+
+                public int IndexOf (CompilationTarget item)
+                {
+                        return compilationTargets.IndexOf (item);
+                }
+
+                public void Insert (int index, CompilationTarget item)
+                {
+                        TargetMismatchCheck (item);
+                        compilationTargets.Insert (index, item);
+                }
+
+                public bool Remove (CompilationTarget item)
+                {
+                        return compilationTargets.Remove (item);
+                }
+
+                public void RemoveAt (int index)
+                {
+                        compilationTargets.RemoveAt (index);
+                }
+
+                IEnumerator IEnumerable.GetEnumerator ()
+                {
+                        return GetEnumerator ();
+                }
+
+                bool IsTargetMismatched (CompilationTarget target)
+                {
+                        if (Count == 0)
+                                return false;
+                        var first = this [0];
+                        return target.Environment != first.Environment ||
+                                target.Manufacturer != first.Manufacturer ||
+                                target.OperatingSystem != first.OperatingSystem ||
+                                target.MinimumOSVersion != first.MinimumOSVersion;
+                }
+
+                CompilationTarget FirstOrFail {
+                        get {
+                                if (Count == 0)
+                                        throw new NotSupportedException ("empty collection");
+                                return this [0];
+                        }
+                }
+
+                public PlatformName OperatingSystem { get => FirstOrFail.OperatingSystem; }
+                public TargetManufacturer Manufacturer { get => FirstOrFail.Manufacturer; }
+                public TargetEnvironment Environment { get => FirstOrFail.Environment; }
+
+                public void AddRange (IEnumerable<CompilationTarget> fileTargets)
+                {
+                        foreach (var elem in fileTargets)
+                                Add (elem);
+                }
+        }
+}

--- a/SwiftReflector/FrameworkRepresentation.cs
+++ b/SwiftReflector/FrameworkRepresentation.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using SwiftRuntimeLibrary;
+using System.Linq;
+using System.IO;
+
+namespace SwiftReflector {
+	public class FrameworkRepresentation {
+		CompilationTargetCollection compilationTargets = new CompilationTargetCollection ();
+
+		public FrameworkRepresentation (string pathToFramework)
+		{
+			Path = Exceptions.ThrowOnNull (pathToFramework, nameof (pathToFramework));
+		}
+
+		public CompilationTargetCollection Targets { get => compilationTargets; }
+		public PlatformName OperatingSystem { get => compilationTargets.OperatingSystem; }
+		public TargetEnvironment Environment { get => compilationTargets.Environment; }
+		public string Path { get; private set; }
+	}
+
+	public class XCFrameworkRepresentation {
+		List<FrameworkRepresentation> frameworks = new List<FrameworkRepresentation> ();
+
+		public XCFrameworkRepresentation (string pathToXCFramework)
+		{
+			Path = Exceptions.ThrowOnNull (pathToXCFramework, nameof (pathToXCFramework));
+		}
+
+		public List<FrameworkRepresentation> Frameworks { get => frameworks; }
+		public string Path { get; private set; }
+	}
+
+	public class LibraryRepresentation : FrameworkRepresentation {
+		public LibraryRepresentation (string pathToLibrary)
+			: base (pathToLibrary)
+		{
+		}
+	}
+
+	public class UniformTargetRepresentation {
+		UniformTargetRepresentation (FrameworkRepresentation framework)
+		{
+			Framework = framework;
+		}
+
+		UniformTargetRepresentation (XCFrameworkRepresentation xCFramework)
+		{
+			XCFramework = xCFramework;
+		}
+
+		UniformTargetRepresentation (LibraryRepresentation library)
+		{
+			Library = library;
+		}
+
+		public XCFrameworkRepresentation XCFramework { get; private set; }
+		public FrameworkRepresentation Framework { get; private set; }
+		public LibraryRepresentation Library { get; private set; }
+
+		public static UniformTargetRepresentation FromPath (string moduleName, List<string> directoriesToSearch, ErrorHandling errors)
+		{
+			string path = null;
+			try {
+				if (TryGetFrameworkPath (moduleName, directoriesToSearch, out path)) {
+					return FrameworkFromPath (moduleName, path, errors);
+				} else if (TryGetXCFrameworkPath (moduleName, directoriesToSearch, out path)) {
+					return XCFrameworkFromPath (moduleName, path, errors);
+				} else if (TryGetLibraryPath (moduleName, directoriesToSearch, out path)) {
+					return LibraryFromPath (moduleName, path, errors);
+				}
+				return null;
+			} catch (Exception e) {
+				errors.Add (e);
+				return null;
+			}
+		}
+
+		static bool TryGetAnyDirectory (string targetFrameworkName, List<string> directories, out string path)
+		{
+			path = directories.FirstOrDefault (d => d.EndsWith (targetFrameworkName) && Directory.Exists (d));
+			if (path != null)
+				return true;
+			path = directories.FirstOrDefault (d => Directory.Exists (Path.Combine (d, targetFrameworkName)));
+			if (path != null) {
+				path = Path.Combine (path, targetFrameworkName);
+				return true;
+			}
+			return false;
+		}
+
+		static bool TryGetFrameworkPath (string moduleName, List<string> directories, out string path)
+		{
+			var targetFrameworkName = $"{moduleName}.framework";
+			return TryGetAnyDirectory (targetFrameworkName, directories, out path);
+		}
+
+		static bool TryGetXCFrameworkPath (string moduleName, List<string> directories, out string path)
+		{
+			var targetFrameworkName = $"{moduleName}.xcframework";
+			return TryGetAnyDirectory (targetFrameworkName, directories, out path);
+		}
+
+		static bool TryGetLibraryPath (string moduleName, List<string> directories, out string path)
+		{
+			var targetLibrary = $"lib{moduleName}.dylib";
+			path = directories.FirstOrDefault (d => File.Exists (Path.Combine (d, targetLibrary)));
+			if (path != null) path = Path.Combine (path, targetLibrary);
+			return path != null;
+		}
+
+		static UniformTargetRepresentation LibraryFromPath (string moduleName, string path, ErrorHandling errors)
+		{
+			var libraryRep = new LibraryRepresentation (path);
+			try {
+				ReadCompilationTargets (path, libraryRep.Targets);
+			} catch (Exception e) {
+				errors.Add (e);
+				return null;
+			}
+			return new UniformTargetRepresentation (libraryRep);
+		}
+
+		static void ReadCompilationTargets (string libFile, CompilationTargetCollection targets)
+		{
+			using (FileStream stm = new FileStream (libFile, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+				var fileTargets = MachOHelpers.CompilationTargetsFromDylib (stm);
+				targets.AddRange (fileTargets);
+			}
+		}
+
+		static UniformTargetRepresentation FrameworkFromPath (string moduleName, string frameworkPath, ErrorHandling errors)
+		{
+			var frameworkRep = new FrameworkRepresentation (frameworkPath);
+			try {
+				var libraryPath = Path.Combine (frameworkPath, moduleName);
+				if (!File.Exists (libraryPath)) {
+					errors.Add (new FileNotFoundException (libraryPath));
+					return null;
+				}
+				ReadCompilationTargets (libraryPath, frameworkRep.Targets);
+			} catch (Exception e) {
+				errors.Add (e);
+				return null;
+			}
+			return new UniformTargetRepresentation (frameworkRep);
+		}
+
+		static UniformTargetRepresentation XCFrameworkFromPath (string moduleName, string pathToXCFramework, ErrorHandling errors)
+		{
+			var xcframeworkRep = new XCFrameworkRepresentation (pathToXCFramework);
+			foreach (var candidateFrameworkPath in CandidateFrameworkDirectories (pathToXCFramework, moduleName))
+			{
+				var targetRep = FrameworkFromPath (moduleName, candidateFrameworkPath, errors);
+				if (targetRep != null)
+					xcframeworkRep.Frameworks.Add (targetRep.Framework);
+			}
+			if (xcframeworkRep.Frameworks.Count == 0)
+				return null;
+			return new UniformTargetRepresentation (xcframeworkRep);
+		}
+
+		static IEnumerable<string> CandidateFrameworkDirectories (string pathToXCFramework, string moduleName)
+		{
+			foreach (var path in Directory.GetDirectories (pathToXCFramework))
+			{
+				var candidate = Path.Combine (path, $"{moduleName}.framework");
+				var candidateModule = Path.Combine (candidate, moduleName);
+				if (Directory.Exists (candidate) && File.Exists (candidateModule))
+					yield return candidate;
+			}
+		}
+	}
+}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -186,6 +186,8 @@
     <Compile Include="SwiftXmlReflection\TypeAliasDeclaration.cs" />
     <Compile Include="SwiftXmlReflection\TypeAliasFolder.cs" />
     <Compile Include="CompilationTarget.cs" />
+    <Compile Include="FrameworkRepresentation.cs" />
+    <Compile Include="CompilationTargetCollection.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/plist-swifty/plist-swifty.csproj
+++ b/plist-swifty/plist-swifty.csproj
@@ -61,6 +61,12 @@
     <Compile Include="..\SwiftReflector\MachOHawley.cs">
       <Link>MachOHawley.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftReflector\Enums.cs">
+      <Link>Enums.cs</Link>
+    </Compile>
+    <Compile Include="..\SwiftReflector\CompilationTarget.cs">
+      <Link>CompilationTarget.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
+using SwiftReflector.IOUtils;
+using tomwiftytest;
 
 namespace SwiftReflector {
 	[TestFixture]
@@ -32,6 +35,32 @@ namespace SwiftReflector {
 			var target = new CompilationTarget (PlatformName.watchOS, TargetCpu.I386,
 				TargetEnvironment.Simulator, new Version ("3.2"));
 			Assert.AreEqual ("i386-apple-watchos3.2-simulator", target.ToString ());
+		}
+
+		[Test]
+		public void BasicLibraryTest ()
+		{
+			var swiftCode = @"public func sumIt(a: Int, b: Int) -> Int {
+    return a + b
+}";
+
+			using (var provider = new DisposableTempDirectory ()) {
+				var moduleName = "BasicLibrary";
+				Utils.SystemCompileSwift (swiftCode, provider, moduleName);
+				var errors = new ErrorHandling ();
+
+				var target = UniformTargetRepresentation.FromPath (moduleName,
+					new List<string> () { provider.DirectoryPath }, errors);
+
+				Assert.IsNotNull (target, "Didn't get a target");
+				Assert.IsNotNull (target.Library);
+				Assert.AreEqual (TargetEnvironment.Device, target.Library.Environment, "wrong environment");
+				Assert.AreEqual (1, target.Library.Targets.Count, "more targets than we wanted");
+				Assert.AreEqual (TargetCpu.X86_64, target.Library.Targets [0].Cpu, "cpu mismatch");
+				Assert.AreEqual (PlatformName.macOS, target.Library.OperatingSystem, "operating system mismatch");
+				Assert.AreEqual (new Version ("10.9"), target.Library.Targets [0].MinimumOSVersion, "os version mismatch");
+				Assert.AreEqual (TargetManufacturer.Apple, target.Library.Targets [0].Manufacturer, "wrong manufacturer");
+			}
 		}
 	}
 }

--- a/type-o-matic/type-o-matic.csproj
+++ b/type-o-matic/type-o-matic.csproj
@@ -125,6 +125,9 @@
     <Compile Include="..\SwiftReflector\ExceptionTools\RuntimeException.cs">
       <Link>SwiftType\RuntimeException.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftReflector\CompilationTarget.cs">
+      <Link>CompilationTarget.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Implemented code to model all of the types of input that BTfS can accept.
This could include:
- a `.dylib` files
- a `.framework` directory
- an `.xcframework` directory

This is modeled in the type `UniformFrameworkRepresentation` which is a poor person's discriminated union that can represent exactly 1 of the above.

The first two contain are represented by (more or less) the type `FrameworkRepresentation` (LibraryRepresentation inherits from that). Each of these types contains a `TargetFrameworkCollection` which represents all the cpu architectures that are in the file.

An `XCFrameworkRepresentation` will contain a collection of `FrameworkRepresentation` objects for every framework in it.

Code to build one of these runs from a factory where you hand it a list of places to look and a module name and it does its best to find one of the matching patterns from above.

There is more to come in terms of tests, but I want to make the process of testing these easier and that involves implementing another feature in the code that I'm not ready for yet.

There is a mismatch in supported CPU architectures, but I've got an issue for that open [here](https://github.com/xamarin/binding-tools-for-swift/issues/708).