### PR TITLE
Get rid of target triple strings

### DIFF
--- a/SwiftReflector/CustomSwiftCompiler.cs
+++ b/SwiftReflector/CustomSwiftCompiler.cs
@@ -219,8 +219,7 @@ namespace SwiftReflector {
 
 			var modulesInLibraries = UniformTargetRepresentation.FindModuleNames (libraryDirectories, CompilerInfo.Target);
 
-			var locations = UniformTargetRepresentation.GatherAllReferencedModules (modulesInLibraries,
-													     includeDirectories.ToList (), CompilerInfo.Target);
+			var locations = UniformTargetRepresentation.GatherAllReferencedModules (modulesInLibraries, includeDirectories.ToList ());
 			var output = Reflect (locations.Select (loc => loc.ParentPath), libraryDirectories, pathName, extraArgs, moduleNames);
 
 			ThrowOnCompilerVersionMismatch (output, moduleNames);
@@ -242,7 +241,7 @@ namespace SwiftReflector {
 
 			var modulesInLibraries = UniformTargetRepresentation.FindModuleNames (libraryDirectories, CompilerInfo.Target);
 
-			var locations = UniformTargetRepresentation.GatherAllReferencedModules (modulesInLibraries, includeDirectories.ToList (), CompilerInfo.Target)
+			var locations = UniformTargetRepresentation.GatherAllReferencedModules (modulesInLibraries, includeDirectories.ToList ())
 				.Select (loc => loc.ParentPath).ToList ();
 			locations.AddRange (includeDirectories);
 

--- a/SwiftReflector/FrameworkRepresentation.cs
+++ b/SwiftReflector/FrameworkRepresentation.cs
@@ -449,7 +449,7 @@ namespace SwiftReflector {
 		}
 
 		public static List<UniformTargetRepresentation> GatherAllReferencedModules (IEnumerable<string> allReferencedModules,
-			List<string> inputModuleDirectories, string target)
+			List<string> inputModuleDirectories)
 		{
 			var errors = new ErrorHandling ();
 			var targets = new List<UniformTargetRepresentation> ();

--- a/SwiftReflector/MachOHelpers.cs
+++ b/SwiftReflector/MachOHelpers.cs
@@ -141,12 +141,12 @@ namespace SwiftReflector {
 			return minOS.Version.ToString ();
 		}
 
-		public static List<string> CommonTargets (List<string> lt, List<string> commonTo)
+		public static List<CompilationTarget> CommonTargets (List<CompilationTarget> lt, List<CompilationTarget> commonTo)
 		{
-			List<string> isec = new List<string> ();
-			foreach (string s in lt) {
-				if (commonTo.Contains (s))
-					isec.Add (s);
+			var isec = new List<CompilationTarget> ();
+			foreach (var ct in lt) {
+				if (commonTo.Contains (ct))
+					isec.Add (ct);
 			}
 			return isec;
 		}

--- a/SwiftReflector/WrappingCompiler.cs
+++ b/SwiftReflector/WrappingCompiler.cs
@@ -44,7 +44,7 @@ namespace SwiftReflector {
 
 		public Tuple<string, HashSet<string>> CompileWrappers (string [] inputLibraryDirectories, string [] inputModuleDirectories,
 			IEnumerable<ModuleDeclaration> modulesToCompile, ModuleInventory modInventory,
-			List<string> targets, string wrappingModuleName, bool outputIsFramework,
+			CompilationTargetCollection targets, string wrappingModuleName, bool outputIsFramework,
 			string minimumOSVersion = null, bool isLibrary = false)
 		{
 			wrappingModuleName = wrappingModuleName ?? kXamWrapPrefix;

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1156,7 +1156,7 @@ public enum Position {
 					ClassCompilerLocations classCompilerLocations = new ClassCompilerLocations (searchPath, searchPath, typeDataBasePaths);
 					ClassCompilerNames compilerNames = new ClassCompilerNames ("Consumer", null);
 
-					ErrorHandling errors = ncc.CompileToCSharp (classCompilerLocations, compilerNames, new List<string> { "x86_64-apple-macosx10.9" }, consumerCompiler.DirectoryPath);
+					ErrorHandling errors = ncc.CompileToCSharp (classCompilerLocations, compilerNames, new CompilationTargetCollection { new CompilationTarget ("x86_64-apple-macosx10.9") }, consumerCompiler.DirectoryPath);
 
 					Utils.CheckErrors (errors);
 

--- a/tests/tom-swifty-test/SwiftReflector/Utils.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Utils.cs
@@ -122,7 +122,7 @@ namespace SwiftReflector {
 				args.Append ($"--module-name={StringUtils.Quote (moduleName)} ");
 				return ExecAndCollect.Run ("mono", args.ToString ());
 			} else {
-				ErrorHandling errors = ncc.CompileToCSharp (classCompilerLocations, compilerNames, new List<string> { target }, outputDirectory ?? provider.DirectoryPath);
+				ErrorHandling errors = ncc.CompileToCSharp (classCompilerLocations, compilerNames, new CompilationTargetCollection { new CompilationTarget (target) }, outputDirectory ?? provider.DirectoryPath);
 				CheckErrors (errors, expectedErrorCount);
 				return null;
 			}


### PR DESCRIPTION
Went through and got rid of target triple strings as per issue [692](https://github.com/xamarin/binding-tools-for-swift/issues/692)

Note to future Steve: I know that strings look like a convenient encoding format, but really you should favor actual data structures.

I changed most of the interfacing to use `CompilationTargetCollection`, `List<CompilationTarget>` and `CompilationTarget` instead of `List<string>` and `string`. Most of what I needed was already in the data structures and what wasn't was easy to write and less error prone than using strings.

Unit tests pass.