### PR TITLE
Add async support to TypeSpec

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -615,6 +615,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public TypeSpec Arguments { get; set; }
 		public TypeSpec ReturnType { get; set; }
 		public bool Throws { get; set; }
+		public bool IsAsync { get; set; }
 
 		public bool HasReturn ()
 		{

--- a/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
@@ -26,6 +26,9 @@ namespace SwiftReflector.SwiftXmlReflection {
 			List<TypeSpecAttribute> attrs = null;
 			var inout = false;
 			string typeLabel = null;
+			var throwsClosure = false;
+			var asyncClosure = false;
+			var expectClosure = false;
 
 			// Prefix
 
@@ -73,18 +76,26 @@ namespace SwiftReflector.SwiftXmlReflection {
 				throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 0, $"Unexpected token {token.Value}.");
 			}
 
-			// look-ahead for closure
-			if (tokenizer.Peek ().Kind == TypeTokenKind.TypeName && tokenizer.Peek ().Value == "throws") {
+			if (tokenizer.NextIs ("async")) {
 				tokenizer.Next ();
-				if (tokenizer.Peek ().Kind != TypeTokenKind.Arrow)
-					throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 1, $"Unexpected token {tokenizer.Peek ().Value} after a 'throws' in a closure.");
+				asyncClosure = true;
+				expectClosure = true;
+			}
+
+			if (tokenizer.NextIs ("throws")) {
 				tokenizer.Next ();
-				type = ParseClosure (type, true);
+				throwsClosure = true;
+				expectClosure = true;
 			}
 
 			if (tokenizer.Peek ().Kind == TypeTokenKind.Arrow) {
 				tokenizer.Next ();
-				type = ParseClosure (type, false);
+				type = ParseClosure (type, throwsClosure, asyncClosure);
+				expectClosure = false;
+				throwsClosure = false;
+				asyncClosure = false;
+			} else if (expectClosure) {
+				throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 1, $"Unexpected token {tokenizer.Peek ().Value} after a 'throws' in a closure.");
 			} else if (tokenizer.Peek ().Kind == TypeTokenKind.LeftAngle) {
 				tokenizer.Next ();
 				type = Genericize (type);
@@ -260,7 +271,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 		}
 
-		ClosureTypeSpec ParseClosure (TypeSpec arg, bool throws)
+		ClosureTypeSpec ParseClosure (TypeSpec arg, bool throws, bool isAsync)
 		{
 			TypeSpec returnType = Parse ();
 			if (returnType == null)
@@ -269,6 +280,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			closure.Arguments = arg;
 			closure.ReturnType = returnType;
 			closure.Throws = throws;
+			closure.IsAsync = isAsync;
 			return closure;
 		}
 

--- a/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
@@ -95,7 +95,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				throwsClosure = false;
 				asyncClosure = false;
 			} else if (expectClosure) {
-				var errorCase = asyncClosure && throwsClosure ? "'async throws'" : asyncClosure ? 'async' : 'throws';
+				var errorCase = asyncClosure && throwsClosure ? "'async throws'" : asyncClosure ? "'async'" : "'throws'";
 				throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 1, $"Unexpected token {tokenizer.Peek ().Value} after {errorCase} in a closure.");
 			} else if (tokenizer.Peek ().Kind == TypeTokenKind.LeftAngle) {
 				tokenizer.Next ();

--- a/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
@@ -95,7 +95,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 				throwsClosure = false;
 				asyncClosure = false;
 			} else if (expectClosure) {
-				throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 1, $"Unexpected token {tokenizer.Peek ().Value} after a 'throws' in a closure.");
+				var errorCase = asyncClosure && throwsClosure ? "'async throws'" : asyncClosure ? 'async' : 'throws';
+				throw ErrorHelper.CreateError (ReflectorError.kTypeParseBase + 1, $"Unexpected token {tokenizer.Peek ().Value} after {errorCase} in a closure.");
 			} else if (tokenizer.Peek ().Kind == TypeTokenKind.LeftAngle) {
 				tokenizer.Next ();
 				type = Genericize (type);

--- a/SwiftReflector/SwiftXmlReflection/TypeSpecTokenizer.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecTokenizer.cs
@@ -85,6 +85,11 @@ namespace SwiftReflector.SwiftXmlReflection {
 			return token;
 		}
 
+		public bool NextIs (string name)
+		{
+			return Peek ().Kind == TypeTokenKind.TypeName && Peek ().Value == name;
+		}
+
 		TypeSpecToken DoName ()
 		{
 			int curr = reader.Peek ();

--- a/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/TypeSpecParserTests.cs
@@ -396,6 +396,33 @@ namespace XmlReflectionTests {
 			Assert.IsNotNull (inner, "second is not a named type spec");
 			Assert.AreEqual ("Frobozz", inner.ToString (), "wrong second type spec");
 		}
+
+		[Test]
+		public void TestAsyncClosure ()
+		{
+			var inType = TypeSpecParser.Parse ("() async -> ()") as ClosureTypeSpec;
+			Assert.IsNotNull (inType, "not a closure");
+			Assert.IsTrue (inType.IsAsync, "not async");
+			Assert.IsFalse (inType.Throws, "doesn't throw");
+		}
+
+		[Test]
+		public void TestAsyncThrowsClosure ()
+		{
+			var inType = TypeSpecParser.Parse ("() async throws -> ()") as ClosureTypeSpec;
+			Assert.IsNotNull (inType, "not a closure");
+			Assert.IsTrue (inType.IsAsync, "not async");
+			Assert.IsTrue (inType.Throws, "doesn't throw");
+		}
+
+		[Test]
+		public void TestThrowsClosure ()
+		{
+			var inType = TypeSpecParser.Parse ("() throws -> ()") as ClosureTypeSpec;
+			Assert.IsNotNull (inType, "not a closure");
+			Assert.IsFalse (inType.IsAsync, "not async");
+			Assert.IsTrue (inType.Throws, "doesn't throw");
+		}
 	}
 }
 


### PR DESCRIPTION
Added support for async to `ClosureTypeSpec`

This involves a property in `ClosureTypeSpec` as a change in the parser.

The folks at Apple are really clear in the WWDC videos that the ordering of the `async` and `throws` keywords are and always will be `async` first and `throws` second.

Added a tool to peek ahead for a specific keyword.

Added unit tests.