### PR TITLE
handle virtual methods with closures that throw

### DIFF
--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -222,9 +222,15 @@ namespace SwiftReflector {
 						argTypes [idx] = parmType.GenericTypes [idx].Typeof ();
 					}
 					var typeArr = new CSArray1DInitialized (CSSimpleType.Type, argTypes);
+					CSBaseExpression flags = new CSIdentifier ("ClosureFlags.None");
+					var closure = swiftParm.TypeSpec as ClosureTypeSpec;
+					if (closure.Throws)
+						flags = new CSBinaryExpression(CSBinaryOperator.BitOr, flags, new CSIdentifier ("ClosureFlags.Throws"));
+					if (closure.IsAsync)
+						flags = new CSBinaryExpression (CSBinaryOperator.BitOr, flags, new CSIdentifier ("ClosureFlags.Async"));
 
 					var closureExpr = new CSFunctionCall ("StructMarshal.Marshaler.MakeDelegateFromBlindClosure", false, delegateParams [i].Name,
-									      typeArr, returnType);
+									      typeArr, returnType, flags);
 					var castTo = new CSCastExpression (csParm.CSType, closureExpr);
 					callParams.Add (castTo);
 				} else if (entityType == EntityType.ProtocolList) {

--- a/SwiftRuntimeLibrary/BlindSwiftClosureRepresentation.cs
+++ b/SwiftRuntimeLibrary/BlindSwiftClosureRepresentation.cs
@@ -181,6 +181,11 @@ namespace SwiftRuntimeLibrary {
 		                                            SwiftMetatype t9, SwiftMetatype t10, SwiftMetatype t11, SwiftMetatype t12,
 							    SwiftMetatype t13, SwiftMetatype t14, SwiftMetatype t15, SwiftMetatype t16, SwiftMetatype tr);
 
+		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.BlindSwiftClosureRepresentation_InvokeFunctionThrows2)]
+		internal static extern void InvokeFunctionThrows (BlindSwiftClosureRepresentation clos, IntPtr retval, IntPtr args, SwiftMetatype t1, SwiftMetatype tr);
+
+
+
 	}
 
 

--- a/SwiftRuntimeLibrary/Enums.cs
+++ b/SwiftRuntimeLibrary/Enums.cs
@@ -121,5 +121,12 @@ namespace SwiftRuntimeLibrary {
 		DirectObjCClassName,
 		IndirectObjCClass,
 	}
+
+	[Flags]
+	public enum ClosureFlags {
+		None = 0,
+		Throws = 1 << 0,
+		Async = 1 << 1,
+	}
 }
 

--- a/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
+++ b/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
@@ -94,7 +94,7 @@ namespace SwiftRuntimeLibrary {
 #endif
 			refPtr = LocateRefPtrFromPartialApplicationForwarder (refPtr);
 #if DEBUG
-			//Console.WriteLine($"FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString("X8")} args {args.ToString("X8")} refPtr {refPtr.ToString("X8")}");
+			//Console.WriteLine($"Before call FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString("X8")} args {args.ToString("X8")} refPtr {refPtr.ToString("X8")}");
 			//Console.WriteLine ("retValPtr: ");
 			//Memory.Dump (retValPtr, 128);
 			//Console.WriteLine ("args: ");
@@ -110,6 +110,11 @@ namespace SwiftRuntimeLibrary {
 			//}
 #endif
 			var argumentValues = args != IntPtr.Zero ? StructMarshal.Marshaler.MarshalSwiftTupleMemoryToNet (args, delInfo.Item2) : null;
+#if DEBUG
+			//foreach (var arg in argumentValues) {
+			//	Console.WriteLine ($"arg: {arg} type: {arg.GetType ().Name}");
+			//}
+#endif
 
 			object retval = null;
 			Exception thrownException = null;
@@ -134,6 +139,15 @@ namespace SwiftRuntimeLibrary {
 #endif
 			} else {
 				StructMarshal.Marshaler.SetErrorNotThrownWithValue (retValPtr, delInfo.Item3, retval);
+#if DEBUG
+				//Console.WriteLine ($"After call FuncCallbackMaybeThrows: retValPtr {retValPtr.ToString ("X8")} args {args.ToString ("X8")} refPtr {refPtr.ToString ("X8")}");
+				//Console.WriteLine ("retValPtr: ");
+				//Memory.Dump (retValPtr, 128);
+				//Console.WriteLine ("args: ");
+				//Memory.Dump (args, 128);
+				//Console.WriteLine ("refPtr: ");
+				//Memory.DumpPtrs (refPtr, 8);
+#endif
 			}
 			StructMarshal.ReleaseSwiftObject (capsule);
 		}

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -842,7 +842,6 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			} else {
 				methodName = returnType == null ? "ActionForSwiftClosure" : "FuncForSwiftClosure";
 			}
