### PR TITLE
Let's actually compile some stuff

### DIFF
--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using SwiftReflector.IOUtils;
+using SwiftRuntimeLibrary;
+using System.Reflection;
+
+namespace SwiftReflector {
+	public class CompilationSettings {
+		public CompilationSettings (string outputDirectory, string moduleName, UniformTargetRepresentation targetRepresentation,
+			IEnumerable<string> frameworkPaths = null, IEnumerable<string> libraryPaths = null,
+			IEnumerable<string> swiftFilePaths = null, string makeFrameworkScript = null,
+			string workingDirectory = null)
+		{
+			OutputDirectory = Exceptions.ThrowOnNull (outputDirectory, nameof (outputDirectory));
+			ModuleName = Exceptions.ThrowOnNull (moduleName, nameof (moduleName));
+
+			FrameworkPaths = new List<string> ();
+			if (frameworkPaths != null)
+				FrameworkPaths.AddRange (frameworkPaths);
+
+			LibraryPaths = new List<string> ();
+			if (libraryPaths != null)
+				LibraryPaths.AddRange (libraryPaths);
+
+			SwiftFilePaths = new List<string> ();
+			if (swiftFilePaths != null)
+				SwiftFilePaths.AddRange (swiftFilePaths);
+
+			MakeFrameworkScript = makeFrameworkScript;
+			WorkingDirectory = workingDirectory;
+			TargetRepresentation = Exceptions.ThrowOnNull (targetRepresentation, nameof (targetRepresentation));
+		}
+
+		public string OutputDirectory { get; private set; }
+		public string ModuleName { get; private set; }
+		public List<string> FrameworkPaths { get; private set; }
+		public List<string> LibraryPaths { get; private set; }
+		public List<string> SwiftFilePaths { get; private set; }
+		public UniformTargetRepresentation TargetRepresentation { get; private set; }
+		public string MakeFrameworkScript { get; private set; }
+		public string WorkingDirectory { get; private set; }
+
+
+		public string CompileTarget ()
+		{
+			var scriptPath = GetScriptPath ();
+			var args = BuildCommandArgs ();
+			var output = ExecAndCollect.Run (scriptPath, args, WorkingDirectory);
+			if (TargetRepresentation.Library != null) {
+				var frameworkDir = Path.Combine (OutputDirectory, $"{ModuleName}.framework");
+				var libraryPath = Path.Combine (OutputDirectory, $"lib{ModuleName}.dylib");
+				File.Copy (Path.Combine (frameworkDir, ModuleName), libraryPath);
+				Directories.DeleteContentsAndSelf (frameworkDir);
+				ChangeInstallName (libraryPath);
+			}
+			return output;
+		}
+
+		void ChangeInstallName (string libraryPath)
+		{
+			var args = $"install_name_tool -id @rpath/lib{ModuleName}.dylib {libraryPath}";
+			var output = ExecAndCollect.Run ("xcrun", args);
+		}
+
+		string BuildCommandArgs ()
+		{
+			// Here are the args to the script that we need:
+			//--frameworks fw1 fw2 ...
+			//   adds framework directories to swift compilation (-F) (optional)
+			//--libraries lb1 lb2...
+			//   adds library directories to swift compilation (-L) (optional)
+			//--swift-files sf1 sf2 ...
+			//   adds swift files to be compiled (required)
+			//--target-os os - name, one of ios, tvos, watchos, macosx (required)
+			//   sets the target operating system for the build.
+			//--minimum-os-version version (required)
+			//   sets the minimum operating system version for the compilation.
+			//--simulator-archs arch1 arch2...
+			//   sets the architectures for a simulator build.
+			//--device-archs arch1 arch2...
+			//   sets the architectures for a device build.
+			//--module-name name (required)
+			//   sets the name of the output module.
+			//--extra-swift-args arg1 arg2...
+			//   sets extra arguments to pass to the swift compiler.
+			//--output-path path (required)
+			//   sets the directory where there final output will live.
+			//--make-xcframework (optional)
+			//   if present, puts both device and simulator builds into an xcframework
+			//   if present, both--simulator - archs and--device - archs must be present.
+
+			if (SwiftFilePaths.Count == 0)
+				throw new Exception ("No files provided to compile.");
+			CheckAllFilesExist ();
+			var args = new StringBuilder ();
+
+			// useful for debugging:
+			// args.Append (" --verbose --verbose ");
+
+			args.Append ("--output-path ").Append (OutputDirectory);
+			args.Append (" --module-name ").Append (ModuleName);
+			if (FrameworkPaths.Count > 0)
+				AppendList (args.Append (" --frameworks"), FrameworkPaths);
+			if (LibraryPaths.Count > 0)
+				AppendList (args.Append (" --libraries"), LibraryPaths);
+			// no need to check for empty, this is mandatory
+			AppendList (args.Append (" --swift-files"), SwiftFilePaths);
+
+			if (TargetRepresentation.Library != null)
+				BuildLibraryArgs (TargetRepresentation.Library, args);
+			else if (TargetRepresentation.Framework != null)
+				BuildFrameworkArgs (TargetRepresentation.Framework, args);
+			else if (TargetRepresentation.XCFramework != null)
+				BuildFrameworkArgs (TargetRepresentation.XCFramework, args);
+			else throw new Exception ("TargetRepresentation has none of Library/Framework/XCFramework in it.");
+			return args.ToString ();
+		}
+
+		void BuildLibraryArgs (LibraryRepresentation library, StringBuilder args)
+		{
+			CommonFrameworkArgs (library, args);
+		}
+
+		void BuildFrameworkArgs (FrameworkRepresentation framework, StringBuilder args)
+		{
+			CommonFrameworkArgs (framework, args);
+		}
+
+		void CommonFrameworkArgs (FrameworkRepresentation framework, StringBuilder args, bool includeOS = true)
+		{
+			if (includeOS) {
+				args.Append (" --minimum-os-version ").Append (framework.Targets.MinimumOSVersion);
+				args.Append (" --target-os ").Append (framework.OperatingSystemString);
+			}
+			if (framework.Environment == TargetEnvironment.Device) {
+				AppendArchitectures (" --device-archs", args, framework.Targets);
+			} else {
+				AppendArchitectures (" --simulator-archs", args, framework.Targets);
+			}
+		}
+
+		void BuildFrameworkArgs (XCFrameworkRepresentation xcFramework, StringBuilder args)
+		{
+			if (xcFramework.Frameworks.Count != 2) {
+				throw new Exception ("Right now, compilation of xcframewords only supports exactly two sub-frameworks: one for device and one for simulator.");
+			}
+			CommonFrameworkArgs (xcFramework.Frameworks [0], args, true);
+			CommonFrameworkArgs (xcFramework.Frameworks [1], args, false);
+			args.Append (" --make-xcframework");
+		}
+
+		void AppendArchitectures (string flag, StringBuilder sb, CompilationTargetCollection compilationTargets)
+		{
+			sb.Append (flag);
+			foreach (var target in compilationTargets) {
+				sb.Append (" ").Append (target.CpuToString ());
+			}
+		}
+
+		StringBuilder AppendList (StringBuilder sb, IEnumerable<string> list)
+		{
+			foreach (var elem in list) {
+				sb.Append (" ").Append (elem);
+			}
+			return sb;
+		}
+
+		void CheckAllFilesExist ()
+		{
+			foreach (var file in SwiftFilePaths) {
+				if (!File.Exists (file))
+					throw new FileNotFoundException ("Couldn't find swift source file", file);
+			}
+		}
+
+		string GetScriptPath ()
+		{
+			var path = MakeFrameworkScript ?? Environment.GetEnvironmentVariable ("") ??
+				SearchForScript ();
+			if (path == null)
+				throw new FileNotFoundException ("Unable to find the make-framework script.\n");
+			if (!File.Exists (path))
+				throw new FileNotFoundException ($"The script specified script '{path}' does not exist at that location.");
+			return path;
+		}
+
+		string SearchForScript ()
+		{
+			// locations to look relative to the running assembly:
+			// from code main code base as run from the IDE:
+			// ../../tools/make-framework
+			// from unit tests:
+			// ../../../../tools/make-framwork
+			// from Pack-Man installation:
+			// ../make-framework/make-framework
+
+			var assemblyPath = AssemblyLocation ();
+			var parent = Directory.GetParent (assemblyPath).ToString ();
+			var pacMacPath = Path.Combine (parent, "make-framework/make-framwork");
+			if (File.Exists (pacMacPath))
+				return pacMacPath;
+			var grandParent = Directory.GetParent (parent).ToString ();
+			var idePath = Path.Combine (grandParent, "tools/make-framework");
+			if (File.Exists (idePath))
+				return idePath;
+			var greatGrandParent = Directory.GetParent (grandParent).ToString ();
+			var greatGreatGrandParent = Directory.GetParent (greatGrandParent).ToString ();
+			var unitTestsPath = Path.Combine (greatGreatGrandParent, "tools/make-framework");
+			return File.Exists (unitTestsPath) ? unitTestsPath : null;
+		}
+
+		string AssemblyLocation ()
+		{
+			// reference code: https://stackoverflow.com/questions/52797/how-do-i-get-the-path-of-the-assembly-the-code-is-in
+			var codeBase = Assembly.GetExecutingAssembly ().CodeBase;
+			var uri = new UriBuilder (codeBase);
+			var path = Uri.UnescapeDataString (uri.Path);
+			return Path.GetDirectoryName (path);
+		}
+	}
+}

