### PR TITLE
Func<T...> can throw now

### DIFF
--- a/Dynamo/Dynamo.SwiftLang/SLArgument.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLArgument.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 
 namespace Dynamo.SwiftLang {
 	public class SLArgument : DelegatedSimpleElement {
@@ -8,6 +9,11 @@ namespace Dynamo.SwiftLang {
 			Identifier = identifierIsRequired ? Exceptions.ThrowOnNull (ident, nameof(ident)) : ident;
 			Expr = Exceptions.ThrowOnNull (expr, nameof(expr));
 			IdentifierIsRequired = identifierIsRequired;
+		}
+
+		public SLArgument (string ident, SLBaseExpr expr, bool identifierIsRequired = false)
+			: this (!String.IsNullOrEmpty (ident) ? new SLIdentifier (ident) : null, expr, identifierIsRequired)
+		{
 		}
 
 		protected override void LLWrite (ICodeWriter writer, object o)

--- a/Dynamo/Dynamo.SwiftLang/SLType.cs
+++ b/Dynamo/Dynamo.SwiftLang/SLType.cs
@@ -223,12 +223,13 @@ namespace Dynamo.SwiftLang {
 
 
 	public class SLFuncType : SLType {
-		public SLFuncType (SLType argType, SLType retType)
-			: this (retType, ConvertSLTypeToParameters (argType))
+		public SLFuncType (SLType argType, SLType retType, bool hasThrows = false, bool isAsync = false)
+			: this (retType, ConvertSLTypeToParameters (argType), hasThrows, isAsync)
 		{
 		}
 
-		public SLFuncType (SLType retType, IEnumerable<SLUnnamedParameter> parameters)
+		public SLFuncType (SLType retType, IEnumerable<SLUnnamedParameter> parameters,
+			bool hasThrows = false, bool isAsync = false)
 		{
 			Exceptions.ThrowOnNull (parameters, nameof (parameters));
 			Attributes = new List<SLAttribute> ();
@@ -236,11 +237,15 @@ namespace Dynamo.SwiftLang {
 			if (parameters != null)
 				Parameters.AddRange (parameters);
 			ReturnType = Exceptions.ThrowOnNull (retType, nameof (retType));
+			Throws = hasThrows;
+			IsAsync = isAsync;
 		}
 
 		public List<SLUnnamedParameter> Parameters { get; private set; }
 		public SLType ReturnType { get; private set; }
 		public List<SLAttribute> Attributes { get; private set; }
+		public bool Throws { get; private set; }
+		public bool IsAsync { get; private set; }
 
 		protected override void LLWrite (ICodeWriter writer, object o)
 		{
@@ -254,7 +259,14 @@ namespace Dynamo.SwiftLang {
 					writer.Write (", ", true);
 				Parameters [i].WriteAll (writer);
 			}
-			writer.Write (") -> ", true);
+			writer.Write (") ", true);
+			if (IsAsync) {
+				writer.Write ("async ", true);
+			}
+			if (Throws) {
+				writer.Write ("throws", true);
+			}
+			writer.Write ("-> ", true);
 			ReturnType.WriteAll (writer);
 		}
 

--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -305,6 +305,7 @@ namespace SwiftReflector {
 
 						RequiredUnsafeCode = true;
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.None));
 					} else if (returnEntity != null && returnEntity.EntityType == EntityType.Struct) {
 						// if the struct is non blitable, we need to do something like this:
@@ -318,6 +319,7 @@ namespace SwiftReflector {
 						absolutelyMustBeFirst.Add (CreateNominalCall (returnType, returnIdent, returnType, returnEntity));
 
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.None));
 					} else if (returnEntity != null && (returnEntity.EntityType == EntityType.Class || returnEntity.IsObjCProtocol)) {
 						returnIntPtr = new CSIdentifier (Uniqueify ("retvalIntPtr", identifiersUsed));
@@ -344,6 +346,7 @@ namespace SwiftReflector {
 						}
 						preMarshalCode.Insert (0, CSVariableDeclaration.VarLine (returnType, returnIdent, initialValue));
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.None));
 					} else if (swiftReturnType is TupleTypeSpec) {
 						RequiredUnsafeCode = true;
@@ -356,15 +359,18 @@ namespace SwiftReflector {
 
 						preMarshalCode.Add (CSVariableDeclaration.VarLine (returnType, returnIdent, ctorCall));
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.None));
 					} else if (returnIsGeneric || returnIsProtocolList || returnIsAssocPath) {
 						use.AddIfNotPresent (typeof (StructMarshal));
 						preMarshalCode.Add (CSVariableDeclaration.VarLine (returnType, returnIdent, returnType.Default ()));
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.None));
 					} else if (returnIsTrivialEnum) {
 						absolutelyMustBeFirst.Add (CSVariableDeclaration.VarLine (returnType, returnIdent, CSFunctionCall.Default ((CSSimpleType)returnType)));
 						indexOfReturn = 0;
+						indexOfInstance = 1;
 						parms.Insert (0, new CSParameter (returnType, returnIdent, CSParameterKind.Out));
 					}
 				}

