### PR TITLE
Fixed two more failing Swift 5.5 tests

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -346,8 +346,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			while (members != null) {
 				if (members.union_style_enum_member () != null) {
 					var member = members.union_style_enum_member ();
-					if (member.declaration ()?.typealias_declaration () != null)
-						yield return member.declaration ().typealias_declaration ();
+					if (member.nominal_declaration ()?.typealias_declaration () != null)
+						yield return member.nominal_declaration ().typealias_declaration ();
 				}
 				members = members.union_style_enum_members ();
 			}

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -360,8 +360,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			while (members != null) {
 				if (members.raw_value_style_enum_member () != null) {
 					var member = members.raw_value_style_enum_member ();
-					if (member.declaration ()?.typealias_declaration () != null)
-						yield return member.declaration ().typealias_declaration ();
+					if (member.nominal_declaration ()?.typealias_declaration () != null)
+						yield return member.nominal_declaration ().typealias_declaration ();
 				}
 				members = members.raw_value_style_enum_members ();
 			}

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -25,6 +25,23 @@ declaration:
 	| struct_declaration
 	| class_declaration
 	| protocol_declaration
+	| extension_declaration
+// technically wrong since this can't be at top level
+// but the swift compiler will never generate a top-level subscript
+// so...
+	| subscript_declaration
+	| operator_declaration
+	| precedence_group_declaration
+	;
+
+nominal_declaration :
+	 variable_declaration
+	| typealias_declaration
+	| function_declaration
+	| enum_declaration
+	| struct_declaration
+	| class_declaration
+	| protocol_declaration
 	| initializer_declaration
 	| deinitializer_declaration
 	| extension_declaration
@@ -35,7 +52,6 @@ declaration:
 	| operator_declaration
 	| precedence_group_declaration
 	;
-
 
 
 import_statement: attributes? 'import' import_kind? import_path ;
@@ -89,7 +105,7 @@ union_style_enum : 'indirect'? 'enum' enum_name generic_parameter_clause? type_i
 union_style_enum_members : union_style_enum_member union_style_enum_members? ;
 
 union_style_enum_member :
-	declaration
+	nominal_declaration
 	| union_style_enum_case_clause 
 	;
 
@@ -111,7 +127,7 @@ raw_value_style_enum : 'enum' enum_name generic_parameter_clause? type_inheritan
 raw_value_style_enum_members : raw_value_style_enum_member raw_value_style_enum_members? ;
 
 raw_value_style_enum_member : 
-	declaration
+	nominal_declaration
 	| raw_value_style_enum_case_clause
 	;
 
@@ -132,7 +148,7 @@ struct_declaration : attributes? access_level_modifier? 'struct' struct_name gen
 struct_name : declaration_identifier  ;
 struct_body : OpLBrace struct_member* OpRBrace  ;
 
-struct_member : declaration ;
+struct_member : nominal_declaration ;
 
 // class
 
@@ -143,7 +159,7 @@ class_declaration :
 
 class_name : declaration_identifier ;
 class_body : OpLBrace class_member* OpRBrace ;
-class_member : declaration ;
+class_member : nominal_declaration ;
 final_clause : 'final' ;
 
 protocol_declaration : attributes? access_level_modifier? 'protocol' protocol_name type_inheritance_clause? protocol_body ;
@@ -303,7 +319,7 @@ class_requirement : 'class' ;
 
 
 attribute : OpAt attribute_name attribute_argument_clause? ;
-attribute_name : declaration_identifier ;
+attribute_name : declaration_identifier | attribute_name OpDot declaration_identifier ;
 attribute_argument_clause : OpLParen balanced_tokens OpRParen;
 attributes : attribute+ ;
 

--- a/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NSObjectTests.cs
@@ -306,7 +306,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("getting a conflict in the C# wrapping (check signature?) ")]
 		public void NSImageViewSmokeTest1 ()
 		{
 			string swiftCode =
@@ -375,7 +374,6 @@ namespace SwiftReflector {
 
 
 		[Test]
-		[Ignore ("failing in Xcode 13 https://github.com/xamarin/binding-tools-for-swift/issues/739")]
 		public void NSImageViewSmokeTest4 ()
 		{
 			string swiftCode =


### PR DESCRIPTION
Fixes issues [738](https://github.com/xamarin/binding-tools-for-swift/issues/738) and [739](https://github.com/xamarin/binding-tools-for-swift/issues/739).

What's going on:
In Swift 5.5, if you declare an ObjC class the compiler will add a new attribute to some of the declarations: `@_Concurrency.MainActor`. This is an issue because the published swift grammar doesn't allow periods in names, yet here we are. I opened [this issue](https://bugs.swift.org/browse/SR-15050) with Apple so that they fix the grammar.

I adjusted the parser grammar in two ways. The first was to make a separate rule for nominal declarations which includes `init` and `deinit` and removed that from the `declaration` rule. Second, I adjusted the rule for attributes to allow the identifier to have period separators. I do not know if they allow arbitrary depth, but until they correct the grammar, this is what it is.

Tests pass.