--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -104,11 +104,11 @@ namespace SwiftReflector {
 			args.Append ("--output-path ").Append (StringUtils.Quote (OutputDirectory));
 			args.Append (" --module-name ").Append (ModuleName);
 			if (FrameworkPaths.Count > 0)
-				AppendList (args.Append (" --frameworks"), FrameworkPaths);
+				AppendFileList (args.Append (" --frameworks"), FrameworkPaths);
 			if (LibraryPaths.Count > 0)
-				AppendList (args.Append (" --libraries"), LibraryPaths);
+				AppendFileList (args.Append (" --libraries"), LibraryPaths);
 			// no need to check for empty, this is mandatory
-			AppendList (args.Append (" --swift-files"), SwiftFilePaths);
+			AppendFileList (args.Append (" --swift-files"), SwiftFilePaths);
 
 			if (TargetRepresentation.Library != null)
 				BuildLibraryArgs (TargetRepresentation.Library, args);
@@ -161,7 +161,7 @@ namespace SwiftReflector {
 			}
 		}
 
-		StringBuilder AppendList (StringBuilder sb, IEnumerable<string> list)
+		StringBuilder AppendFileList (StringBuilder sb, IEnumerable<string> list)
 		{
 			foreach (var elem in list) {
 				sb.Append (" ").Append (StringUtils.Quote (elem));

--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -184,7 +184,7 @@ namespace SwiftReflector {
 			if (path == null)
 				throw new FileNotFoundException ("Unable to find the make-framework script.\n");
 			if (!File.Exists (path))
-				throw new FileNotFoundException ($"The script specified script '{path}' does not exist at that location.");
+				throw new FileNotFoundException ($"The specified script '{path}' does not exist at that location.");
 			return path;
 		}
 

--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using SwiftReflector.IOUtils;
 using SwiftRuntimeLibrary;
 using System.Reflection;
+using Xamarin.Utils;
 
 namespace SwiftReflector {
 	public class CompilationSettings {
@@ -100,7 +101,7 @@ namespace SwiftReflector {
 			// useful for debugging:
 			// args.Append (" --verbose --verbose ");
 
-			args.Append ("--output-path ").Append (OutputDirectory);
+			args.Append ("--output-path ").Append (StringUtils.Quote (OutputDirectory));
 			args.Append (" --module-name ").Append (ModuleName);
 			if (FrameworkPaths.Count > 0)
 				AppendList (args.Append (" --frameworks"), FrameworkPaths);
@@ -163,7 +164,7 @@ namespace SwiftReflector {
 		StringBuilder AppendList (StringBuilder sb, IEnumerable<string> list)
 		{
 			foreach (var elem in list) {
-				sb.Append (" ").Append (elem);
+				sb.Append (" ").Append (StringUtils.Quote (elem));
 			}
 			return sb;
 		}

--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -179,7 +179,7 @@ namespace SwiftReflector {
 
 		string GetScriptPath ()
 		{
-			var path = MakeFrameworkScript ?? Environment.GetEnvironmentVariable ("") ??
+			var path = MakeFrameworkScript ?? Environment.GetEnvironmentVariable ("BTFS_MAKE_FRAMEWORK") ??
 				SearchForScript ();
 			if (path == null)
 				throw new FileNotFoundException ("Unable to find the make-framework script.\n");

--- a/SwiftReflector/CompilationTargetCollection.cs
+++ b/SwiftReflector/CompilationTargetCollection.cs
@@ -103,8 +103,10 @@ namespace SwiftReflector {
                 }
 
                 public PlatformName OperatingSystem { get => FirstOrFail.OperatingSystem; }
+                public string OperatingSystemString { get => FirstOrFail.OperatingSystemToString (); }
                 public TargetManufacturer Manufacturer { get => FirstOrFail.Manufacturer; }
                 public TargetEnvironment Environment { get => FirstOrFail.Environment; }
+                public Version MinimumOSVersion { get => FirstOrFail.MinimumOSVersion; }
 
                 public void AddRange (IEnumerable<CompilationTarget> fileTargets)
                 {

--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -155,6 +155,7 @@ namespace SwiftReflector {
 		Armv7,
 		Armv7s,
 		Arm7vk,
+		Arm64e,
 		Arm64_32,
 		I386,
 		X86_64,

--- a/SwiftReflector/FrameworkRepresentation.cs
+++ b/SwiftReflector/FrameworkRepresentation.cs
@@ -15,6 +15,7 @@ namespace SwiftReflector {
 
 		public CompilationTargetCollection Targets { get => compilationTargets; }
 		public PlatformName OperatingSystem { get => compilationTargets.OperatingSystem; }
+		public string OperatingSystemString { get => compilationTargets.OperatingSystemString; }
 		public TargetEnvironment Environment { get => compilationTargets.Environment; }
 		public string Path { get; private set; }
 	}
@@ -39,17 +40,17 @@ namespace SwiftReflector {
 	}
 
 	public class UniformTargetRepresentation {
-		UniformTargetRepresentation (FrameworkRepresentation framework)
+		public UniformTargetRepresentation (FrameworkRepresentation framework)
 		{
 			Framework = framework;
 		}
 
-		UniformTargetRepresentation (XCFrameworkRepresentation xCFramework)
+		public UniformTargetRepresentation (XCFrameworkRepresentation xCFramework)
 		{
 			XCFramework = xCFramework;
 		}
 
-		UniformTargetRepresentation (LibraryRepresentation library)
+		public UniformTargetRepresentation (LibraryRepresentation library)
 		{
 			Library = library;
 		}

--- a/SwiftReflector/IOUtils/Directories.cs
+++ b/SwiftReflector/IOUtils/Directories.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+namespace SwiftReflector.IOUtils {
+	public static class Directories {
+		// from https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
+		public static void DeleteContentsAndSelf (string target_dir)
+		{
+			string [] files = Directory.GetFiles (target_dir);
+			string [] dirs = Directory.GetDirectories (target_dir);
+
+			foreach (string file in files) {
+				File.SetAttributes (file, FileAttributes.Normal);
+				File.Delete (file);
+			}
+
+			foreach (string dir in dirs) {
+				DeleteContentsAndSelf (dir);
+			}
+
+			Directory.Delete (target_dir, false);
+		}
+	}
+}

--- a/SwiftReflector/MachOHawley.cs
+++ b/SwiftReflector/MachOHawley.cs
@@ -37,6 +37,7 @@ namespace Xamarin {
 			ARM64 = 16,
 			x86_64 = 32,
 			ARM64e = 64,
+			ARM64_32 = 128,
 		}
 
 		public enum LoadCommands : uint {
@@ -726,6 +727,13 @@ namespace Xamarin {
 					case 2:
 						return MachO.Architectures.ARM64e;
 					case 0:
+					default:
+						return MachO.Architectures.ARM64;
+					}
+				case 12 | 0x02000000:
+					switch (cpusubtype & ~0xff000000) {
+					case 1:
+						return MachO.Architectures.ARM64_32;
 					default:
 						return MachO.Architectures.ARM64;
 					}

--- a/SwiftReflector/MachOHelpers.cs
+++ b/SwiftReflector/MachOHelpers.cs
@@ -75,7 +75,8 @@ namespace SwiftReflector {
 			case MachO.Architectures.ARMv7s: return TargetCpu.Armv7s;
 			case MachO.Architectures.i386: return TargetCpu.I386;
 			case MachO.Architectures.x86_64: return TargetCpu.X86_64;
-			case MachO.Architectures.ARM64e:
+			case MachO.Architectures.ARM64_32: return TargetCpu.Arm64_32;
+			case MachO.Architectures.ARM64e: return TargetCpu.Arm64e;
 			case MachO.Architectures.ARMv6:
 			default:
 				throw new ArgumentOutOfRangeException (nameof (arch));

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -188,6 +188,8 @@
     <Compile Include="CompilationTarget.cs" />
     <Compile Include="FrameworkRepresentation.cs" />
     <Compile Include="CompilationTargetCollection.cs" />
+    <Compile Include="CompilationSettings.cs" />
+    <Compile Include="IOUtils\Directories.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/CompilationTargetTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using NUnit.Framework;
 using SwiftReflector.IOUtils;
+using Xamarin;
+using System.Linq;
 using tomwiftytest;
 
 namespace SwiftReflector {
@@ -60,6 +63,187 @@ namespace SwiftReflector {
 				Assert.AreEqual (PlatformName.macOS, target.Library.OperatingSystem, "operating system mismatch");
 				Assert.AreEqual (new Version ("10.9"), target.Library.Targets [0].MinimumOSVersion, "os version mismatch");
 				Assert.AreEqual (TargetManufacturer.Apple, target.Library.Targets [0].Manufacturer, "wrong manufacturer");
+			}
+		}
+
+		CompilationTargetCollection BuildCompilationTargetCollection (PlatformName platform, TargetEnvironment env, List<TargetCpu> cpus, string minVersion)
+		{
+			var version = new Version (minVersion);
+
+			var collection = new CompilationTargetCollection ();
+			foreach (var cpu in cpus) {
+				collection.Add (new CompilationTarget (platform, cpu, env, version));
+			}
+			return collection.Count > 0 ? collection : null;
+		}
+
+		CompilationSettings BuildCompilationSettings (List<string> swiftFiles, PlatformName platform,
+			List<TargetCpu> simArchs, List<TargetCpu> deviceArchs, string minVersion, string outputDirectory,
+			bool isLibrary)
+		{
+			CompilationTargetCollection simTargets = null;
+			CompilationTargetCollection devTargets = null;
+			UniformTargetRepresentation targetRepresentation = null;
+			if (simArchs != null) {
+				simTargets = BuildCompilationTargetCollection (platform, TargetEnvironment.Simulator, simArchs, minVersion);
+			}
+			if (deviceArchs != null) {
+				devTargets = BuildCompilationTargetCollection (platform, TargetEnvironment.Device, deviceArchs, minVersion);
+			}
+
+			if (isLibrary) {
+				var library = new LibraryRepresentation ("");
+				library.Targets.AddRange (simTargets ?? devTargets);
+				targetRepresentation = new UniformTargetRepresentation (library);
+			} else {
+				if (simTargets != null && devTargets != null) {
+					var devFm = new FrameworkRepresentation ("");
+					devFm.Targets.AddRange (devTargets);
+					var simFm = new FrameworkRepresentation ("");
+					simFm.Targets.AddRange (simTargets);
+					var xcFramework = new XCFrameworkRepresentation ("");
+					xcFramework.Frameworks.Add (devFm);
+					xcFramework.Frameworks.Add (simFm);
+					targetRepresentation = new UniformTargetRepresentation (xcFramework);
+				} else {
+					var framework = new FrameworkRepresentation ("");
+					framework.Targets.AddRange (simTargets ?? devTargets);
+					targetRepresentation = new UniformTargetRepresentation (framework);
+				}
+			}
+			var compilationSettings = new CompilationSettings (outputDirectory, "NoNameModule", targetRepresentation);
+			compilationSettings.SwiftFilePaths.AddRange (swiftFiles);
+			return compilationSettings;
+		}
+
+		DisposableTempDirectory CompileStringToResult (string swiftCode, PlatformName platform,
+			string minVersion, List<TargetCpu> simArchs, List<TargetCpu> deviceArchs, bool isLibrary)
+		{
+			var outputDirectory = new DisposableTempDirectory ();
+			try {
+				using (var codeDirectory = new DisposableTempDirectory ()) {
+					var sourceFile = Path.Combine (codeDirectory.DirectoryPath, "noname.swift");
+					using (var sourceCode = new StreamWriter (sourceFile))
+						sourceCode.Write (swiftCode);
+					var compilationSettings = BuildCompilationSettings (new List<string> () { sourceFile }, platform, simArchs, deviceArchs,
+						minVersion, outputDirectory.DirectoryPath, isLibrary);
+					var result = compilationSettings.CompileTarget ();
+				}
+			} catch {
+				outputDirectory.Dispose ();
+				throw;
+			}
+			return outputDirectory;
+		}
+
+		[Test]
+		public void SimpleLibraryTest ()
+		{
+			var swiftCode = @"public func sum (a: Int, b: Int) -> Int {
+    return a + b
+}";
+			using (var output = CompileStringToResult (swiftCode, PlatformName.macOS, "11.0", null,
+				new List<TargetCpu> () { TargetCpu.X86_64 }, true)) {
+
+				var outputFile = Path.Combine (output.DirectoryPath, "libNoNameModule.dylib");
+				Assert.IsTrue (File.Exists (outputFile), "we didn't get a file!");
+
+				using (var macho = MachO.Read (outputFile, ReadingMode.Immediate)) {
+					Assert.AreEqual (1, macho.Count, "wrong contents");
+					Assert.AreEqual (MachO.Architectures.x86_64, macho [0].Architecture, "wrong arch");
+				}
+			}
+		}
+
+		[Test]
+		public void IphoneDeviceFramework ()
+		{
+			var swiftCode = @"public func sum (a: Int, b: Int) -> Int {
+    return a + b
+}";
+			using (var output = CompileStringToResult (swiftCode, PlatformName.iOS, "10.2", null,
+				new List<TargetCpu> () { TargetCpu.Arm64, TargetCpu.Armv7s }, false)) {
+
+				var outputFile = Path.Combine (output.DirectoryPath, "NoNameModule.framework", "NoNameModule");
+				Assert.IsTrue (File.Exists (outputFile), "we didn't get a file!");
+
+				using (var macho = MachO.Read (outputFile, ReadingMode.Immediate)) {
+					Assert.AreEqual (2, macho.Count, "wrong contents");
+					var file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARM64);
+					Assert.IsNotNull (file, "no arm64");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARMv7s);
+					Assert.IsNotNull (file, "no arm7s");
+				}
+			}
+		}
+
+		[Test]
+		public void IphoneSimulatorFramework ()
+		{
+			var swiftCode = @"public func sum (a: Int, b: Int) -> Int {
+    return a + b
+}";
+			using (var output = CompileStringToResult (swiftCode, PlatformName.iOS, "10.2",
+				new List<TargetCpu> () { TargetCpu.Arm64, TargetCpu.X86_64, TargetCpu.I386 }, null, false)) {
+
+				var outputFile = Path.Combine (output.DirectoryPath, "NoNameModule.framework", "NoNameModule");
+				Assert.IsTrue (File.Exists (outputFile), "we didn't get a file!");
+
+				using (var macho = MachO.Read (outputFile, ReadingMode.Immediate)) {
+					Assert.AreEqual (3, macho.Count, "wrong contents");
+					var file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARM64);
+					Assert.IsNotNull (file, "no arm64");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.x86_64);
+					Assert.IsNotNull (file, "no x86_64");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.i386);
+					Assert.IsNotNull (file, "no i386");
+				}
+			}
+		}
+
+
+		[Test]
+		public void IphoneXCFramework ()
+		{
+			var swiftCode = @"public func sum (a: Int, b: Int) -> Int {
+    return a + b
+}";
+			using (var output = CompileStringToResult (swiftCode, PlatformName.iOS, "10.2",
+				new List<TargetCpu> () { TargetCpu.Arm64, TargetCpu.X86_64, TargetCpu.I386 },
+				new List<TargetCpu> () { TargetCpu.Arm64, TargetCpu.Armv7s }, false)) {
+
+				var outputDirectory = Path.Combine (output.DirectoryPath, "NoNameModule.xcframework");
+				Assert.IsTrue (Directory.Exists (outputDirectory), "no xcframework");
+
+				var deviceFM = Path.Combine (outputDirectory, "ios-arm64_armv7s", "NoNameModule.framework");
+				Assert.IsTrue (Directory.Exists (deviceFM), "no device directory");
+
+				var simFM = Path.Combine (outputDirectory, "ios-arm64_i386_x86_64-simulator", "NoNameModule.framework");
+				Assert.IsTrue (Directory.Exists (simFM), "no simulator directory");
+
+				var outputFile = Path.Combine (deviceFM, "NoNameModule");
+				Assert.IsTrue (File.Exists (outputFile), "we didn't get a device file!");
+
+				using (var macho = MachO.Read (outputFile, ReadingMode.Immediate)) {
+					Assert.AreEqual (2, macho.Count, "wrong device contents");
+					var file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARM64);
+					Assert.IsNotNull (file, "device: no arm64");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARMv7s);
+					Assert.IsNotNull (file, "device: no armv7s");
+				}
+
+				outputFile = Path.Combine (simFM, "NoNameModule");
+				Assert.IsTrue (File.Exists (outputFile), "we didn't get a simulator file!");
+
+				using (var macho = MachO.Read (outputFile, ReadingMode.Immediate)) {
+					Assert.AreEqual (3, macho.Count, "wrong simulator contents");
+					var file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.ARM64);
+					Assert.IsNotNull (file, "simulator: no arm64");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.i386);
+					Assert.IsNotNull (file, "simulator: no i386");
+					file = macho.FirstOrDefault (f => f.Architecture == MachO.Architectures.x86_64);
+					Assert.IsNotNull (file, "simulator: no x86_64");
+				}
 			}
 		}
 	}

