### PR TITLE
Attributes are types.

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/AttributeDeclaration.cs
+++ b/SwiftReflector/SwiftXmlReflection/AttributeDeclaration.cs
@@ -9,9 +9,9 @@ using System.Linq;
 
 namespace SwiftReflector.SwiftXmlReflection {
 	public class AttributeDeclaration {
-		public AttributeDeclaration (string name)
+		public AttributeDeclaration (string typeName)
 		{
-			Name = Exceptions.ThrowOnNull (name, nameof (name));
+			Name = Exceptions.ThrowOnNull (typeName, nameof (typeName));
 			Parameters = new List<AttributeParameter> ();
 		}
 
@@ -56,7 +56,20 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		public string Name { get; private set; }
+		public NamedTypeSpec AttributeType { get; private set; }
+		public string Name {
+			get {
+				return AttributeType.ToString (true);
+			}
+			private set {
+				Exceptions.ThrowOnNull (value, nameof (value));
+				var ts = TypeSpecParser.Parse (value);
+				if (ts is NamedTypeSpec named)
+					AttributeType = named;
+				else
+					throw new ArgumentOutOfRangeException ($"TypeSpec for {value} is a {ts.Kind} and not a named type spec");
+			}
+		}
 		public List<AttributeParameter> Parameters { get; private set; }
 	}
 

--- a/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
@@ -379,6 +379,23 @@ namespace XmlReflectionTests {
 			var lastIndex = textRep.LastIndexOf ("_onAnimation");
 			Assert.IsTrue (firstIndex == lastIndex);
 		}
+
+		[Test]
+		public void TestAttributeParsing ()
+		{
+			var inAttributeType = "Foo.Bar<Baz<Frobozz>>";
+			var attribute = new AttributeDeclaration (inAttributeType);
+			var attrType = attribute.AttributeType;
+			Assert.AreEqual ("Foo.Bar", attrType.Name, "wrong type name");
+			Assert.IsTrue (attrType.GenericParameters.Count == 1, "no first generic");
+			var inner = attrType.GenericParameters [0] as NamedTypeSpec;
+			Assert.IsNotNull (inner, "first is not a named type spec");
+			Assert.AreEqual ("Baz<Frobozz>", inner.ToString (), "wrong first type spec");
+			Assert.IsTrue (inner.GenericParameters.Count == 1, "no second generic");
+			inner = inner.GenericParameters [0] as NamedTypeSpec;
+			Assert.IsNotNull (inner, "second is not a named type spec");
+			Assert.AreEqual ("Frobozz", inner.ToString (), "wrong second type spec");
+		}
 	}
 }
 


### PR DESCRIPTION
Make the attribute name a full `NamedTypeSpec` fixing issue [746](https://github.com/xamarin/binding-tools-for-swift/issues/746).
In [discussing the grammar of attributes with people at Apple](https://bugs.swift.org/browse/SR-15050), it became clear that the name of an Attribute is much more complicated than it appears. It's best to treat this as a `NamedTypeSpec`, so we do.

There are no dependencies on the name of attributes (yet), so yay for early refactoring.