### PR TITLE
It helps if you run through the actual code path.

### DIFF
--- a/tom-swifty/SwiftyOptions.cs
+++ b/tom-swifty/SwiftyOptions.cs
@@ -316,7 +316,7 @@ namespace tomswifty {
 								var targetRep = UniformTargetRepresentation.FromPath (ModuleName, ModulePaths, errors);
 								if (targetRep == null)
 									errors.Add (new ReflectorError (new FileNotFoundException ($"Unable to find swift module file for {ModuleName}. Searched in {sb.ToString ()}.")));
-								if (targetRep.HasTarget (target))
+								else if (!targetRep.HasTarget (target))
 									errors.Add (new ReflectorError (new FileNotFoundException ($"Unable to find swift module file for {ModuleName} in target {target}. Searched in {sb.ToString ()}.")));
 							}
 						}


### PR DESCRIPTION
Fix so that samples build, addressing issue [728](https://github.com/xamarin/binding-tools-for-swift/issues/728).

What happened?
In checking that the changes I made to include more demangling cleaned up the samples, I noted that they were not building.
I forgot to put in a `!` on `HasTarget` and that caused a failure condition - also noted that the second `if` clause would fail if  targetRep returned `null` and fixed that too.

Why did this happen?
Because unit tests, by design, don't go through this code path.
Wait, by _design_?
Yes - the code that does that work is treated like an API so that testing it would be as easy as possible and would be insulated from CLI argument changes. The failure happened in code that verifies CLI options and turns them into an API call. One test is to ensure that we have valid input files and that we have work to do on them. This code failed.

Can we not have this happen again?
Sure - I opened [this issue](https://github.com/xamarin/binding-tools-for-swift/issues/730) so we don't forget.