--- a/tools/make-framework
+++ b/tools/make-framework
@@ -323,7 +323,9 @@ compile_c_files () {
 	local arch=$1
 	shift
 	local odir="${output_path}/build/${devicesim}/${arch}/ofiles"
-	mkdir -p "$odir"
+	if [[ "$#" -gt 0 ]]; then
+		mkdir -p "$odir"
+	fi
 
 	get_target_arch "$devicesim" "$arch" targetarch
 	get_sdk_path "$devicesim" sdk
@@ -336,9 +338,9 @@ compile_c_files () {
 			echo "[Compiling C files ${targetarch}]"
 		fi
 		if [[ -n $superverbose ]]; then
-			echo clang -x c -c -arch "$arch" -target "$targetarch" -isysroot "$sdk" -std=gnu11 -fasm-blocks "$extra_c_args" "$cfile" -o "${odir}/${ofile}" &
+			echo clang -x c -c -arch "$arch" -target "$targetarch" -isysroot "$sdk" -std=gnu11 -fasm-blocks $extra_c_args "$cfile" -o "${odir}/${ofile}" &
 		fi
-		clang -x c -c -arch "$arch" -target "$targetarch" -isysroot "$sdk" -std=gnu11 -fasm-blocks "$extra_c_args" "$cfile" -o "${odir}/${ofile}" &
+		clang -x c -c -arch "$arch" -target "$targetarch" -isysroot "$sdk" -std=gnu11 -fasm-blocks $extra_c_args "$cfile" -o "${odir}/${ofile}" &
 	done
 	wait
 }
@@ -367,10 +369,10 @@ compile_swift_files () {
 		echo "[Compiling Swift $targetarch]"
 	fi
 	if [[ -n $superverbose ]]; then
-		echo swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
+		echo swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
 	fi
 
-	swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
+	swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
 }
 
 copy_arch_files ()


### PR DESCRIPTION
Here's what we get here -

There is a class called CompilationSettings which represents extra the bits and pieces we're going to need to compiling swift code.

Unlike previously, instead of building up all the various settings that are needed to match a given existing library, the settings includes the `UniformTargetRepresentation` of a (possibly) existing library, framework, or xcframework. Then when you supply the swift files, libraries, frameworks, and module name the `CompilationSettings` will conjure up the arguments needed to correctly run `make-framework` in such a way to match the `UniformTargetRepresentation`.

In addition, I made `MachOHawley.cs` accept arm64e, and arm64_32 fixing issue [708](https://github.com/xamarin/binding-tools-for-swift/issues/708).

Unit tests verify that this code builds a library for macOS, frameworks for iOS and iOS-simulator, and an xcframework for iOS and iOS simulator.