### PR TITLE
integrate make-framework

### DIFF
--- a/SwiftReflector/Enums.cs
+++ b/SwiftReflector/Enums.cs
@@ -169,5 +169,12 @@ namespace SwiftReflector {
 		Device,
 		Simulator,
 	}
+
+	public enum TargetRepresentationKind {
+		None,
+		Library,
+		Framework,
+		XCFramework,
+	}
 }
 

--- a/SwiftReflector/FrameworkRepresentation.cs
+++ b/SwiftReflector/FrameworkRepresentation.cs
@@ -77,6 +77,23 @@ namespace SwiftReflector {
 			}
 		}
 
+		public static TargetRepresentationKind TargetRepresentationKindFromPath (string moduleName, List<string> directoriesToSearch, out string path)
+		{
+			path = null;
+			try {
+				if (TryGetFrameworkPath (moduleName, directoriesToSearch, out path)) {
+					return TargetRepresentationKind.Framework;
+				} else if (TryGetXCFrameworkPath (moduleName, directoriesToSearch, out path)) {
+					return TargetRepresentationKind.XCFramework;
+				} else if (TryGetLibraryPath (moduleName, directoriesToSearch, out path)) {
+					return TargetRepresentationKind.Library;
+				}
+				return TargetRepresentationKind.None;
+			} catch {
+				return TargetRepresentationKind.None;
+			}
+		}
+
 		static bool TryGetAnyDirectory (string targetFrameworkName, List<string> directories, out string path)
 		{
 			path = directories.FirstOrDefault (d => d.EndsWith (targetFrameworkName) && Directory.Exists (d));

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -99,13 +99,16 @@ namespace SwiftReflector {
 		public bool Verbose { get; }
 		public bool RetainReflectedXmlOutput { get; }
 		public bool RetainSwiftWrappers { get; }
+		public UniformTargetRepresentation TargetRepresentation { get; }
 
-		public ClassCompilerOptions (bool targetPlatformIs64Bit, bool verbose, bool retainReflectedXmlOutput, bool retainSwiftWrappers)
+		public ClassCompilerOptions (bool targetPlatformIs64Bit, bool verbose, bool retainReflectedXmlOutput, bool retainSwiftWrappers,
+			UniformTargetRepresentation targetRepresentation)
 		{
 			TargetPlatformIs64Bit = targetPlatformIs64Bit;
 			Verbose = verbose;
 			RetainReflectedXmlOutput = retainReflectedXmlOutput;
 			RetainSwiftWrappers = retainSwiftWrappers;
+			TargetRepresentation = targetRepresentation;
 		}
 	}
 
@@ -5315,7 +5318,7 @@ namespace SwiftReflector {
 			wrappingModuleName = wrappingModuleName ?? "XamWrapping";
 
 			var wrappingCompiler = new WrappingCompiler (outputDirectory, SwiftCompilerLocations, retainSwiftWrappers,
-			                                             TypeMapper, verbose, errors);
+			                                             TypeMapper, verbose, errors, Options.TargetRepresentation);
 
 			bool noWrappersNeeded = false;
 			Tuple<string, HashSet<string>> wrapStuff = null;

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1143,7 +1143,11 @@ public enum Position {
 
 					consumerCompiler.CompileString (options, consumerCode);
 
-					NewClassCompiler ncc = Utils.DefaultCSharpCompiler ();
+					var localErrors = new ErrorHandling ();
+					var inputTarget = UniformTargetRepresentation.FromPath ("Consumer", new List<string> () { consumerProvider.DirectoryPath }, localErrors);
+					Assert.IsNotNull (inputTarget, "Didn't get an input target");
+
+					NewClassCompiler ncc = Utils.DefaultCSharpCompiler (inputTarget);
 
 					var searchPath = new List<string> { consumerCompiler.DirectoryPath, libProvider.DirectoryPath, Compiler.kSwiftRuntimeGlueDirectory };
 					List<String> typeDataBasePaths = new List<String> { Path.Combine (libProvider.DirectoryPath, "bindings/Lib") };

--- a/tom-swifty/Program.cs
+++ b/tom-swifty/Program.cs
@@ -103,7 +103,8 @@ namespace tomswifty {
 			try {
 				using (DisposableTempDirectory temp = new DisposableTempDirectory (null, true)) {
 					SwiftCompilerLocation compilerLocation = new SwiftCompilerLocation (options.SwiftBinPath, options.SwiftLibPath);
-					ClassCompilerOptions compilerOptions = new ClassCompilerOptions (options.TargetPlatformIs64Bit, options.Verbose, options.RetainXmlReflection, options.RetainSwiftWrappingCode);
+					ClassCompilerOptions compilerOptions = new ClassCompilerOptions (options.TargetPlatformIs64Bit, options.Verbose, options.RetainXmlReflection, options.RetainSwiftWrappingCode,
+						options.InputTargetRepresentation);
 					NewClassCompiler classCompiler = new NewClassCompiler (compilerLocation, compilerOptions, unicodeMapper);
 
 					ClassCompilerNames compilerNames = new ClassCompilerNames (options.ModuleName, options.WrappingModuleName);

--- a/tom-swifty/SwiftyOptions.cs
+++ b/tom-swifty/SwiftyOptions.cs
@@ -134,6 +134,7 @@ namespace tomswifty {
 		public int Verbosity { get; set; }
 		public bool PrintHelp { get; set; }
 		public bool Demangle { get; set; }
+		public UniformTargetRepresentation InputTargetRepresentation { get; private set; }
 
 		#region Parsing Command Line
 
@@ -252,6 +253,13 @@ namespace tomswifty {
 			EnsureFileExists ("swift", new string [] { SwiftBinPath }, errors);
 			ModulePaths.ForEach (path => CheckPath (path, "module path", errors));
 			DylibPaths.ForEach (path => CheckPath (path, "library path", errors));
+
+			if (ModuleName != null) {
+				InputTargetRepresentation = UniformTargetRepresentation.FromPath (ModuleName, DylibPaths, errors);
+				if (InputTargetRepresentation == null)
+					return;
+			}
+
 			if (ModuleName != null) {
 				string wholeModule = "lib" + ModuleName + ".dylib";
 				string libDir = DylibPaths.FirstOrDefault (path => File.Exists (Path.Combine (path, wholeModule)));

--- a/tools/make-framework
+++ b/tools/make-framework
@@ -16,6 +16,10 @@ usage () {
 	echo "    adds framework directories to swift compilation (-F) (optional)"
 	echo " --libraries lb1 lb2 ..."
 	echo "    adds library directories to swift compilation (-L) (optional)"
+	echo " --swift-library-references lib1 lib2 ..."
+	echo "    adds references to the libraries (-llib1 -llib2 ...)"
+	echo " --swift-framework-references fm1 fm1 ..."
+	echo "    adds references to the frameworks (-framework fm1 -framework -fm2"
 	echo " --swift-files sf1 sf2 ..."
 	echo "    adds swift files to be compiled (required)"
 	echo " --c-files cf1 cf2 ..."
@@ -62,7 +66,6 @@ usageexit () {
 	exit 1
 }
 
-
 while (( "$#" )); do
 	case "$1" in
 	--frameworks)
@@ -83,7 +86,30 @@ while (( "$#" )); do
 			then
 				break
 			fi
+			includes="$includes -I $1"
 			libraries="$libraries -L $1"
+			shift
+		done
+		;;
+	--swift-library-references)
+		shift
+		while (( "$#" )); do
+			if [[ $1 == "--"* ]]
+			then
+				break
+			fi
+			libreferences="$libreferences -l$1"
+			shift
+		done
+		;;
+	--swift-framework-references)
+		shift
+		while (( "$#" )); do
+			if [[ $1 == "--"* ]]
+			then
+				break
+			fi
+			frameworkreferences="$frameworkreferences -framework $1"
 			shift
 		done
 		;;
@@ -369,10 +395,10 @@ compile_swift_files () {
 		echo "[Compiling Swift $targetarch]"
 	fi
 	if [[ -n $superverbose ]]; then
-		echo swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
+	echo swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args $includes $libraries $frameworks $libreferences $frameworkreferences -module-name $module_name -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
 	fi
 
-	swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
+	swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args $includes $libraries $frameworks $libreferences $frameworkreferences -module-name $module_name -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
 }
 
 copy_arch_files ()
@@ -383,7 +409,7 @@ copy_arch_files ()
 	local arch=$1
 	local odir=$2
 	local destdir=$3
-	for suffix in swiftdoc swiftinterface siftmodule siftsourceinfo
+	for suffix in swiftdoc swiftinterface swiftmodule swiftsourceinfo
 	do
 		local sourcefile="$odir/${arch}/${module_name}.${suffix}"
 		if [[ -f "$sourcefile" ]]; then


### PR DESCRIPTION
Alrighty - make-framework is now integrated into BtFS.

What's different?
- Added support for `-l` and `-f` flags in `make-framework`
- Fixed typos in `make-framework` that prevented 
- the compile flags to the swift compiler were incorrect and we didn't have the right set of flags.
We needed `-lLibName` for each library `-f FrameworkName` for each framework, `-I LibraryDirectory` for the compilation phase, `-L LibraryDirectory` for the link phase and `-F FrameworkDirectory`.
- Set the working directory to the directory with the swift files being compiled
- Added a way to distinguish the type of target directory we're looking at
- Passed the `UniformTargetRepresentation` of the input all along through the code path and refactored unit tests that jumped into the middle of the code path

All unit tests pass.
