### PR TITLE
Added in EnumCase support

### DIFF
--- a/SwiftReflector/Demangling/TLDefinition.cs
+++ b/SwiftReflector/Demangling/TLDefinition.cs
@@ -151,6 +151,14 @@ namespace SwiftReflector.Demangling {
 		}
 	}
 
+	public class TLEnumCase : TLFunction {
+		public TLEnumCase (string mangledName, SwiftName module, SwiftName functionName,
+			SwiftClassType classType, SwiftBaseFunctionType signature, ulong offset, OperatorType oper = OperatorType.None)
+			: base (mangledName, module, functionName, classType, signature, offset, oper, CoreCompoundType.MethodDescriptor)
+		{
+		}
+	}
+
 	public class TLDefaultArgumentInitializer : TLDefinition {
 		public TLDefaultArgumentInitializer(string mangledName, SwiftName module, SwiftBaseFunctionType function, int index, ulong offset)
 			: base(CoreCompoundType.ArgumentInitializer, mangledName, module, offset)

--- a/SwiftReflector/Inventory/ClassContents.cs
+++ b/SwiftReflector/Inventory/ClassContents.cs
@@ -26,6 +26,7 @@ namespace SwiftReflector.Inventory {
 			PrivateSubscripts = new List<TLFunction> (sizeofMachinePointer);
 			StaticFunctions = new FunctionInventory (sizeofMachinePointer);
 			Destructors = new FunctionInventory (sizeofMachinePointer);
+			EnumCases = new FunctionInventory (sizeofMachiinePointer);
 			WitnessTable = new WitnessInventory (sizeofMachinePointer);
 			FunctionsOfUnknownDestination = new List<TLFunction> ();
 			DefinitionsOfUnknownDestination = new List<TLDefinition> ();
@@ -50,6 +51,8 @@ namespace SwiftReflector.Inventory {
 						throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 12, $"multiple type metadata accessors for {tlf.Class.ClassName.ToFullyQualifiedName ()}");
 				} else if (IsDestructor (tlf.Signature, tlf.Class)) {
 					AddOrChainInNewThunk (Destructors, tlf, srcStm);
+				} else if (tlf is TLEnumCase) {
+					AddOrChainInNewThunk (EnumCases, tlf, srcStm);
 				} else if (IsProperty (tlf.Signature, tlf.Class)) {
 					if (IsSubscript (tlf.Signature, tlf.Class)) {
 						if (IsPrivateProperty (tlf.Signature, tlf.Class))
@@ -265,6 +268,7 @@ namespace SwiftReflector.Inventory {
 		public FunctionInventory Constructors { get; private set; }
 		public FunctionInventory ClassConstructor { get; private set; }
 		public FunctionInventory Destructors { get; private set; }
+		public FunctionInventory EnumCases { get; private set; }
 		public PropertyInventory Properties { get; private set; }
 		public PropertyInventory StaticProperties { get; private set; }
 		public PropertyInventory PrivateProperties { get; private set; }

--- a/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/Swift4DemanglerTests.cs
@@ -1790,5 +1790,33 @@ namespace SwiftReflector.Demangling {
 			var tld = Decomposer.Decompose ("_$s8HelloMod0A0CMu", false);
 			Assert.NotNull (tld, "failed decomposition");
 		}
+
+		[Test]
+		public void TestUnusualEnumCase0 ()
+		{
+			var tld = Decomposer.Decompose ("_$s7Sampler6NumberO4RealyACSdcACmFWC", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLEnumCase;
+			Assert.IsNotNull (tlf, "not an enum case");
+			var func = tlf.Signature as SwiftUncurriedFunctionType;
+			Assert.IsNotNull (func);
+			var instanceType = func.UncurriedParameter as SwiftClassType;
+			Assert.IsNotNull (instanceType, "not a class in uncurried parameter");
+			Assert.AreEqual ("Sampler.Number", instanceType.ClassName.ToFullyQualifiedName (), "wrong class name");
+		}
+
+		[Test]
+		public void TestUnusualEnumCase1 ()
+		{
+			var tld = Decomposer.Decompose ("_$s7Sampler6NumberO7IntegeryACSicACmFWC", false);
+			Assert.IsNotNull (tld, "failed decomposition");
+			var tlf = tld as TLEnumCase;
+			Assert.IsNotNull (tlf, "not an enum case");
+			var func = tlf.Signature as SwiftUncurriedFunctionType;
+			Assert.IsNotNull (func);
+			var instanceType = func.UncurriedParameter as SwiftClassType;
+			Assert.IsNotNull (instanceType, "not a class in uncurried parameter");
+			Assert.AreEqual ("Sampler.Number", instanceType.ClassName.ToFullyQualifiedName (), "wrong class name");
+		}
 	}
 }


### PR DESCRIPTION
Added in support for `EnumCase` fixing issue [729](https://github.com/xamarin/binding-tools-for-swift/issues/729).

An `EnumCase` AFAICT is a method that returns a closure that acts as a factory for that case.
For example:
```swift
public enum Number {
    case Integer(Int)
    case Real(Double)
}
```
This will generate the following extra functions:
```swift
public func Number.Real () -> (Double) -> Number
public func Number.Integer () -> (Int) -> Number
```

Why are these here?
Because when `enable-library-evolution` is on it allows a guaranteed way of constructing these enums without depending on either (1) the layout of the enum in memory (2) technically non-breaking changes in the enum (adding a new case, for example).

Do we need them?
TL;DR No/probably not.
Long answer, in wrapping this enum we write these two functions:
```swift
public func xamarin_NumberfInteger(retval: UnsafeMutablePointer<Number>, 
    val: Int)
    {
    retval.initialize(to: Number.Integer(val));
}
public func xamarin_NumberfReal(retval: UnsafeMutablePointer<Number>, 
    val: Double)
    {
    retval.initialize(to: Number.Real(val));
}
```
To decrypt *my* mangling, these are named [xamarin prefix][typename][enum factory signifier][enum case name]. So yeah, we already take case of this and using their closures means that we would have to wrap the closures in order to handle the different ABI, so no we probably don't need them.

Why did you go to the trouble of making a space in the `ClassContents` for them then? Well, because they come through as `TLFunction` and we don't want them to go someplace they shouldn't - in other words, if we're looking for a method to P/Invoke into, we don't want to inadvertently match one of these, so we wrap them up all nice and pretty into their own space where they're never bother us again.
