### PR TITLE
Refactor to clean up targetrepresentation interfacing

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -5341,8 +5341,9 @@ namespace SwiftReflector {
 
 			var targetRepresentation = UniformTargetRepresentation.FromPath (wrappingModuleName, new List<string> () { outputDirectory }, errors);
 
-			string wrapperLibraryPath = targetRepresentation.PathToDylib (targets [0]);
-			var wrapperModulePath = targetRepresentation.PathToSwiftModule (targets [0]);
+			var compilationTarget = new CompilationTarget (targets [0]);
+			string wrapperLibraryPath = targetRepresentation.PathToDylib (compilationTarget);
+			var wrapperModulePath = targetRepresentation.PathToSwiftModule (compilationTarget);
 
 			var wrapperModuleInventory = ModuleInventory.FromFile (wrapperLibraryPath, errors);
 			if (errors.AnyErrors) {


### PR DESCRIPTION
I hoisted the common methods into an interface then made everything implement that interface taking care of issue [719](https://github.com/xamarin/binding-tools-for-swift/issues/719)