--- a/SwiftReflector/MarshalEngine.cs
+++ b/SwiftReflector/MarshalEngine.cs
@@ -97,11 +97,6 @@ namespace SwiftReflector {
 				callParameters.Add (Marshal (classDecl, wrapperFunc, parms [i], filteredTypes [i], false, false, originalParamType));
 			}
 
-			//var callParameters = parms.Select ((p, i) => {
-			//	skipThisParameterPremarshal = skipThisParam && i == 0;
-			//	return Marshal (classDecl, wrapperFunc, p, filteredTypes [i], false, false, null);
-			//}).ToList ();
-
 			// class objects need a class constructor parameter, not so structs.
 			if (entity.EntityType != EntityType.Struct) {
 				callParameters.Add (new CSFunctionCall ($"{cl.ToCSType ().ToString ()}.GetSwiftMetatype", false));
@@ -398,10 +393,6 @@ namespace SwiftReflector {
 				callParameters.Add (Marshal (typeContext, wrapperFuncDecl, p, filteredTypeSpec [i], instanceIsSwiftProtocol && i == indexOfInstance,
 							 indexOfReturn >= 0 && i == indexOfReturn, originalParm));
 			}
-
-			//var callParameters = parms.Select ((p, i) => Marshal (typeContext, wrapperFuncDecl, p, filteredTypeSpec [i], instanceIsSwiftProtocol && i == indexOfInstance,
-			//                             indexOfReturn >= 0 && i == indexOfReturn)).ToList ();
-
 
 			if (wrapperFuncDecl.ContainsGenericParameters) {
 				AddExtraGenericParameters (wrapperFuncDecl, callParameters);

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -504,7 +504,7 @@ namespace SwiftReflector {
 				var codeBlock = wrapperProp != null ? wrapperProp.Getter : wrapperGetter.Body;
 				codeBlock.AddRange (marshaler.MarshalFunctionCall (getterWrapperFunc, false,
 					piGetterRef, new CSParameterList (), getterWrapperFunc, prop.TypeSpec, 
-					wrapperProp?.PropType ?? wrapperGetter.Type, null, new CSSimpleType (cl.Name.Name), false, wrapper));
+					wrapperProp?.PropType ?? wrapperGetter.Type, null, new CSSimpleType (cl.Name.Name), false, getter));
 
 
 																			
@@ -523,7 +523,7 @@ namespace SwiftReflector {
 				var codeBlock = wrapperProp != null ? wrapperProp.Setter : wrapperSetter.Body;
 				codeBlock.AddRange (marshaler.MarshalFunctionCall (setterWrapperFunc, false,
 					piSetterRef, new CSParameterList (valParm), getterWrapperFunc, null, CSSimpleType.Void,
-					null, new CSSimpleType (cl.Name.Name), false, wrapper));
+					null, new CSSimpleType (cl.Name.Name), false, setter));
 
 			}
 
