### PR TITLE
add support for parsing async

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -96,6 +96,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		internal const string kAccessibility = "accessibility";
 		internal const string kIsVariadic = "isVariadic";
 		internal const string kTypeDeclaration = "typedeclaration";
+		internal const string kIsAsync = "isAsync";
 		internal const string kProperty = "property";
 		internal const string kIsProperty = "isProperty";
 		internal const string kStorage = "storage";
@@ -560,9 +561,10 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var attributes = GatherAttributes (head.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
 			var isUnavailable = CheckForUnavailable (attributes);
+			var isAsync = signature.async_clause () != null;
 			var functionDecl = ToFunctionDeclaration (name, returnType, accessibility, isStatic, hasThrows,
 				isFinal, isOptional, isConvenienceInit, objCSelector: null, operatorKind,
-				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, attributes);
+				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync, attributes);
 			var generics = HandleGenerics (context.generic_parameter_clause (), context.generic_where_clause (), true);
 			if (generics != null)
 				functionDecl.Add (generics);
@@ -658,7 +660,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var functionDecl = ToFunctionDeclaration (name, returnType, accessibility, isStatic, hasThrows,
 				isFinal, isOptional, isConvenienceInit, objCSelector: null, operatorKind,
 				isDeprecated, isUnavailable, isMutating, isRequired, isProperty,
-				attributes);
+				isAsync: false, attributes);
 			currentElement.Push (functionDecl);
 		}
 
@@ -688,7 +690,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isProperty = false;
 			var functionDecl = ToFunctionDeclaration (name, returnType, accessibility, isStatic, hasThrows,
 				isFinal, isOptional, isConvenienceInit, objCSelector: null, operatorKind,
-				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, attributes);
+				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync: false, attributes);
 
 			// always has two parameter lists: (instance)()
 			currentElement.Push (functionDecl);
@@ -733,7 +735,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var getParamList = MakeParameterList (head.parameter_clause ().parameter_list (), 1, true);
 			var getFunc = ToFunctionDeclaration (kGetSubscript, resultType, accessibility, isStatic, hasThrows,
 				isFinal, isOptional, isConvenienceInit: false, objCSelector: null, kNone,
-				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, attributes);
+				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync:false, attributes);
 
 			currentElement.Push (getFunc);
 			var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
@@ -759,7 +761,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 				var setFunc = ToFunctionDeclaration (kSetSubscript, "()", accessibility, isStatic, hasThrows,
 					isFinal, isOptional, isConvenienceInit: false, objCSelector: null, kNone,
-					isDeprecated, isUnavailable, isMutating, isRequired, isProperty, attributes);
+					isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync: false, attributes);
 
 				currentElement.Push (setFunc);
 				var setParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), setParamList);
@@ -804,7 +806,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				var getFunc = ToFunctionDeclaration ("get_" + name,
 					resultType, accessibility, isStatic, hasThrows, isFinal, isOptional,
 					isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
-					isUnavailable, isMutating, isRequired, isProperty, attributes);
+					isUnavailable, isMutating, isRequired, isProperty, isAsync: false, attributes);
 
 				currentElement.Push (getFunc);
 				var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
@@ -827,7 +829,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					var setFunc = ToFunctionDeclaration ("set_" + name,
 						"()", accessibility, isStatic, hasThrows, isFinal, isOptional,
 						isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
-						isUnavailable, isMutating, isRequired, isProperty, attributes);
+						isUnavailable, isMutating, isRequired, isProperty, isAsync: false, attributes);
 
 					currentElement.Push (setFunc);
 					var setParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), setParamList);
