### PR TITLE
Samples should build

### DIFF
--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -264,7 +264,7 @@ namespace SwiftReflector {
 
 			var assemblyPath = AssemblyLocation ();
 			var parent = Directory.GetParent (assemblyPath).ToString ();
-			var pacMacPath = Path.Combine (parent, "make-framework/make-framwork");
+			var pacMacPath = Path.Combine (parent, "make-framework/make-framework");
 			if (File.Exists (pacMacPath))
 				return pacMacPath;
 			var grandParent = Directory.GetParent (parent).ToString ();
@@ -272,12 +272,15 @@ namespace SwiftReflector {
 			if (File.Exists (idePath))
 				return idePath;
 			var greatGrandParent = Directory.GetParent (grandParent).ToString ();
+			var backupIDEPath = Path.Combine (greatGrandParent, "tools/make-framework");
+			if (File.Exists (backupIDEPath))
+				return backupIDEPath;
 			var greatGreatGrandParent = Directory.GetParent (greatGrandParent).ToString ();
 			var unitTestsPath = Path.Combine (greatGreatGrandParent, "tools/make-framework");
 			return File.Exists (unitTestsPath) ? unitTestsPath : null;
 		}
 
-		string AssemblyLocation ()
+		public static string AssemblyLocation ()
 		{
 			// reference code: https://stackoverflow.com/questions/52797/how-do-i-get-the-path-of-the-assembly-the-code-is-in
 			var codeBase = Assembly.GetExecutingAssembly ().CodeBase;

--- a/SwiftReflector/FrameworkRepresentation.cs
+++ b/SwiftReflector/FrameworkRepresentation.cs
@@ -59,6 +59,19 @@ namespace SwiftReflector {
 		public FrameworkRepresentation Framework { get; private set; }
 		public LibraryRepresentation Library { get; private set; }
 
+		public string Path {
+			get {
+				return Library?.Path ?? Framework?.Path ?? XCFramework.Path;
+			}
+		}
+
+		public string ParentPath {
+			get {
+				var path = Path;
+				return path != null ? Directory.GetParent (path).ToString () : null;
+			}
+		}
+
 		public static UniformTargetRepresentation FromPath (string moduleName, List<string> directoriesToSearch, ErrorHandling errors)
 		{
 			string path = null;
@@ -99,9 +112,9 @@ namespace SwiftReflector {
 			path = directories.FirstOrDefault (d => d.EndsWith (targetFrameworkName) && Directory.Exists (d));
 			if (path != null)
 				return true;
-			path = directories.FirstOrDefault (d => Directory.Exists (Path.Combine (d, targetFrameworkName)));
+			path = directories.FirstOrDefault (d => Directory.Exists (System.IO.Path.Combine (d, targetFrameworkName)));
 			if (path != null) {
-				path = Path.Combine (path, targetFrameworkName);
+				path = System.IO.Path.Combine (path, targetFrameworkName);
 				return true;
 			}
 			return false;
@@ -122,8 +135,8 @@ namespace SwiftReflector {
 		static bool TryGetLibraryPath (string moduleName, List<string> directories, out string path)
 		{
 			var targetLibrary = $"lib{moduleName}.dylib";
-			path = directories.FirstOrDefault (d => File.Exists (Path.Combine (d, targetLibrary)));
-			if (path != null) path = Path.Combine (path, targetLibrary);
+			path = directories.FirstOrDefault (d => File.Exists (System.IO.Path.Combine (d, targetLibrary)));
+			if (path != null) path = System.IO.Path.Combine (path, targetLibrary);
 			return path != null;
 		}
 
@@ -182,7 +195,7 @@ namespace SwiftReflector {
 		{
 			var frameworkRep = new FrameworkRepresentation (frameworkPath);
 			try {
-				var libraryPath = Path.Combine (frameworkPath, moduleName);
+				var libraryPath = System.IO.Path.Combine (frameworkPath, moduleName);
 				if (!File.Exists (libraryPath)) {
 					errors.Add (new FileNotFoundException (libraryPath));
 					return null;
@@ -213,8 +226,8 @@ namespace SwiftReflector {
 		{
 			foreach (var path in Directory.GetDirectories (pathToXCFramework))
 			{
-				var candidate = Path.Combine (path, $"{moduleName}.framework");
-				var candidateModule = Path.Combine (candidate, moduleName);
+				var candidate = System.IO.Path.Combine (path, $"{moduleName}.framework");
+				var candidateModule = System.IO.Path.Combine (candidate, moduleName);
 				if (Directory.Exists (candidate) && File.Exists (candidateModule))
 					yield return candidate;
 			}

--- a/SwiftReflector/IOUtils/SwiftModuleFinder.cs
+++ b/SwiftReflector/IOUtils/SwiftModuleFinder.cs
@@ -200,6 +200,8 @@ namespace SwiftReflector.IOUtils {
 			string moduleFileName = moduleName + ".swiftmodule";
 
 			if (IsAppleFramework (targetDir, moduleFileName)) {
+				if (!targetDir.EndsWith (".framework"))
+					targetDir = Path.Combine (targetDir, moduleName + ".framework");
 				return new AppleFrameworkModule (targetDir, moduleFileName, target);
 			}
 
@@ -273,7 +275,15 @@ namespace SwiftReflector.IOUtils {
 		{
 			string modulesDir = Path.Combine (dir, "Modules");
 			string swiftModuleDir = Path.Combine (modulesDir, modfileName);
-			return Directory.Exists (modulesDir) && Directory.Exists (swiftModuleDir);
+			if (!(Directory.Exists (modulesDir) && Directory.Exists (swiftModuleDir))) {
+				if (!dir.EndsWith (".framework")) {
+					modulesDir = Path.Combine (dir, Path.GetFileNameWithoutExtension (modfileName) + ".framework", "Modules");
+					swiftModuleDir = Path.Combine (modulesDir, modfileName);
+					return Directory.Exists (modulesDir) && Directory.Exists (swiftModuleDir);
+				}
+				return false;
+			}
+			return true;
 		}
 
 		public static bool IsXamarinLayout (string dir, string moduleFileName, string target)

--- a/SwiftReflector/Inventory/ModuleInventory.cs
+++ b/SwiftReflector/Inventory/ModuleInventory.cs
@@ -102,7 +102,7 @@ namespace SwiftReflector.Inventory {
 			try {
 				stm = new FileStream (pathToDynamicLibrary, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 			} catch (Exception e) {
-				errors.Add (ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 57, e, "unable to open file {0}: {1} \n{e.Message}", pathToDynamicLibrary, e.Message));
+				errors.Add (ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 57, e, "unable to open file {0}: {1}\n", pathToDynamicLibrary, e.Message));
 			}
 			try {
 				return FromStream (stm, errors, pathToDynamicLibrary);

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -20,6 +20,7 @@ namespace SwiftReflector.TypeMapping {
 		TypeSpecToSLType specMapper, overrideSpecMapper;
 		SwiftTypeToSLType swiftTypeMapper;
 		UnicodeMapper unicodeMapper;
+		HashSet<string> loadedFiles = new HashSet<string> ();
 
 		public TypeMapper (List<string> typeDatabasePaths, UnicodeMapper unicodeMapper)
 		{
@@ -43,6 +44,9 @@ namespace SwiftReflector.TypeMapping {
 
 		public void AddTypeDatabase (string fileName)
 		{
+			if (loadedFiles.Contains (fileName))
+				return;
+			loadedFiles.Add (fileName);
 			var errors = TypeDatabase.Read (fileName);
 			if (errors.AnyErrors)
 				throw new AggregateException (errors.Errors.Select ((v) => v.Exception));

--- a/samples/foreach/Makefile
+++ b/samples/foreach/Makefile
@@ -1,5 +1,5 @@
 SWIFT_BIN = /usr/bin
-SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 SWIFTC = $(SWIFT_BIN)/swiftc
 SWIFTARGS = -sdk `xcrun --show-sdk-path` -emit-module -emit-library -enable-library-evolution -emit-module-interface

--- a/samples/helloswift/Makefile
+++ b/samples/helloswift/Makefile
@@ -1,5 +1,5 @@
 SWIFT_BIN = /usr/bin
-SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 SWIFTC = $(SWIFT_BIN)/swiftc
 SWIFTARGS = -sdk `xcrun --show-sdk-path` -emit-module -emit-library -enable-library-evolution -emit-module-interface

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -1,5 +1,5 @@
 SWIFT_BIN = /usr/bin
-SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 TOM_SWIFTY = ../../tom-swifty/bin/Debug/tom-swifty.exe
 SWIFT_GLUE = ../../swiftglue/bin/Debug/mac/FinalProduct/XamGlue.framework

--- a/samples/piglatin/Makefile
+++ b/samples/piglatin/Makefile
@@ -19,14 +19,14 @@ swift_pig_latin: swiftPigLatinLibrary/SwiftPigLatinLibrary/SwiftIgPay.swift
 	# copy the swift framework locally
 	cp -r derived_data/Build/Products/Debug-iphonesimulator/SwiftPigLatinLibrary.framework frameworks
 	rm -rf derived_data
+	cp -r ../../lib/SwiftInterop/iphone/XamGlue.xcframework/ios-i386_x86_64-simulator/XamGlue.framework frameworks
 
 	# build the C# binding
 	mkdir -p bindingtoolsoutput
-	$(BINDINGTOOLSFORSWIFT) --type-database-path=../../bindings --retain-swift-wrappers --swift-bin-path $(SWIFT_BIN) --swift-lib-path $(SWIFT_LIB) -o bindingtoolsoutput -C . -C frameworks/SwiftPigLatinLibrary.framework -module-name SwiftPigLatinLibrary
+	$(BINDINGTOOLSFORSWIFT) --type-database-path=../../bindings --retain-swift-wrappers --swift-bin-path $(SWIFT_BIN) --swift-lib-path $(SWIFT_LIB) -o bindingtoolsoutput -C . -C frameworks/SwiftPigLatinLibrary.framework -C frameworks/XamGlue.framework -C frameworks -module-name SwiftPigLatinLibrary
 	
 	# copy all the needed frameworks
 	cp -r bindingtoolsoutput/XamWrapping.framework frameworks
-	cp -r ../../lib/SwiftInterop/iphone/XamGlue.framework frameworks
 	cp -r frameworks PigLatin/PigLatin
 
 	# copy the C# binding

--- a/samples/propertybag/Makefile
+++ b/samples/propertybag/Makefile
@@ -1,12 +1,9 @@
 SWIFT_BIN = /usr/bin
 XCODE_DEV = /Applications/Xcode.app/Contents/Developer
-SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 SWIFTC = $(SWIFT_BIN)/swiftc
-SWIFTARGS = -emit-library -enable-library-evolution -emit-module -emit-module-interface \
-	-sdk $(XCODE_DEV)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
-	-L $(SWIFT_LIB)/macosx \
-	-framework XamGlue
+SWIFTARGS = -sdk `xcrun --show-sdk-path` -emit-module -emit-library -enable-library-evolution -emit-module-interface
 
 
 BINDINGTOOLSFORSWIFT=../../binding-tools-for-swift
@@ -17,8 +14,8 @@ libPropertyBag.dylib: *.swift
 	@rm -rf XamWrappingSource armv7 armv7s arm64 x86_64
 	@cp ../../lib/binding-tools-for-swift/SwiftRuntimeLibrary.dll .
 	@mkdir -p XamGlue.framework
-	@cp ../../lib/SwiftInterop/mac/XamGlue.framework/XamGlue XamGlue.framework
-	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) -F . *.swift
+	@cp -r ../../lib/SwiftInterop/mac/XamGlue.framework .
+	$(SWIFTC) $(SWIFTARGS) -module-name $(OUTPUT_MODULE) *.swift
 	$(BINDINGTOOLSFORSWIFT) --retain-swift-wrappers --swift-bin-path $(SWIFT_BIN) --swift-lib-path $(SWIFT_LIB) -o . -C . -module-name $(OUTPUT_MODULE) 
 	mcs -nowarn:CS0169 -lib:../lib -r:SwiftRuntimeLibrary -lib:. *.cs -unsafe+ -out:$(OUTPUT_MODULE).exe
 

--- a/samples/sampler/Makefile
+++ b/samples/sampler/Makefile
@@ -1,6 +1,6 @@
 SWIFT_BIN = /usr/bin
 XCODE_DEV = /Applications/Xcode.app/Contents/Developer
-SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 SWIFTC = $(SWIFT_BIN)/swiftc
 SWIFTARGS = -emit-library -enable-library-evolution -emit-module -emit-module-interface \

--- a/samples/sandwiches/Makefile
+++ b/samples/sandwiches/Makefile
@@ -1,6 +1,6 @@
 SWIFT_BIN = /usr/bin
 XCODE_DEV = /Applications/Xcode.app/Contents/Developer
-SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0
+SWIFT_LIB = $(XCODE_DEV)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift
 
 SWIFTC = $(SWIFT_BIN)/swiftc
 SWIFTARGS = -emit-library -enable-library-evolution -emit-module -emit-module-interface \


### PR DESCRIPTION
None of the samples built. Yay.
But all of the unit tests pass - how could this be?

The answer is that unit tests come with various paths already installed set up in them that don't exist in the final product.
One of them is that because packaging was never really planned out we just depended on the user to tell us where the XamGlue lives. When I put in the code for handling of targets/libraries/frameworks, I borked some code that found XamGlue.

To fix this, I put in code to locate the correct XamGlue and add it into the Module and Library paths.

I found that the type database wasn't being loaded in all cases, so I put in code to track that down and add in it into the paths. In some cases, it was getting loaded twice (!) so I put in a cache to make sure you only load a database once.

I found that some of the libraries in the makefiles were conflicting with compilation settings internally so I reset those.

Now everything but piglatin builds and runs. piglatin is the only iOS sample and I was starting to get really off into the weeds, so I'll save that for another PR.
