### PR TITLE
put async support into props and subscripts

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -726,6 +726,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isUnavailable = CheckForUnavailable (attributes);
 			var isStatic = false;
 			var hasThrows = false;
+			var isAsync = HasAsync (context.getter_setter_keyword_block ()?.getter_keyword_clause ());
 			var isFinal = ModifiersContains (head.declaration_modifiers (), kFinal);
 			var isOptional = ModifiersContains (head.declaration_modifiers (), kOptional);
 			var isMutating = ModifiersContains (head.declaration_modifiers (), kMutating);
@@ -735,7 +736,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var getParamList = MakeParameterList (head.parameter_clause ().parameter_list (), 1, true);
 			var getFunc = ToFunctionDeclaration (kGetSubscript, resultType, accessibility, isStatic, hasThrows,
 				isFinal, isOptional, isConvenienceInit: false, objCSelector: null, kNone,
-				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync:false, attributes);
+				isDeprecated, isUnavailable, isMutating, isRequired, isProperty, isAsync: isAsync, attributes);
 
 			currentElement.Push (getFunc);
 			var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
@@ -801,12 +802,13 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				var name = UnTick (tail.variable_name ().GetText ());
 				var resultType = TrimColon (tail.type_annotation ().GetText ());
 				var hasThrows = false;
+				var isAsync = HasAsync (tail.getter_setter_keyword_block ()?.getter_keyword_clause ());
 
 				var getParamList = new XElement (kParameterList, new XAttribute (kIndex, "1"));
 				var getFunc = ToFunctionDeclaration ("get_" + name,
 					resultType, accessibility, isStatic, hasThrows, isFinal, isOptional,
 					isConvenienceInit: false, objCSelector: null, operatorKind: kNone, isDeprecated,
-					isUnavailable, isMutating, isRequired, isProperty, isAsync: false, attributes);
+					isUnavailable, isMutating, isRequired, isProperty, isAsync: isAsync, attributes);
 
 				currentElement.Push (getFunc);
 				var getParamLists = new XElement (kParameterLists, MakeInstanceParameterList (), getParamList);
@@ -2001,6 +2003,11 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					return result;
 			}
 			return kInternalCap;
+		}
+
+		static bool HasAsync (Getter_keyword_clauseContext context)
+		{
+			return context == null ? false : context.async_clause () != null;
 		}
 
 		static bool ModifiersContains (Declaration_modifiersContext context, string match)

--- a/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/PropertyDeclaration.cs
@@ -49,6 +49,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public bool IsDeprecated { get; set; }
 		public bool IsUnavailable { get; set; }
 		public bool IsOptional { get; set; }
+		public bool IsAsync {
+			get {
+				var getter = GetGetter ();
+				return getter == null ? false : getter.IsAsync;
+			}
+		}
 
 		public FunctionDeclaration GetGetter ()
 		{

--- a/SwiftReflector/SwiftXmlReflection/SubscriptDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/SubscriptDeclaration.cs
@@ -14,6 +14,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public FunctionDeclaration Getter { get; set; }
 		public FunctionDeclaration Setter { get; set; }
 		public FunctionDeclaration Materializer { get; set; }
+		public bool IsAsync => Getter.IsAsync;
 	}
 }
 

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -68,7 +68,7 @@ getter_setter_keyword_block :
 	;
 
 
-getter_keyword_clause : attributes? mutation_modifier? 'get' ;
+getter_keyword_clause : attributes? mutation_modifier? 'get' async_clause? ;
 setter_keyword_clause : attributes? mutation_modifier? 'set' |
 	attributes? mutation_modifier? 'set' OpLParen new_value_name OpRParen ;
 

--- a/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/SwiftInterfaceParserTests.cs
@@ -764,5 +764,207 @@ public protocol bar {
 			Assert.IsNotNull (fn, "no function");
 			Assert.IsFalse (fn.IsAsync, "not async");
 		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestAsyncPropertyPresent ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	var _x = 4
+	public var x:Int {
+		get async {
+			return _x
+		}
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllProperties ().FirstOrDefault (p => p.Name == "x");
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.GetGetter ();
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+			Assert.IsTrue (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		public void TestAsyncPropertyNotPresent ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	var _x = 4
+	public var x:Int {
+		get {
+			return _x
+		}
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllProperties ().FirstOrDefault (p => p.Name == "x");
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.GetGetter ();
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+			Assert.IsFalse (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestAsyncSubscriptPresent ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	public subscript(a: Int) -> Int {
+		get async {
+			return a * 2;
+		}
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllSubscripts ().FirstOrDefault ();
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.Getter;
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+			Assert.IsTrue (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		public void TestAsyncSubscriptNotPresent ()
+		{
+			var code = @"
+public class bar {
+	public init () { }
+	public subscript(a: Int) -> Int {
+		get {
+			return a * 2;
+		}
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllClasses.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllSubscripts ().FirstOrDefault ();
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.Getter;
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+			Assert.IsFalse (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestProtocolPropertyAsyncPresent ()
+		{
+			var code = @"
+public protocol bar {
+	var x:Int {
+		get async
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllProperties ().FirstOrDefault (p => p.Name == "x");
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.GetGetter ();
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+			Assert.IsTrue (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		public void TestProtocolPropertyAsyncNotPresent ()
+		{
+			var code = @"
+public protocol bar {
+	var x:Int {
+		get
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllProperties ().FirstOrDefault (p => p.Name == "x");
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.GetGetter ();
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+			Assert.IsFalse (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		[Ignore ("not until we update to 5.5")]
+		public void TestProtocolAsyncSubscriptPresent ()
+		{
+			var code = @"
+public protocol bar {
+	subscript(a: Int) -> Int {
+		get async
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllSubscripts ().FirstOrDefault ();
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.Getter;
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsTrue (fn.IsAsync, "not async");
+			Assert.IsTrue (prop.IsAsync, "prop not async");
+		}
+
+		[Test]
+		public void TestProtocolAsyncSubscriptNotPresent ()
+		{
+			var code = @"
+public protocol bar {
+	subscript(a: Int) -> Int {
+		get
+	}
+}
+";
+			SwiftInterfaceReflector reflector;
+			var module = ReflectToModules (code, "SomeModule", out reflector).Find (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "not a module");
+			var cl = module.AllProtocols.FirstOrDefault (c => c.Name == "bar");
+			Assert.IsNotNull (cl, "no class");
+			var prop = cl.AllSubscripts ().FirstOrDefault ();
+			Assert.IsNotNull (prop, "no property");
+			var fn = prop.Getter;
+			Assert.IsNotNull (fn, "no function");
+			Assert.IsFalse (fn.IsAsync, "not async");
+			Assert.IsFalse (prop.IsAsync, "prop not async");
+		}
 	}
 }


### PR DESCRIPTION
When I did the initial cut of async in the SwiftInterfaceParser grammar, I went from the published grammar [here](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#), but it turns out that once I started playing with the language that the documentation is missing this (opened an issue [here](https://bugs.swift.org/browse/SR-15019)).

async can appear in precisely two places:

1. after the function args (and before throws/rethrows)
2. after the `get` keyword

Notable - you cannot have async setters. There's probably a good reason for that likely tied to how they handle, but I think it leaves a functional hole in the language.  For example:

```swift
public class ProfileStore {
    // setting or retrieving the profile might be slow, so let's make them async
    public func getProfile () async -> Profile { /* ... */ }
    public func setProfile (newValue: Profile) async { /* ... */}
    // but what if we wanted to make this a property?
    public var profile: Profile {
        get async { /* legal */}
        set async { /* illegal */} // can't have a setter at all
    }
}
```

So yeah. Moar tests.