@@ -649,7 +649,7 @@ namespace SwiftReflector {
 
 			var lines = marshaler.MarshalFunctionCall (wrapperFunc, false, pinvokeMethodRef,
 				publicMethod.Parameters, func, func.ReturnTypeSpec, publicMethod.Type,
-				null, null, false, wrapper, false, -1, func.HasThrows);
+				null, null, false, func, false, -1, func.HasThrows);
 
 			publicMethod.Body.AddRange (lines);
 			methods.Add (publicMethod);
@@ -706,7 +706,7 @@ namespace SwiftReflector {
 
 			var marshaler = new MarshalEngine (use, localIdents, TypeMapper, wrapper.Module.SwiftCompilerVersion);
 			var lines = marshaler.MarshalFunctionCall (func, false, pinvokeMethodRef, publicMethod.Parameters,
-				func, func.ReturnTypeSpec, publicMethod.Type, null, null, false, wrapper,
+				func, func.ReturnTypeSpec, publicMethod.Type, null, null, false, func,
 				false, -1, func.HasThrows);
 			publicMethod.Body.AddRange (lines);
 			methods.Add (publicMethod);
@@ -938,7 +938,7 @@ namespace SwiftReflector {
 
 			var callingCode1 = marshal1.MarshalFunctionCall (caseFinderWrapperFunc, false, caseFinderRef,
 				new CSParameterList (), enumDecl, caseFinderWrapperFunc.ReturnTypeSpec, new CSSimpleType (enumCaseName),
-				caseFinderWrapperFunc.ParameterLists.Last () [0].TypeSpec, enumClass.ToCSType (), true, wrapper, true).ToList ();
+				caseFinderWrapperFunc.ParameterLists.Last () [0].TypeSpec, enumClass.ToCSType (), true, caseFinderWrapperFunc, true).ToList ();
 
 			var caseProp = new CSProperty (new CSSimpleType (enumCaseName), CSMethodKind.None, new CSIdentifier (finderMethodName),
 						    CSVisibility.Public, callingCode1, CSVisibility.Public, null);
@@ -1021,7 +1021,7 @@ namespace SwiftReflector {
 
 			var marshal = new MarshalEngine (use, localUsedNames, TypeMapper, wrapper.Module.SwiftCompilerVersion);
 			var callingCode = marshal.MarshalFunctionCall (wrappingFunc, false, pinvokeRef, factoryMethod.Parameters, factoryDecl,
-			                                               returnTypeSpec, csEnumType, null, null, false, wrapper, false,
+			                                               returnTypeSpec, csEnumType, null, null, false, factoryDecl, false,
 			                                              -1, false);
 			factoryMethod.Body.AddRange (callingCode);
 			return factoryMethod;
@@ -1092,7 +1092,7 @@ namespace SwiftReflector {
 			var callingCode = marshal.MarshalFunctionCall (wrappingFunc, false, pinvokeRef, new CSParameterList (),
 								       enumDecl, element.TypeSpec, payloadFunc.Type,
 								       new NamedTypeSpec (enumDecl.ToFullyQualifiedName (true)),
-								       csEnumType, false, wrapper, false);
+								       csEnumType, false, payloadDecl, false);
 			payloadFunc.Body.AddRange (callingCode);
 			cl.Methods.Add (payloadFunc);
 
@@ -2321,7 +2321,7 @@ namespace SwiftReflector {
 				pl.AddRange (wrapperProp.IndexerParameters);
 				pl.Insert (0, new CSParameter (wrapperProp.PropType, new CSIdentifier ("value")));
 				elseBlock.AddRange (marshal.MarshalFunctionCall (etterWrapperFunc, false, piEtterRef, pl,
-				                                                          etterFunc, null, CSSimpleType.Void, etterFunc.ParameterLists [0] [0].TypeSpec, iface.ToCSType (), false, wrapper,
+				                                                          etterFunc, null, CSSimpleType.Void, etterFunc.ParameterLists [0] [0].TypeSpec, iface.ToCSType (), false, etterFunc,
 											  etterFunc.HasThrows));
 			} else {
 				ifBlock.Add (CSReturn.ReturnLine (indexerExpr));
@@ -2329,7 +2329,7 @@ namespace SwiftReflector {
 				elseBlock.AddRange (marshal.MarshalFunctionCall (etterWrapperFunc, false, piEtterRef, wrapperProp.IndexerParameters,
 				                                                          etterFunc, etterFunc.ReturnTypeSpec, wrapperProp.PropType,
 				                                                          etterFunc.ParameterLists [0] [0].TypeSpec,
-				                                                          iface.ToCSType (), false, wrapper,
+				                                                          iface.ToCSType (), false, etterFunc,
 											  etterFunc.HasThrows));
 			}
 
@@ -2604,13 +2604,13 @@ namespace SwiftReflector {
 				var p = new CSParameter (wrapperProp.PropType, new CSIdentifier ("value"));
 				var pl = new CSParameterList (p);
 				elseBlock.AddRange (marshal.MarshalFunctionCall (etterWrapperFunc, false, piEtterRef, pl,
-											  etterFunc, null, CSSimpleType.Void, etterFunc.ParameterLists [0] [0].TypeSpec, proxyClass.ToCSType (), false, wrapper, etterFunc.HasThrows,
+											  etterFunc, null, CSSimpleType.Void, etterFunc.ParameterLists [0] [0].TypeSpec, proxyClass.ToCSType (), false, etterFunc, etterFunc.HasThrows,
 											  restoreDynamicSelf: !protocolDecl.IsExistential));
 			} else {
 				ifBlock.Add (CSReturn.ReturnLine (kInterfaceImpl.Dot (wrapperProp.Name)));
 				target = wrapperProp.Getter;
 				elseBlock.AddRange (marshal.MarshalFunctionCall (etterWrapperFunc, false, piEtterRef, new CSParameterList (),
-											  etterFunc, etterFunc.ReturnTypeSpec, wrapperProp.PropType, etterFunc.ParameterLists [0] [0].TypeSpec, proxyClass.ToCSType (), false, wrapper, etterFunc.HasThrows,
+											  etterFunc, etterFunc.ReturnTypeSpec, wrapperProp.PropType, etterFunc.ParameterLists [0] [0].TypeSpec, proxyClass.ToCSType (), false, etterFunc, etterFunc.HasThrows,
 											  restoreDynamicSelf: !protocolDecl.IsExistential));
 			}
 
@@ -3935,7 +3935,7 @@ namespace SwiftReflector {
 				engine.GenericReferenceNamer = genericNamer;
 
 				privateConsImpl.Body.AddRange(engine.MarshalFunctionCall (wrapperFunc, false, pictorRef,
-					publicCons.Parameters, funcDecl, funcDecl.ReturnTypeSpec, CSSimpleType.IntPtr, null, null, false, wrapper));
+					publicCons.Parameters, funcDecl, funcDecl.ReturnTypeSpec, CSSimpleType.IntPtr, null, null, false, funcDecl));
 					
 				var privateConsImplID = $"{cl.ToCSType ().ToString ()}.{privateConsImpl.Name.Name}";
 
@@ -4252,7 +4252,7 @@ namespace SwiftReflector {
 
 					publicCons.Body.AddRange (engine.MarshalFunctionCall (wrapperFunc, false, pinvokeConsRef,
 						publicCons.Parameters, enumDecl, funcDecl.ReturnTypeSpec, csReturnType, swiftInstanceType: null,
-						instanceType: null, includeCastToReturnType: true, wrapper, includeIntermediateCastToLong: true));
+						instanceType: null, includeCastToReturnType: true, funcDecl, includeIntermediateCastToLong: true));
 
 					en.Methods.Add (publicCons);
 					picl.Methods.Add (piConstructor);
@@ -4717,7 +4717,7 @@ namespace SwiftReflector {
 				getter.Parameters.Add (new CSParameter (thisCSType, new CSIdentifier ("this0"), propDecl.Parent.IsNested ? CSParameterKind.None : CSParameterKind.This));
 
 				getter.Body.AddRange (marshaler.MarshalFunctionCall (getterWrapperFunc, false, piGetterRef, getter.Parameters,
-					propDecl.GetGetter (), propDecl.GetGetter ().ReturnTypeSpec, getter.Type, null, null, false, wrapper));
+					propDecl.GetGetter (), propDecl.GetGetter ().ReturnTypeSpec, getter.Type, null, null, false, propGetter));
 
 				cl.Methods.Add (getter);
 
