### PR TITLE
fix up minor issues with closure parsing

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
@@ -57,11 +57,15 @@ namespace SwiftReflector.SwiftXmlReflection {
 				TupleTypeSpec tuple = ParseTuple ();
 				type = tuple.Elements.Count == 1 ? tuple.Elements [0] : tuple;
 				typeLabel = type.TypeLabel;
+				type.TypeLabel = null;
 			} else if (token.Kind == TypeTokenKind.TypeName) { // name
 				tokenizer.Next ();
 				var tokenValue = token.Value.StartsWith ("ObjectiveC.", StringComparison.Ordinal) ?
 						      "Foundation" + token.Value.Substring ("ObjectiveC".Length) : token.Value;
-				type = new NamedTypeSpec (tokenValue);
+				if (tokenValue == "Swift.Void")
+					type = TupleTypeSpec.Empty;
+				else
+					type = new NamedTypeSpec (tokenValue);
 			} else if (token.Kind == TypeTokenKind.LeftBracket) { // array
 				tokenizer.Next ();
 				type = ParseArray ();

--- a/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
@@ -791,7 +791,6 @@ open class SecondClass : FirstClass {
 		}
 
 		[Test]
-		[Ignore ("failing in Xcode 13 https://github.com/xamarin/binding-tools-for-swift/issues/737")]
 		public void TestClosureProp ()
 		{
 			var swiftCode = @"

--- a/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
@@ -366,6 +366,19 @@ namespace XmlReflectionTests {
 			var same = inType.ReplaceName ("Blah", "Slarty.Bartfast") as ProtocolListTypeSpec;
 			Assert.AreEqual (same, inType, "changed?!");
 		}
+
+		[Test]
+		public void TestWeirdClosureIssue ()
+		{
+			var inType = TypeSpecParser.Parse ("@escaping[] (_onAnimation:Swift.Bool)->Swift.Void");
+			Assert.IsTrue (inType is ClosureTypeSpec, "not closure");
+			var closSpec = inType as ClosureTypeSpec;
+			Assert.IsTrue (closSpec.IsEscaping, "not escaping");
+			var textRep = closSpec.ToString ();
+			var firstIndex = textRep.IndexOf ("_onAnimation");
+			var lastIndex = textRep.LastIndexOf ("_onAnimation");
+			Assert.IsTrue (firstIndex == lastIndex);
+		}
 	}
 }
 


### PR DESCRIPTION
This fixed issue [737](https://github.com/xamarin/binding-tools-for-swift/issues/737).

Swift 5.5 was generating two things in the `.swiftinterface` that were new to us:
1. arguments in closure parameter types
2. `Swift.Void` as a type

The first thing exposed a bug where we promoted the type label from a singleton tuple to the enclosing type but didn't clear the one in the contained type. This would generate two type labels instead of one.

The second thing we didn't know how to handle `Swift.Void` so I special cased the parser such that if it gets `Swift.Void` it turns it into `()` which we already know how to handle.

Added a test for the double type label and unignored the test that was failing in Swift 5.5

