### PR TITLE
make throwing manifest

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSAttribute.cs
+++ b/Dynamo/Dynamo.CSLang/CSAttribute.cs
@@ -6,10 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace Dynamo.CSLang {
 	public class CSAttribute : LineCodeElementCollection<ICodeElement> {
-		public CSAttribute (CSIdentifier name, CSArgumentList args, bool isSingleLine = false)
+		public CSAttribute (CSIdentifier name, CSArgumentList args, bool isSingleLine = false, bool isReturn = false)
 			: base (isSingleLine, false, isSingleLine)
 		{
 			Add (new SimpleElement ("["));
+			if (isReturn)
+				Add (new SimpleElement ("return:"));
 			Add (Exceptions.ThrowOnNull (name, nameof(name)));
 			if (args != null) {
 				Add (new SimpleElement ("("));
@@ -57,14 +59,14 @@ namespace Dynamo.CSLang {
 			return new CSAttribute (new CSIdentifier ("StructLayout"), args, true);
 		}
 
-		public static CSAttribute FromAttr (Type attribute, CSArgumentList args, bool isSingleLine = false)
+		public static CSAttribute FromAttr (Type attribute, CSArgumentList args, bool isSingleLine = false, bool isReturn = false)
 		{
 			Exceptions.ThrowOnNull (attribute, nameof(attribute));
 			if (!attribute.IsSubclassOf (typeof (Attribute)))
 				throw new ArgumentException (String.Format ("Type {0} is not an Attribute type.", attribute.Name), nameof(attribute));
 			var name = attribute.Name.EndsWith ("Attribute") ?
 				attribute.Name.Substring (0, attribute.Name.Length - "Attribute".Length) : attribute.Name;
-			return new CSAttribute (new CSIdentifier (name), args, isSingleLine);
+			return new CSAttribute (new CSIdentifier (name), args, isSingleLine, isReturn);
 		}
 
 		public static CSAttribute MarshalAsFunctionPointer ()

--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -231,7 +231,7 @@ namespace SwiftReflector {
 
 					var closureExpr = new CSFunctionCall ("StructMarshal.Marshaler.MakeDelegateFromBlindClosure", false, delegateParams [i].Name,
 									      typeArr, returnType, flags);
-					var castTo = new CSCastExpression (csParm.CSType, closureExpr);
+					var castTo = new CSCastExpression (CSType.Copy (csParm.CSType), closureExpr);
 					callParams.Add (castTo);
 				} else if (entityType == EntityType.ProtocolList) {
 					preMarshalCode.Add (CSFunctionCall.FunctionCallLine ("throw new NotImplementedException", false, CSConstant.Val ($"Argument {csParm.Name} is a protocol list type and can't be marshaled from a virtual method.")));

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -491,6 +491,8 @@ namespace SwiftReflector {
 				wrapperProp = TLFCompiler.CompileProperty (prop.Name, use,
 									       propType, piGetter != null, piSetter != null,
 									       prop.IsStatic ? CSMethodKind.Static : CSMethodKind.None);
+				if (TopLevelFunctionCompiler.TypeSpecCanThrow (getter.ReturnTypeSpec, false))
+					TopLevelFunctionCompiler.DecorateTypeWithThrows (wrapperProp.PropType, use);
 			}
 
 			if (piGetter != null) {
@@ -4864,6 +4866,10 @@ namespace SwiftReflector {
 			publicMethod = CSMethod.CopyGenerics (publicMethod, new CSMethod (publicMethod.Visibility, CSMethodKind.Virtual, publicMethod.Type,
 			                             new CSIdentifier(publicMethod.Name.Name + homonymSuffix), publicMethod.Parameters,
 			                             publicMethod.Body));
+
+			if (TopLevelFunctionCompiler.TypeSpecCanThrow (funcDecl.ReturnTypeSpec, false))
+				TopLevelFunctionCompiler.DecorateReturnWithThrows (publicMethod, use);
+
 			var call = new CSFunctionCall (superCallName + homonymSuffix, false, publicMethod.Parameters.Select (p => p.Name).ToArray ());
 			publicMethod.Body.Add (publicMethod.Type == null || publicMethod.Type == CSSimpleType.Void ? new CSLine (call) : CSReturn.ReturnLine (call));
 			cl.Methods.Add (publicMethod);
@@ -4902,6 +4908,8 @@ namespace SwiftReflector {
 			if (forcePrivate) {
 				publicMethod = new CSMethod (CSVisibility.None, publicMethod.Kind, publicMethod.Type,
 							publicMethod.Name, publicMethod.Parameters, publicMethod.Body);
+				if (TopLevelFunctionCompiler.TypeSpecCanThrow (methodToWrap.ReturnTypeSpec, false))
+					TopLevelFunctionCompiler.DecorateReturnWithThrows (publicMethod, use);
 			}
 
 			var localIdentifiers = new List<string> {
@@ -5022,6 +5030,8 @@ namespace SwiftReflector {
 
 			publicMethod = CSMethod.CopyGenerics (publicMethod, new CSMethod (forcePrivate ? CSVisibility.None : publicMethod.Visibility, publicMethod.Kind, publicMethod.Type,
 			                                                                  new CSIdentifier(publicMethod.Name.Name + homonymSuffix), publicMethod.Parameters, publicMethod.Body));
+			if (TopLevelFunctionCompiler.TypeSpecCanThrow (funcToWrap.ReturnTypeSpec, false))
+				TopLevelFunctionCompiler.DecorateReturnWithThrows (publicMethod, use);
 
 			if (funcToWrap.Parent is ClassDeclaration classDeclaration) {
 				if (classDeclaration.HasImportedOverride (publicMethod, TypeMapper)) {

--- a/SwiftReflector/TypeMapping/NetTypeBundle.cs
+++ b/SwiftReflector/TypeMapping/NetTypeBundle.cs
@@ -14,7 +14,8 @@ namespace SwiftReflector.TypeMapping {
 		const string kNoType = "!!NO_TYPE!!";
 		List<NetTypeBundle> genericTypes = new List<NetTypeBundle> ();
 
-		public NetTypeBundle (string nameSpace, string entityName, bool isScalar, bool isReference, EntityType entity)
+		public NetTypeBundle (string nameSpace, string entityName, bool isScalar, bool isReference, EntityType entity,
+			bool swiftThrows = false)
 		{
 			GenericIndex = -1;
 			IsVoid = entityName == kNoType;
@@ -25,6 +26,7 @@ namespace SwiftReflector.TypeMapping {
 			IsScalar = isScalar;
 			IsReference = isReference;
 			Entity = entity;
+			Throws = swiftThrows;
 		}
 
 		public NetTypeBundle (List<NetTypeBundle> tupleElements, bool isReference)
@@ -41,13 +43,15 @@ namespace SwiftReflector.TypeMapping {
 			TupleTypes.AddRange (Exceptions.ThrowOnNull (tupleElements, "tupleElements"));
 		}
 
-		public NetTypeBundle (string nameSpace, string entityName, EntityType entity, bool isReference, IEnumerable<NetTypeBundle> genericTypes)
+		public NetTypeBundle (string nameSpace, string entityName, EntityType entity, bool isReference, IEnumerable<NetTypeBundle> genericTypes,
+			bool swiftThrows = false)
 			: this (nameSpace, entityName, false, isReference, entity)
 		{
 			GenericIndex = -1;
 			this.genericTypes.AddRange (genericTypes);
 			if (this.genericTypes.Count == 0)
 				throw new ArgumentOutOfRangeException (nameof (genericTypes), "Generic NetBundle constructor needs actual generic types.");
+			Throws = swiftThrows;
 		}
 
 		public NetTypeBundle (int depth, int index)
@@ -108,6 +112,7 @@ namespace SwiftReflector.TypeMapping {
 		public ProtocolDeclaration AssociatedTypeProtocol { get; private set; }
 		public AssociatedTypeDeclaration AssociatedType { get; private set; }
 		public bool IsAssociatedType {  get { return AssociatedTypeProtocol != null; } }
+		public bool Throws { get; private set; }
 		public bool ContainsGenericParts {
 			get {
 				return genericTypes.Count > 0;

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -691,6 +691,7 @@ namespace SwiftReflector.TypeMapping {
 					return new NetTypeBundle ("SwiftRuntimeLibrary", isReturnValue ? "BlindSwiftClosureRepresentation" : "SwiftClosureRepresentation", false, false, EntityType.Closure);
 				} else {
 					ClosureTypeSpec ft = spec as ClosureTypeSpec;
+					var throws = !isPinvoke && ft.Throws;
 					var arguments = ft.EachArgument().Select (parm => MapType (context, parm, false)).ToList ();
 
 					string delegateName = "Action";
@@ -701,9 +702,9 @@ namespace SwiftReflector.TypeMapping {
 					}
 
 					if (arguments.Count == 0)
-						return new NetTypeBundle ("System", delegateName, false, false, EntityType.Closure);
+						return new NetTypeBundle ("System", delegateName, false, false, EntityType.Closure, swiftThrows: throws);
 					else
-						return new NetTypeBundle ("System", delegateName, EntityType.Closure, false, arguments);
+						return new NetTypeBundle ("System", delegateName, EntityType.Closure, false, arguments, swiftThrows: throws);
 				}
 			case TypeSpecKind.ProtocolList:
 				var pl = (ProtocolListTypeSpec)spec;

--- a/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
+++ b/SwiftRuntimeLibrary.Mac/SwiftRuntimeLibrary.Mac.csproj
@@ -286,6 +286,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\ISwiftValueType.cs">
       <Link>ISwiftValueType.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftThrowsAttribute.cs">
+      <Link>SwiftMarshal\SwiftThrowsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SwiftMarshal\" />

--- a/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
+++ b/SwiftRuntimeLibrary.iOS/SwiftRuntimeLibrary.iOS.csproj
@@ -291,6 +291,9 @@
     <Compile Include="..\SwiftRuntimeLibrary\ISwiftValueType.cs">
       <Link>ISwiftValueType.cs</Link>
     </Compile>
+    <Compile Include="..\SwiftRuntimeLibrary\SwiftMarshal\SwiftThrowsAttribute.cs">
+      <Link>SwiftMarshal\SwiftThrowsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="GeneratedCSCode" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFullPath)" Outputs="GeneratedCode\BindingMetadata.iOS.cs">
     <Exec Command="make --directory=../SwiftRuntimeLibrary create-pinvokes-ios configuration=$(Configuration)" />

--- a/SwiftRuntimeLibrary/SwiftMarshal/SwiftThrowsAttribute.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/SwiftThrowsAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+namespace SwiftRuntimeLibrary.SwiftMarshal {
+	[AttributeUsage (AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.Property, AllowMultiple = false)]
+	public sealed class SwiftThrowsAttribute : Attribute {
+		public SwiftThrowsAttribute ()
+		{
+		}
+	}
+}

--- a/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
+++ b/SwiftRuntimeLibrary/SwiftRuntimeLibrary.csproj
@@ -119,6 +119,7 @@
     <Compile Include="SwiftNativeInstance.cs" />
     <Compile Include="SwiftNativeValueType.cs" />
     <Compile Include="ISwiftValueType.cs" />
+    <Compile Include="SwiftMarshal\SwiftThrowsAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/tom-swifty-test/dynamo/SimpleClassTests.cs
+++ b/tests/tom-swifty-test/dynamo/SimpleClassTests.cs
@@ -79,7 +79,7 @@ namespace dynamotests {
 		public void ClassWithSingleDeclAllTypes ()
 		{
 			foreach (MethodInfo mi in typeof (CSType).GetMethods ().Where (mii => mii.IsStatic && mii.IsPublic &&
-				   mii.ReturnType == typeof (CSType))) {
+				   mii.ReturnType == typeof (CSType) && mii.Name != "Copy")) {
 				CSType cs = mi.Invoke (null, null) as CSType;
 				if (cs != null)
 					DeclType (cs);


### PR DESCRIPTION
Added code to put a `[SwiftThrows]` attribute on parameters and return values fixing issue [751](https://github.com/xamarin/binding-tools-for-swift/issues/751).

I thought this was going to be simple.
Right.

1st complication: I needed to use the `[return: attribute]` flavor of attribute which I didn't have support for in Dynamo (but now do)
2nd complication: properties don't like the `[return: attribute]` (why), so properties get handled differently
3rd complication: there is a case where we put in a cast to a parameter type, which carries across the `[SwiftThrows]` attribute if it's there, so I made a `Copy` method for `CSType` which will invoke a copy constructor for each type (we only have 2 right now) which has the side effect of leaving attachments behind.
4th complication: there is a unit test that runs static methods in `CSType` and we added the copy constructor which doesn't fit into this model (put in an extra rule to skip `Copy`).