@@ -4910,7 +4910,7 @@ namespace SwiftReflector {
 			var methodContents = marshaler.MarshalFunctionCall (wrapperFunctionDecl, methodToWrap.IsExtension, pinvokeMethodRef, publicMethod.Parameters,
 										   methodToWrap, methodToWrap.ReturnTypeSpec, publicMethod.Type,
 										   instanceTypeSpec, csInstanceType,
-										   false, wrapper, methodToWrap.HasThrows, restoreDynamicSelf: restoreDynamicSelf);
+										   false, methodToWrap, methodToWrap.HasThrows, restoreDynamicSelf: restoreDynamicSelf);
 
 			if (methodToWrap.IsProtocolMember || genericReferenceNamer != null) {
 				var ifRedirect = InterfaceMethodRedirect (publicMethod, methodContents);
@@ -5017,7 +5017,7 @@ namespace SwiftReflector {
 
 			publicMethod.Body.AddRange (marshaler.MarshalFunctionCall (wrapperFuncDecl, false, pinvokeMethodRef,
 				publicMethod.Parameters, funcToWrap, funcToWrap.ReturnTypeSpec, publicMethod.Type, instanceTypeSpec, cl.ToCSType (),
-				false, wrapper, false, -1, funcToWrap.HasThrows));
+				false, funcToWrap, false, -1, funcToWrap.HasThrows));
 
 
 			picl.Methods.Add (piMethod);

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -1102,7 +1102,7 @@ namespace SwiftReflector {
 				usedIds.Add (varId.Name);
 				var varDecl = SLDeclaration.LetLine (varId, null, variadicAdapter, Visibility.None);
 				body.Add (varDecl);
-				call = new SLFunctionCall (varId.Name, false, parameters.Select (p => new SLArgument (null, p.PrivateName, false)).ToArray ());
+				call = new SLFunctionCall (varId.Name, false, parameters.Select (p => new SLArgument ("", p.PrivateName, false)).ToArray ());
 			} else {
 				call = new SLFunctionCall ("super." + func.Name, false, parameters.Select ((p, i) => {
 					var arg = func.ParameterLists.Last () [i];
@@ -1263,7 +1263,7 @@ namespace SwiftReflector {
 				var adapterID = new SLIdentifier (MarshalEngine.Uniqueify ("variadicAdapter", idents));
 				idents.Add (adapterID.Name);
 				body.Add (SLDeclaration.LetLine (adapterID, null, variadicAdapter, Visibility.None));
-				funcCall = new SLFunctionCall (adapterID.Name, false, parameters.Select (parm => new SLArgument (null, parm.PrivateName, false)).ToArray ());
+				funcCall = new SLFunctionCall (adapterID.Name, false, parameters.Select (parm => new SLArgument ("", parm.PrivateName, false)).ToArray ());
 			} else {
 				funcCall = new SLFunctionCall (callSite, false,
 				                               parameters.Select ((p, i) =>

--- a/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
+++ b/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
@@ -132,7 +132,7 @@ namespace SwiftRuntimeLibrary {
 				//Console.WriteLine ("after set error throws retValPtr: ");
 				//Memory.Dump (retValPtr, 128);
 #endif
-            } else {
+			} else {
 				StructMarshal.Marshaler.SetErrorNotThrownWithValue (retValPtr, delInfo.Item3, retval);
 			}
 			StructMarshal.ReleaseSwiftObject (capsule);

--- a/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
+++ b/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
@@ -41,7 +41,6 @@ namespace SwiftRuntimeLibrary {
 			StructMarshal.ReleaseSwiftObject (capsule);
 		}
 
-
 		[MonoPInvokeCallback (typeof (Action<IntPtr, IntPtr, IntPtr>))]
 		public static void FuncCallback (IntPtr retValPtr, IntPtr args, IntPtr refPtr)
 		{
@@ -71,6 +70,71 @@ namespace SwiftRuntimeLibrary {
 			var argumentValues = StructMarshal.Marshaler.MarshalSwiftTupleMemoryToNet (args, delInfo.Item2);
 			var retval = delInfo.Item1.DynamicInvoke (argumentValues);
 			StructMarshal.Marshaler.ToSwift (delInfo.Item3, retval, retValPtr);
+			StructMarshal.ReleaseSwiftObject (capsule);
+		}
+
+		[MonoPInvokeCallback (typeof (Action<IntPtr, IntPtr>))]
+		public static void FuncCallbackVoidMaybeThrows (IntPtr retValPtr, IntPtr refPtr)
+		{
+			FuncCallbackMaybeThrows (retValPtr, IntPtr.Zero, refPtr);
+		}
+
+		[MonoPInvokeCallback (typeof (Action<IntPtr, IntPtr, IntPtr>))]
+		public static void FuncCallbackMaybeThrows (IntPtr retValPtr, IntPtr args, IntPtr refPtr)
+		{
+			// instead of a pointer to a return value, this is a pointer to a Medusa tuple of the form:
+			// (T, SwiftError, bool)
+			// T is the return value if and only if the bool is false and in that case
+			// SwiftError will be invalid.
+			// SwiftError is the exception thrown if and only if the bool is true and in that case
+			// T will be invalid.
+#if DEBUG
+			//Console.WriteLine ($"FuncCallback: refPtr initially {refPtr.ToString ("X8")}");
+			//Console.WriteLine ("dereferencing refPtr ");
+#endif
+			refPtr = LocateRefPtrFromPartialApplicationForwarder (refPtr);
+#if DEBUG
+			//Console.WriteLine($"FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString("X8")} args {args.ToString("X8")} refPtr {refPtr.ToString("X8")}");
+			//Console.WriteLine ("retValPtr: ");
+			//Memory.Dump (retValPtr, 128);
+			//Console.WriteLine ("args: ");
+			//Memory.Dump (args, 128);
+			//Console.WriteLine ("refPtr: ");
+			//Memory.DumpPtrs (refPtr, 8);
+#endif
+			var capsule = SwiftObjectRegistry.Registry.ExistingCSObjectForSwiftObject<SwiftDotNetCapsule> (refPtr);
+			var delInfo = SwiftObjectRegistry.Registry.ClosureForCapsule (capsule);
+#if DEBUG
+			//if (delInfo == null) {
+			//	Console.WriteLine ("delInfo is null.");
+			//}
+#endif
+			var argumentValues = args != IntPtr.Zero ? StructMarshal.Marshaler.MarshalSwiftTupleMemoryToNet (args, delInfo.Item2) : null;
+
+			object retval = null;
+			Exception thrownException = null;
+
+			try {
+				retval = delInfo.Item1.DynamicInvoke (argumentValues);
+			} catch (Exception e) {
+				thrownException = e;
+			}
+
+			if (thrownException != null) {
+#if DEBUG
+				//Console.WriteLine ($"FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString ("X8")} args {args.ToString ("X8")} refPtr {refPtr.ToString ("X8")}");
+				//Console.WriteLine ("before set error throws retValPtr: ");
+				//Memory.Dump (retValPtr, 128);
+#endif
+		                StructMarshal.Marshaler.SetErrorThrown (retValPtr, SwiftError.FromException (thrownException), delInfo.Item3);
+#if DEBUG
+				//Console.WriteLine ($"FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString ("X8")} args {args.ToString ("X8")} refPtr {refPtr.ToString ("X8")}");
+				//Console.WriteLine ("after set error throws retValPtr: ");
+				//Memory.Dump (retValPtr, 128);
+#endif
+            } else {
+				StructMarshal.Marshaler.SetErrorNotThrownWithValue (retValPtr, delInfo.Item3, retval);
+			}
 			StructMarshal.ReleaseSwiftObject (capsule);
 		}
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -1419,6 +1419,15 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			Write ((byte)0, boolPtr);
 		}
 
+		public void SetErrorNotThrownWithValue (IntPtr swiftMedusaTuple, Type t, object value)
+		{
+			var tMap = TupleMapForException (t);
+			var boolPtr = swiftMedusaTuple + tMap.Offsets [tMap.Offsets.Length - 1];
+			Write ((byte)0, boolPtr);
+			ToSwift (tMap.Types [0], value, swiftMedusaTuple);
+		}
+
+
 		public SwiftException GetExceptionThrown (IntPtr swiftMeduaTuple, Type t)
 		{
 			var error = GetErrorThrown (swiftMeduaTuple, t);

--- a/swiftglue/pointerhelpers.swift
+++ b/swiftglue/pointerhelpers.swift
@@ -70,7 +70,7 @@ private func getExceptionBool<T>(retval: UnsafeMutablePointer<(T, Error, Bool)>)
 
 public func setExceptionThrown<T>(err: Error, retval: UnsafeMutablePointer<(T, Error, Bool)>)
 {
-	let alignment = MemoryLayout<T>.alignment;
+	let alignment = MemoryLayout<Error>.alignment;
 	let errOffset = roundUpToAlignment(value: MemoryLayout<T>.size, align:alignment);
 	let rawPointer = UnsafeMutableRawPointer(retval).bindMemory(to: Int8.self,
 		capacity: errOffset + MemoryLayout<Error>.stride) + errOffset;
@@ -97,12 +97,17 @@ public func isExceptionThrown<T>(retval: UnsafeMutablePointer<(T, Error, Bool)>)
 
 public func getExceptionThrown<T>(retval: UnsafeMutablePointer<(T, Error, Bool)>) -> Error?
 {
+//	print ("memory dump of exception pointer")
+//	dumpMemory(ptr: retval, count: 4)
 	var result:Error? = nil;
 	if getExceptionBool(retval:retval) {
-		let alignment = MemoryLayout<T>.alignment;
+		let alignment = MemoryLayout<Error>.alignment;
 		let errOffset = roundUpToAlignment(value: MemoryLayout<T>.size, align:alignment);
+//		print("errOffset: \(errOffset)")
 		let rawPointer = UnsafeMutableRawPointer(retval).bindMemory(to: Int8.self,
 			capacity: errOffset + MemoryLayout<Error>.stride) + errOffset;
+//	print ("memory dump of exception pointer offset")
+//	dumpMemory(ptr: rawPointer, count: 4)
 		rawPointer.withMemoryRebound(to: Error.self, capacity: 1) {
 			result = $0.pointee;
 		}
@@ -191,10 +196,34 @@ public func alignmentof<T> (_ ignored: T) -> Int
 //print("0x", hexString(x: p[0]))
 //}
 //
+//public func printHexInt(ptr: UnsafeMutableRawPointer)
+//{
+//let p = ptr.assumingMemoryBound(to:UInt64.self)
+//print("Data:") 
+//print("0x", hexString(x: p[0]))
+//}
+//
+//
 //public func printHexInt<T>(ptr: UnsafeMutablePointer<T>)
 //{
 //printHexInt(ptr: UnsafeRawPointer(ptr))
 //}
+//
+//public func dumpMemory<T> (ptr: UnsafeMutablePointer<T>, count: Int)
+//{
+//	dumpMemory (ptr: UnsafeRawPointer (ptr), count: count)
+//}
+//
+//public func dumpMemory (ptr: UnsafeRawPointer, count: Int)
+//{
+//	let addr = unsafeBitCast(ptr, to: UInt64.self)
+//	print ("address \(hexString(x: addr))")
+//	let p = ptr.assumingMemoryBound(to: UInt64.self)
+//	for i in 0...count {
+//		print (hexString(x: p [i]))
+//	}
+//}
+
 
 //public func printProtocol(ptr: UnsafeRawPointer)
 //{


### PR DESCRIPTION
Swift allows closures to be declared as throwing. We need to support this.

This is not a complete PR. Here's why:
Swift closures map into C# in one of 5 possible forms
```
Action
Action<T, ....>
Func<T>
Func<T, ....>
```
For this PR, I tackled the last two. Doing all of these would make a PR that is ungainly(ier) and this one is going to be challenging enough. "If it was hard to write, it should be hard to read."
In addition, I chose to only handle closures being passed from C# to swift, not the other way around (yet).

Quick refresher: if a function throws, it gets adapted with a magic tuple called a medusa tuple. The type in swift is `(T, Error, Bool)` where T is the return value of the function. This means that given the following function:
```swift
public func foo<T>() throws -> T { }
```
We can't call this in C# because if it throws, the error is in R13 (or whatever register is available on the target platform) and we don't have access to that. It will get wrapped into a function like this, which is callable from C#:
```swift
public func fooCaller(result: UnsafeMutablePointer<(T, Error, Bool)> {
   do {
       let r = foo ()
       setExceptionNotThrown(result, r)
  catch (Error e) {
      setExceptionThrown(result, e)
  }
}
```
Or something like that. Basically, if the Bool is true, then the Error part is valid else the T part is valid.
It's called a medusa tuple because if you look at the wrong parts at the wrong time, you die.

Now, in order to handle closures we write an adapter in swift takes a C# callable closure and then adapts it into a swift closure that matches the original swift code. It calls the C# closure and either gets a result or gets an Error. It then either returns the result or throws the error.

Generally speaking, I broke more of the C# code that handles this up into this pattern:
```C#
if (closure.Throws && !closure.IsAsync) {
    // new code
} else if (closure.IsAsync) {
   // throw an exception
} else {
  // old code
}
```
So expect to see that pattern.

There is one other catch in all of this. When we are wrapping the C# function with a throwing closure, the C# type will be something like `Action<Tuple<T, SwiftError, Bool>, Tuple<args>>` and matching swift tuple will be this: `(UnsafeMutablePointer<(T, Error, Bool)>, UnsafeMutablePointer<(args)>) -> ()`. Nowhere in there is there any information about whether the function throws, so our marshaler can't handle it. So I refactored it to include the original function so when we marshal arguments, we also pass in the original argument, which does have the information about throwing. To do this, I replaced the wrapper argument with the original function. The wrapper argument was unused, so this is a minor issue.

Also, I found I bug in the swift code for getting a thrown exception that would crash if the alignment of the T return value is less than the pointer size. The trick is to get the offset to the Error without touching the first argument. The alignment of Bool is 1 so we crashed on access. That's fixed now. I looked into other solutions including addressing the tuple numerically:
`let error = (T, Error, Bool).1`, but the generated code touches all the tuple elements, and not in a good way.

Some lessons learned:
Past Steve put in exceptions when the code hit closures that throw. Present Steve really appreciated that. It made the implementation much easier.
Present Steve put those exceptions in for async so that future Steve won't suffer so much.
Past Steve wrote routines to dump memory in C# and in Swift. Present Steve used them both and augmented the latter. It made debugging the crashes **so** much faster.
Past Steve liked to use linq expressions for code. It can be very tight and pretty, but it's a royal pain to debug. I rewrote a couple of those in for loops which made fixing (inevitable) errors easier.