@@ -1354,7 +1356,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		XElement ToFunctionDeclaration (string name, string returnType, string accessibility,
 			bool isStatic, bool hasThrows, bool isFinal, bool isOptional, bool isConvenienceInit,
 			string objCSelector, string operatorKind, bool isDeprecated, bool isUnavailable,
-			bool isMutating, bool isRequired, bool isProperty, XElement attributes)
+			bool isMutating, bool isRequired, bool isProperty, bool isAsync, XElement attributes)
 		{
 			var decl = new XElement (kFunc, new XAttribute (nameof (name), name), new XAttribute (nameof (returnType), returnType),
 				new XAttribute (nameof (accessibility), accessibility), new XAttribute (nameof (isStatic), XmlBool (isStatic)),
@@ -1364,6 +1366,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				new XAttribute (nameof (isDeprecated), XmlBool (isDeprecated)),
 				new XAttribute (nameof (isUnavailable), XmlBool (isUnavailable)),
 				new XAttribute (nameof (isRequired), XmlBool (isRequired)),
+				new XAttribute (kIsAsync, XmlBool (isAsync)),
 				new XAttribute (kIsProperty, XmlBool (isProperty)),
 				new XAttribute (nameof (isMutating), XmlBool (isMutating)));
 

--- a/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/FunctionDeclaration.cs
@@ -53,6 +53,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			ObjCSelector = other.ObjCSelector;
 			IsRequired = other.IsRequired;
 			IsConvenienceInit = other.IsConvenienceInit;
+			IsAsync = other.IsAsync;
 			foreach (var genDecl in other.Generics) {
 				Generics.Add (new GenericDeclaration (genDecl));
 			}
@@ -83,6 +84,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public string ObjCSelector { get; set; }
 		public bool IsOptional { get; set; }
 		public bool HasThrows { get; set; }
+		public bool IsAsync { get; set; }
 		public bool IsProperty { get; set; }
 		public string PropertyName { get { return Name.Substring (kPropertyGetterPrefix.Length); } }
 		public bool IsStatic { get; set; }
@@ -229,6 +231,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				Parent = parent,
 				Access = TypeDeclaration.AccessibilityFromString ((string)elem.Attribute ("accessibility")),
 				ReturnTypeName = Exceptions.ThrowOnNull ((string)elem.Attribute ("returnType"), "returnType"),
+				IsAsync = elem.BoolAttribute ("isAsync"),
 				IsProperty = elem.BoolAttribute ("isProperty"),
 				IsStatic = elem.BoolAttribute ("isStatic"),
 				IsFinal = elem.BoolAttribute ("isFinal"),
@@ -276,6 +279,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			                                 new XAttribute ("name", Name),
 			                                 new XAttribute ("accessibility", TypeDeclaration.ToString (Access)),
 			                                 new XAttribute ("returnType", ReturnTypeName),
+							 new XAttribute ("isAsync", BoolString (IsAsync)),
 			                                 new XAttribute ("isProperty", BoolString (IsProperty)),
 			                                 new XAttribute ("isStatic", BoolString (IsStatic)),
 			                                 new XAttribute ("isFinal", BoolString (IsFinal)),

--- a/docs/XMLReflection.md
+++ b/docs/XMLReflection.md
@@ -90,6 +90,7 @@ A `<func>` element represents a method or a top-level function. It contains the 
 - name - a string representing the function’s name
 - accessibility - one of `Public`, `Private`, `Internal`, `Open`
 - returnType - a string which is a type specification (`TypeSpec`) that represents a type
+- isAsync = boolen
 - isProperty - boolean
 - isStatic - boolean
 - isFinal - boolean

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -232,10 +232,11 @@ function_body : OpLBrace dyckSubExpression* OpRBrace ;
 
 operator_name : operator ;
 
-function_signature : parameter_clause throws_clause? function_result?
-	| parameter_clause rethrows_clause function_result?
+function_signature : parameter_clause async_clause? throws_clause? function_result?
+	| parameter_clause async_clause? rethrows_clause function_result?
 	;
 
+async_clause : 'async' ;
 throws_clause : 'throws' ;
 rethrows_clause : 'rethrows' ;
 

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -30,7 +30,7 @@ namespace XmlReflectionTests {
 				}
 			}
 		}
-			
+
 
 		void CompileStringToModule (string code, string moduleName)
 		{
@@ -656,6 +656,113 @@ public func foo () -> [Int] {
 			Assert.IsNotNull (fn, "no function");
 			var retType = fn.ReturnTypeName;
 			Assert.AreEqual ("Swift.Array<Swift.Int>", retType, "wrong return");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestAsyncBasic ()
+		{
+			var code = @"
+public func foo () async -> Int {
+	return 5
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+		}
+
+		[Test]
+		public void TestAsyncBasicNotPresent ()
+		{
+			var code = @"
+public func foo () -> Int {
+	return 5
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestAsyncMethod ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	public func foo () async -> Int {
+		return 5
+	}
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var fn = cl.AllMethodsNoCDTor ().FirstOrDefault (m => m.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+		}
+
+		[Test]
+		public void TestAsyncMethodNotPresent ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	public func foo () -> Int {
+		return 5
+	}
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var fn = cl.AllMethodsNoCDTor ().FirstOrDefault (m => m.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestAsyncProtocolMethod ()
+		{
+			var code = @"
+public protocol bar {
+	func foo () async -> Int
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var fn = cl.AllMethodsNoCDTor ().FirstOrDefault (m => m.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+		}
+
+		[Test]
+		public void TestAsyncProtocolMethodNotPresent ()
+		{
+			var code = @"
+public protocol bar {
+	func foo () -> Int
+}";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var fn = cl.AllMethodsNoCDTor ().FirstOrDefault (m => m.Name == "foo");
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
 		}
 	}
 }


### PR DESCRIPTION
Support in place for parsing async and propagating it into the the XML and attendant XmlReflection data structures.
Until the compiler dependency changes, the positive tests for it need to stay ignored.