-			Console.WriteLine ("calling this method " + methodName);
 			var mi = typeof (SwiftObjectRegistry).GetMethod (methodName);
 			if (mi == null)
 				throw new SwiftRuntimeException ($"Making a closure, unable to find method {methodName}");

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -845,7 +845,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			Console.WriteLine ("calling this method " + methodName);
 			var mi = typeof (SwiftObjectRegistry).GetMethod (methodName);
 			if (mi == null)
-				throw new SwiftRuntimeException ($"Making a closure, unable to fine method {methodName}");
+				throw new SwiftRuntimeException ($"Making a closure, unable to find method {methodName}");
 			var genCall = mi.MakeGenericMethod (argTypes);
 			return (Delegate)genCall.Invoke (SwiftObjectRegistry.Registry, new object [] { blindClosure });
 		}

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -822,16 +822,30 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			return new SwiftClosureRepresentation (delegateObj, blindClosure.Data);
 		}
 
-		public Delegate MakeDelegateFromBlindClosure (BlindSwiftClosureRepresentation blindClosure, Type [] argTypes, Type returnType)
+		public Delegate MakeDelegateFromBlindClosure (BlindSwiftClosureRepresentation blindClosure, Type [] argTypes, Type returnType, ClosureFlags flags = ClosureFlags.None)
 		{
-			if (argTypes.Length == 0)
+			if (argTypes.Length == 0 && flags == ClosureFlags.None)
 				return SwiftObjectRegistry.Registry.ActionForSwiftClosure (blindClosure);
 
 			if (returnType != null) {
 				Array.Resize (ref argTypes, argTypes.Length + 1);
 				argTypes [argTypes.Length - 1] = returnType;
 			}
-			var mi = typeof (SwiftObjectRegistry).GetMethod (returnType == null ? "ActionForSwiftClosure" : "FuncForSwiftClosure");
+
+			var methodName = "";
+			if (flags == ClosureFlags.Throws) {
+				if (returnType == null)
+					throw new SwiftRuntimeException ("Need to handle Action closures that throw.");
+				methodName = returnType == null ? "ActionForSwiftClosureThrows" : "FuncForSwiftClosureThrows";
+			} else if ((flags & ClosureFlags.Async) == ClosureFlags.Async) {
+				throw new SwiftRuntimeException ("Marshaling async closures isn't supported (yet).");
+			} else {
+				methodName = returnType == null ? "ActionForSwiftClosure" : "FuncForSwiftClosure";
+			}
+			Console.WriteLine ("calling this method " + methodName);
+			var mi = typeof (SwiftObjectRegistry).GetMethod (methodName);
+			if (mi == null)
+				throw new SwiftRuntimeException ($"Making a closure, unable to fine method {methodName}");
 			var genCall = mi.MakeGenericMethod (argTypes);
 			return (Delegate)genCall.Invoke (SwiftObjectRegistry.Registry, new object [] { blindClosure });
 		}

