### PR TITLE
fix up sample builds

### DIFF
--- a/SwiftReflector/CompilationSettings.cs
+++ b/SwiftReflector/CompilationSettings.cs
@@ -118,7 +118,8 @@ namespace SwiftReflector {
 			//--make-xcframework (optional)
 			//   if present, puts both device and simulator builds into an xcframework
 			//   if present, both--simulator - archs and--device - archs must be present.
-			// 
+			//--install-name-tool args
+                        //   if present, runs the install-name-tool command as part of the swift compilation
 
 			if (SwiftFilePaths.Count == 0)
 				throw new Exception ("No files provided to compile.");
@@ -160,6 +161,7 @@ namespace SwiftReflector {
 				args.Append (" --extra-swift-args -Xlinker -install_name -Xlinker @rpath/lib")
 					.Append (ModuleName).Append (".dylib");
 			}
+			args.Append (" --install-name-tool -change XamGlue @rpath/XamGlue");
 			return args.ToString ();
 		}
 

--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -219,13 +219,13 @@ namespace SwiftReflector {
 
 			var modulesInLibraries = SwiftModuleFinder.FindModuleNames (libraryDirectories, CompilerInfo.Target);
 
-			List<ISwiftModuleLocation> locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries,
-													     includeDirectories, CompilerInfo.Target);
+			var locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries,
+													     includeDirectories.ToList (), CompilerInfo.Target);
 			string output = "";
 			try {
-				output = Reflect (locations.Select (loc => loc.DirectoryPath), libraryDirectories, pathName, extraArgs, moduleNames);
+				output = Reflect (locations.Select (loc => loc.ParentPath), libraryDirectories, pathName, extraArgs, moduleNames);
 			} finally {
-				locations.DisposeAll ();
+				//locations.DisposeAll ();
 			}
 			ThrowOnCompilerVersionMismatch (output, moduleNames);
 			using (var stm = new FileStream (pathName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
@@ -246,8 +246,8 @@ namespace SwiftReflector {
 
 			var modulesInLibraries = SwiftModuleFinder.FindModuleNames (libraryDirectories, CompilerInfo.Target);
 
-			var locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries, includeDirectories, CompilerInfo.Target)
-				.Select (loc => loc.DirectoryPath).ToList ();
+			var locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries, includeDirectories.ToList (), CompilerInfo.Target)
+				.Select (loc => loc.ParentPath).ToList ();
 			locations.AddRange (includeDirectories);
 
 			ReflectWithStrategies (locations, libraryDirectories, pathName, extraArgs, moduleNames);
@@ -297,10 +297,11 @@ namespace SwiftReflector {
 			if (ReflectionTypeDatabase == null)
 				throw ErrorHelper.CreateError (ReflectorError.kCantHappenBase + 72, "Parser reflector requires a TypeDatabase");
 
-			var path = GetSwiftInterfacePath (includeDirectories, moduleNames [0]);
+			var searchPaths = includeDirectories.Union (libraryDirectory);
+			var path = GetSwiftInterfacePath (searchPaths, moduleNames [0]);
 
 			if (path == null) {
-				var lookedIn = includeDirectories.InterleaveStrings (", ");
+				var lookedIn = searchPaths.InterleaveStrings (", ");
 				throw new FileNotFoundException ($"Did not find {moduleNames [0]} in {lookedIn}");
 			}
 
@@ -312,28 +313,12 @@ namespace SwiftReflector {
 
 		string GetSwiftInterfacePath (IEnumerable<string> includeDirectories, string moduleName)
 		{
-			var swiftModule = moduleName + ".swiftmodule";
-			// if the compiler has a target, it means that we have a framework.
-			if (CompilerInfo.HasTarget) {
-				foreach (var path in includeDirectories) {
-					if (SwiftModuleFinder.IsAppleFramework (path, swiftModule)) {
-						var ifaceDir = Path.Combine (path, $"Modules/{swiftModule}");
-						var file = Path.Combine (ifaceDir, $"{CompilerInfo.Target.ClangTargetCpu ()}.swiftinterface");
-						if (File.Exists (file))
-							return file;
-					} else {
-						var file = Path.Combine (path, $"{moduleName}.swiftinterface");
-						if (File.Exists (file))
-							return file;
-					}
-				}
-				return null;
-			} else {
-				var paths = includeDirectories.Select (dir => Path.Combine (dir, swiftModule));
-
-				var path = paths.FirstOrDefault (p => File.Exists (p));
-				return path;
+			var errors = new ErrorHandling ();
+			var targetRepresentation = UniformTargetRepresentation.FromPath (moduleName, includeDirectories.ToList (), errors);
+			if (errors.AnyErrors) {
+				throw errors.Errors.First ().Exception;
 			}
+			return targetRepresentation?.PathToSwiftInterface (targetRepresentation.Targets.First ());
 		}
 
 		public string Reflect (IEnumerable<string> includeDirectories, IEnumerable<string> libraryDirectories,

--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -315,9 +315,7 @@ namespace SwiftReflector {
 		{
 			var errors = new ErrorHandling ();
 			var targetRepresentation = UniformTargetRepresentation.FromPath (moduleName, includeDirectories.ToList (), errors);
-			if (errors.AnyErrors) {
-				throw errors.Errors.First ().Exception;
-			}
+			// ignore the errors - if we found something we're good. If we didn't we'll get an error upstream.
 			return targetRepresentation?.PathToSwiftInterface (targetRepresentation.Targets.First ());
 		}
 

--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -221,12 +221,8 @@ namespace SwiftReflector {
 
 			var locations = SwiftModuleFinder.GatherAllReferencedModules (modulesInLibraries,
 													     includeDirectories.ToList (), CompilerInfo.Target);
-			string output = "";
-			try {
-				output = Reflect (locations.Select (loc => loc.ParentPath), libraryDirectories, pathName, extraArgs, moduleNames);
-			} finally {
-				//locations.DisposeAll ();
-			}
+			var output = Reflect (locations.Select (loc => loc.ParentPath), libraryDirectories, pathName, extraArgs, moduleNames);
+
 			ThrowOnCompilerVersionMismatch (output, moduleNames);
 			using (var stm = new FileStream (pathName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
 				return XDocument.Load (stm);

--- a/SwiftReflector/IOUtils/SwiftModuleFinder.cs
+++ b/SwiftReflector/IOUtils/SwiftModuleFinder.cs
@@ -157,6 +157,8 @@ namespace SwiftReflector.IOUtils {
 				var targetRep = UniformTargetRepresentation.FromPath (moduleName, inputModuleDirectories, errors);
 				if (targetRep != null) {
 					targets.Add (targetRep);
+				} else {
+					throw errors.Errors.First ().Exception;
 				}
 			}
 			return targets;

--- a/SwiftReflector/IOUtils/SwiftModuleFinder.cs
+++ b/SwiftReflector/IOUtils/SwiftModuleFinder.cs
@@ -157,7 +157,7 @@ namespace SwiftReflector.IOUtils {
 				var targetRep = UniformTargetRepresentation.FromPath (moduleName, inputModuleDirectories, errors);
 				if (targetRep != null) {
 					targets.Add (targetRep);
-				} else {
+				} else if (errors.AnyErrors) {
 					throw errors.Errors.First ().Exception;
 				}
 			}

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5359,6 +5359,7 @@ namespace SwiftReflector {
 
 			var mods = new List<string> (modulePaths);
 			mods.Add (targetRepresentation.Path);
+			mods.Add (targetRepresentation.ParentPath);
 			wrapStuff.Item2.Add (wrappingModuleName);
 
 			var targetRepresentations = SwiftModuleFinder.GatherAllReferencedModules (wrapStuff.Item2, mods, targets [0]);

--- a/tools/make-framework
+++ b/tools/make-framework
@@ -46,6 +46,8 @@ usage () {
 	echo " --make-xcframework (optional)"
 	echo "    if present, puts both device and simulator builds into an xcframework"
 	echo "    if present, both --simulator-archs and --device-archs must be present."
+	echo " --install-name-tool arg1 arg2 ..."
+	echo "    if preset, runs the install-name-tool command as part of the swift compilation."
 	echo " --verbose"
 	echo "    if present, be more talky."
 	echo "    if present, more than once be super talky."
@@ -243,6 +245,17 @@ while (( "$#" )); do
 		fi
 		verbose=1
 		;;
+	--install-name-tool)
+		shift
+		while (( "$#" )); do
+                        if [[ $1 == "--"* ]]
+                        then
+                                break
+                        fi
+                        install_name_tool_args="${install_name_tool_args} $1"
+                        shift
+                done
+		;;
 
 	*)
 		echo "${COLOR_RED}Unknown argument $1${COLOR_CLEAR}"
@@ -399,6 +412,15 @@ compile_swift_files () {
 	fi
 
 	swiftc -sdk "$sdk" -target "$targetarch" -emit-module-interface -enable-library-evolution -emit-module -emit-library $extra_swift_args $includes $libraries $frameworks $libreferences $frameworkreferences -module-name $module_name -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker '@executable_path/Frameworks' -Xlinker -rpath -Xlinker '@loader_path' -Xlinker -rpath -Xlinker '@loader_path/Frameworks' -Xlinker -rpath -Xlinker @executable_path -Xlinker -final_output -Xlinker "$module_name" -o "${odir}/${module_name}" $swift_files $ofiles
+	if [[ -n $install_name_tool_args ]]; then
+		if [[ -n $verbose ]]; then
+			echo "[Running install-name-tool]"
+		fi
+		if [[ -n $superverbose ]]; then
+			echo install_name_tool $install_name_tool_args "${odir}/${module_name}"
+		fi
+		install_name_tool $install_name_tool_args "${odir}/${module_name}"
+	fi
 }
 
 copy_arch_files ()


### PR DESCRIPTION
Let's make the samples build, fixing issue [715](https://github.com/xamarin/binding-tools-for-swift/issues/715)
What was happening?
The code was having trouble dealing with `.framework` directories and wasn't building the piglatin sample.
Why was this happening?
The SwiftModuleFinder code is woefully naive. Instead, I'm using the `UniversalFrameworkRepresentation`, which has most of that heavy lifting built into it.
To help things along, I added in a constructor to make a CompilationTarget from a string for some of the places that need that.

There are some problems. The UniformTargetRepresentation has some design errors and [we can make that better](https://github.com/xamarin/binding-tools-for-swift/issues/718). `SwiftModuleFinder` [can probably go away entirely](https://github.com/xamarin/binding-tools-for-swift/issues/719).

Those changes don't belong here. I'll do them later.

Added tests for the code to parse a `CompilationTarget` and all the existing tests pass and the samples build.