--- a/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
+++ b/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
@@ -1265,8 +1265,8 @@ namespace SwiftRuntimeLibrary {
 							      (arg1) => {
 								      unsafe {
 //#if DEBUG_SPEW
-									      Console.WriteLine ("In memoized closure for blind closure, rep.Data: " + rep.Data.ToString ("X8"));
-									      Console.WriteLine ("Arg is {0}", arg1);
+									      //Console.WriteLine ("In memoized closure for blind closure, rep.Data: " + rep.Data.ToString ("X8"));
+									      //Console.WriteLine ("Arg is {0}", arg1);
 //#endif
 									      var returnMemory = stackalloc byte [StructMarshal.Marshaler.Strideof (typeof (Tuple<TR, SwiftError, bool>))];
 									      var returnPtr = new IntPtr (returnMemory);

--- a/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
+++ b/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
@@ -1264,10 +1264,10 @@ namespace SwiftRuntimeLibrary {
 			return MemoizedClosure<Func<T1, TR>> (rep, (bc) =>
 							      (arg1) => {
 								      unsafe {
-//#if DEBUG_SPEW
+#if DEBUG_SPEW
 									      //Console.WriteLine ("In memoized closure for blind closure, rep.Data: " + rep.Data.ToString ("X8"));
 									      //Console.WriteLine ("Arg is {0}", arg1);
-//#endif
+#endif
 									      var returnMemory = stackalloc byte [StructMarshal.Marshaler.Strideof (typeof (Tuple<TR, SwiftError, bool>))];
 									      var returnPtr = new IntPtr (returnMemory);
 									      Console.WriteLine ("before call return block");

--- a/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
+++ b/SwiftRuntimeLibrary/SwiftObjectRegistry.cs
@@ -1259,6 +1259,39 @@ namespace SwiftRuntimeLibrary {
 							      });
 		}
 
+		public Func<T1, TR> FuncForSwiftClosureThrows<T1, TR> (BlindSwiftClosureRepresentation rep)
+		{
+			return MemoizedClosure<Func<T1, TR>> (rep, (bc) =>
+							      (arg1) => {
+								      unsafe {
+//#if DEBUG_SPEW
+									      Console.WriteLine ("In memoized closure for blind closure, rep.Data: " + rep.Data.ToString ("X8"));
+									      Console.WriteLine ("Arg is {0}", arg1);
+//#endif
+									      var returnMemory = stackalloc byte [StructMarshal.Marshaler.Strideof (typeof (Tuple<TR, SwiftError, bool>))];
+									      var returnPtr = new IntPtr (returnMemory);
+									      Console.WriteLine ("before call return block");
+									      Memory.Dump (returnPtr, StructMarshal.Marshaler.Strideof (typeof (Tuple<TR, SwiftError, bool>)));
+									      var types = new Type [] { typeof (T1) };
+									      var args = new object [] { arg1 };
+									      var tupleMap = SwiftTupleMap.FromTypes (types);
+									      var argMemory = stackalloc byte [tupleMap.Stride];
+									      var argPtr = StructMarshal.Marshaler.MarshalObjectsAsTuple (args, tupleMap, new IntPtr (argMemory));
+									      BlindSwiftClosureRepresentation.InvokeFunction (bc, returnPtr, argPtr, StructMarshal.Marshaler.Metatypeof (typeof (T1)),
+															      StructMarshal.Marshaler.Metatypeof (typeof (TR)));
+									      Console.WriteLine ("before call return block");
+									      Memory.Dump (returnPtr, StructMarshal.Marshaler.Strideof (typeof (Tuple<TR, SwiftError, bool>)));
+
+									      var ex = StructMarshal.Marshaler.GetExceptionThrown (returnPtr, typeof (TR));
+									      if (ex != null) {
+										      throw ex;
+									      }
+
+									      return StructMarshal.Marshaler.GetErrorReturnValue<TR> (returnPtr);
+								      }
+							      });
+		}
+
 
 		public static SwiftObjectRegistry Registry {
 			get {

--- a/swiftglue/closurehelpers.swift
+++ b/swiftglue/closurehelpers.swift
@@ -1972,3 +1972,9 @@ public func invokeFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
 public func invokeFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TR>(f:(UnsafeMutablePointer<TR>, UnsafeMutablePointer<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)>)->(), retval: UnsafeMutablePointer<TR>, a: UnsafeMutablePointer<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)>) {
 	f(retval, a)
 }
+
+// throws
+
+public func invokeFunctionThrows<T1, TR>(f:(UnsafeMutablePointer<(TR, Swift.Error, Bool)>, UnsafeMutablePointer<T1>)->(), retval: UnsafeMutablePointer<(TR, Swift.Error, Bool)>, a: UnsafeMutablePointer<T1>) {
+	f(retval, a)
+}

--- a/tools/symbolicator/XamGlueConstants.cs
+++ b/tools/symbolicator/XamGlueConstants.cs
@@ -252,6 +252,7 @@ namespace SwiftRuntimeLibrary {
 		internal const string BlindSwiftClosureRepresentation_InvokeFunction16 = "$s7XamGlue14invokeFunction1f6retval1ayySpyq13_G_Spyx_q_q0_q1_q2_q3_q4_q5_q6_q7_q8_q9_q10_q11_q12_tGtXE_AfGtr14_lF";
 		internal const string BlindSwiftClosureRepresentation_InvokeFunction17 = "$s7XamGlue14invokeFunction1f6retval1ayySpyq14_G_Spyx_q_q0_q1_q2_q3_q4_q5_q6_q7_q8_q9_q10_q11_q12_q13_tGtXE_AfGtr15_lF";
 
+		internal const string BlindSwiftClosureRepresentation_InvokeFunctionThrows2 = "_$s7XamGlue20invokeFunctionThrows1f6retval1ayySpyq__s5Error_pSbtG_SpyxGtXE_AgHtr0_lF";
 		// UnsafeRawBufferPointer
 		[SymbolicatorInfo (Skip = true)]
 		internal const string UnsafeRawBufferPointerNew = "$s7XamGlue25unsafeRawBufferPointerNew6retval5start5countySpySWG_SVSitF";


### PR DESCRIPTION
This adds the ability to handle exactly one type of function that throws: `F<TR, T>`.
Rather than bury you in the spew of many changes, I thought I'd keep this PR simple. The fire hose happens next PR.

To do this, I added an optional argument to `MakeDelegateFromBlindClosure` that includes flags to indicate whether the delegate can throw or is async.

The SwiftToCSharp marshaling now handles closures that throw - this just involves calling the right adapter, but other than that, it's pretty much the same code.