### PR TITLE
Handle associated types embedded in other generic types

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSType.cs
+++ b/Dynamo/Dynamo.CSLang/CSType.cs
@@ -51,7 +51,7 @@ namespace Dynamo.CSLang {
 
 		public CSSimpleType (string name, bool isArray)
 		{
-			Name = Exceptions.ThrowOnNull (name, "name") + (isArray ? "[]" : "");
+			hiddenName = Exceptions.ThrowOnNull (name, "name") + (isArray ? "[]" : "");
 		}
 
 		public static explicit operator CSSimpleType (string name)
@@ -68,25 +68,8 @@ namespace Dynamo.CSLang {
 		{
 			IsGeneric = genericSpecialization != null && genericSpecialization.Length > 0;
 			GenericTypes = genericSpecialization;
-			GenericTypeName = name;
+			GenericTypeName = Exceptions.ThrowOnNull (name, nameof (name));
 			IsArray = isArray;
-
-			StringBuilder sb = new StringBuilder ();
-			sb.Append (Exceptions.ThrowOnNull (name, "name"));
-			if (genericSpecialization != null && genericSpecialization.Length > 0) {
-				sb.Append ("<");
-				int i = 0;
-				foreach (CSType type in genericSpecialization) {
-					if (i > 0)
-						sb.Append (", ");
-					sb.Append (type.ToString ());
-					i++;
-				}
-				sb.Append (">");
-			}
-			if (isArray)
-				sb.Append ("[]");
-			Name = sb.ToString ();
 		}
 
 		public CSSimpleType (string name, bool isArray, params string [] genericSpecialization)
@@ -94,11 +77,36 @@ namespace Dynamo.CSLang {
 		{
 		}
 
-		public string Name { get; private set; }
+		string hiddenName;
+		public string Name {
+			get {
+				return hiddenName ?? GenerateName ();
+			}
+		}
 		public bool IsGeneric { get; private set; }
 		public string GenericTypeName { get; private set; }
 		public CSType [] GenericTypes { get; private set; }
 		public bool IsArray { get; private set; }
+
+		string GenerateName ()
+		{
+			StringBuilder sb = new StringBuilder ();
+			sb.Append (GenericTypeName);
+			if (GenericTypes != null && GenericTypes.Length > 0) {
+				sb.Append ("<");
+				int i = 0;
+				foreach (CSType type in GenericTypes) {
+					if (i > 0)
+						sb.Append (", ");
+					sb.Append (type.ToString ());
+					i++;
+				}
+				sb.Append (">");
+			}
+			if (IsArray)
+				sb.Append ("[]");
+			return sb.ToString ();
+		}
 
 		protected override void LLWrite (ICodeWriter writer, object o)
 		{

--- a/SwiftReflector/GenericReferenceRenamer.cs
+++ b/SwiftReflector/GenericReferenceRenamer.cs
@@ -17,8 +17,7 @@ namespace SwiftReflector {
 
 		public TypeSpec Rename (TypeSpec type)
 		{
-			bool changed;
-			var newType = Rename (type, out changed);
+			var newType = Rename (type, out bool changed);
 			return changed ? newType : type;
 		}
 

--- a/SwiftReflector/GenericReferenceRenamer.cs
+++ b/SwiftReflector/GenericReferenceRenamer.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Dynamo;
+using SwiftReflector.SwiftXmlReflection;
+
+namespace SwiftReflector {
+	public class GenericReferenceRenamer {
+		BaseDeclaration context;
+		Func<int, int, string> genericNamer;
+		public GenericReferenceRenamer (BaseDeclaration context, Func<int, int, string> genericNamer)
+		{
+			this.context = Exceptions.ThrowOnNull (context, nameof (context));
+			this.genericNamer = Exceptions.ThrowOnNull (genericNamer, nameof (genericNamer));
+		}
+
+		public TypeSpec Rename (TypeSpec type)
+		{
+			bool changed;
+			var newType = Rename (type, out changed);
+			return changed ? newType : type;
+		}
+
+		TypeSpec Rename (TypeSpec type, out bool changed)
+		{
+			if (TypeSpec.IsNullOrEmptyTuple (type)) {
+				changed = false;
+				return type;
+			}
+			switch (type.Kind) {
+			case TypeSpecKind.Closure:
+				return Rename (type as ClosureTypeSpec, out changed);
+			case TypeSpecKind.Named:
+				return Rename (type as NamedTypeSpec, out changed);
+			case TypeSpecKind.Tuple:
+				return Rename (type as TupleTypeSpec, out changed);
+			case TypeSpecKind.ProtocolList:
+				return Rename (type as ProtocolListTypeSpec, out changed);
+			default:
+				throw new NotImplementedException ($"Unknown type spec kind {type.Kind.ToString ()}");
+			}
+		}
+
+		TypeSpec Rename (ClosureTypeSpec type, out bool changed)
+		{
+			bool argsChanged, resultChanged;
+			var args = Rename (type.Arguments, out argsChanged);
+			var result = Rename (type.ReturnType, out resultChanged);
+			changed = argsChanged || resultChanged;
+			if (changed) {
+				return new ClosureTypeSpec (args, result);
+			}
+			return type;
+		}
+
+		TypeSpec Rename (NamedTypeSpec type, out bool changed)
+		{
+			bool nameChanged = false, genArgsChanged = false;
+			string newName = null;
+			if (context.IsTypeSpecGenericReference (new NamedTypeSpec (type.Name))) {
+				var depthIndex = context.GetGenericDepthAndIndex (type.Name);
+				if (depthIndex.Item1 < 0 || depthIndex.Item2 < 0)
+					throw new ArgumentOutOfRangeException (type.Name, $"not getting a useful depth or index even though marked as a generic reference");
+				nameChanged = true;
+				newName = genericNamer (depthIndex.Item1, depthIndex.Item2);
+			}
+			TypeSpec [] newGenParms = type.GenericParameters.ToArray ();
+			if (type.GenericParameters != null) {
+				newGenParms = new TypeSpec [type.GenericParameters.Count];
+				for (int i = 0; i < newGenParms.Length; i++) {
+					bool genChanged;
+					newGenParms [i] = (Rename (type.GenericParameters [i], out genChanged));
+					genArgsChanged = genArgsChanged || genChanged;
+				}
+			}
+			changed = nameChanged || genArgsChanged;
+			if (changed) {
+				return new NamedTypeSpec (newName ?? type.Name, newGenParms);
+			}
+			return type;
+		}
+
+		TypeSpec Rename (TupleTypeSpec type, out bool changed)
+		{
+			changed = false;
+			var newTupleElems = new TypeSpec [type.Elements.Count];
+			for (int i = 0; i < type.Elements.Count; i++) {
+				bool elemChanged;
+				newTupleElems [i] = Rename (type.Elements [i], out elemChanged);
+				changed = changed || elemChanged;
+			}
+
+			if (changed) {
+				return new TupleTypeSpec (newTupleElems);
+			}
+			return type;
+		}
+	}
+}

--- a/SwiftReflector/MarshalEngineSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineSwiftToCSharp.cs
@@ -153,7 +153,7 @@ namespace SwiftReflector {
 							postMarshalCode.Add (SLReturn.ReturnLine (returnIdent));
 						}
 					} else {
-						if (func.IsTypeSpecGeneric (returnTypeSpec)) {
+						if (func.IsTypeSpecGenericReference (returnTypeSpec)) {
 							imports.AddIfNotPresent ("XamGlue");
 							// dealing with a generic here.
 							// UnsafeMutablePointer<T> retval = UnsafeMutablePointer<T>.alloc(1)
@@ -242,6 +242,9 @@ namespace SwiftReflector {
 							case TypeSpecKind.ProtocolList:
 							case TypeSpecKind.Tuple:
 							case TypeSpecKind.Named:
+								if (func.IsTypeSpecGeneric (returnTypeSpec) && GenericRenamer != null) {
+									returnTypeSpec = GenericRenamer.Rename (returnTypeSpec);
+								}
 								var namedReturn = returnTypeSpec as NamedTypeSpec;
 								// enums and structs can't get returned directly
 								// instead they will be inserted at the head of the argument list
@@ -484,6 +487,7 @@ namespace SwiftReflector {
 		}
 
 		public string SubstituteForSelf { get; set; }
+		public GenericReferenceRenamer GenericRenamer { get; set; }
 	}
 }
 

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -1252,6 +1252,7 @@ namespace SwiftReflector {
 
 			var marshal = new MarshalEngineSwiftToCSharp (Imports, idents, typeMapper);
 			marshal.SubstituteForSelf = SubstituteForSelf;
+			marshal.GenericRenamer = new GenericReferenceRenamer (func, SLGenericReferenceType.DefaultNamer);
 			ifblock.AddRange (marshal.MarshalFunctionCall (func,
 								      vtRef, VTableEntryIdentifier (index)));
 
@@ -1292,7 +1293,7 @@ namespace SwiftReflector {
 
 			SLType returnType = null;
 			var returnTypeSpec = func.ReturnTypeSpec.ReplaceName ("Self", SubstituteForSelf);
-			if (func.IsTypeSpecGeneric (returnTypeSpec)) {
+			if (func.IsTypeSpecGenericReference (returnTypeSpec)) {
 				var ns = (NamedTypeSpec)returnTypeSpec;
 				var depthIndex = func.GetGenericDepthAndIndex (ns.Name);
 				returnType = new SLGenericReferenceType (depthIndex.Item1, depthIndex.Item2);

--- a/SwiftReflector/PatToGenericMap.cs
+++ b/SwiftReflector/PatToGenericMap.cs
@@ -234,7 +234,7 @@ namespace SwiftReflector {
 			}
 			changed = nameChanged || genArgsChanged;
 			if (changed) {
-				return new NamedTypeSpec (newName, newGenParms);
+				return new NamedTypeSpec (newName ?? type.Name, newGenParms);
 			}
 			return type;
 		}

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -188,6 +188,7 @@
     <Compile Include="CompilationTargetCollection.cs" />
     <Compile Include="CompilationSettings.cs" />
     <Compile Include="IOUtils\Directories.cs" />
+    <Compile Include="GenericReferenceRenamer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/SwiftReflector/TypeMapping/TypeMapper.cs
+++ b/SwiftReflector/TypeMapping/TypeMapper.cs
@@ -590,8 +590,18 @@ namespace SwiftReflector.TypeMapping {
 					if (isPinvoke) {
 						return new NetTypeBundle ("System", "IntPtr", false, named.IsInOut, EntityType.None);
 					} else {
-						var assocType = context.AssociatedTypeDeclarationFromNamedTypeSpec (named);
-						return new NetTypeBundle (context.AsProtocolOrParentAsProtocol (), assocType, named.IsInOut);
+						if (named.ContainsGenericParameters) {
+							var en = TypeDatabase.EntityForSwiftName (named.Name);
+							var retval = new NetTypeBundle (en.SharpNamespace, en.SharpTypeName, false, spec.IsInOut, en.EntityType);
+							foreach (var gen in named.GenericParameters) {
+								var genNtb = MapType (context, gen, isPinvoke, isReturnValue);
+								retval.GenericTypes.Add (genNtb);
+							}
+							return retval;
+						} else {
+							var assocType = context.AssociatedTypeDeclarationFromNamedTypeSpec (named);
+							return new NetTypeBundle (context.AsProtocolOrParentAsProtocol (), assocType, named.IsInOut);
+						}
 					}
 				} else if (named.Name == "Self") {
 					if (isPinvoke) {

--- a/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ProtocolTests.cs
@@ -713,5 +713,20 @@ public func printSandwich (of: Bread, with: Filling) {
 			TestRunning.TestAndExecute (swiftCode, callingCode, "ham on whole wheat\n", otherClass: altClass,
 				generateDeviceTest: false);
 		}
+
+
+		[Test]
+		public void BasicIterator ()
+		{
+			var swiftCode = @"
+public protocol MyIterator {
+	associatedtype Element
+	func next () -> Self.Element?
+}
+";
+			var printIt = CSFunctionCall.ConsoleWriteLine (CSConstant.Val ("Got here"));
+			var callingCode = CSCodeBlock.Create (printIt);
+			TestRunning.TestAndExecute (swiftCode, callingCode, "Got here\n");
+		}
 	}
 }


### PR DESCRIPTION
Fix many issues around not being able to do an apparently simple binding, fixing issue [763](https://github.com/xamarin/binding-tools-for-swift/issues/763)

I started looking at other protocols in swift to build them into BTfS. I thought `Sequence` would be useful, because it's tiny: one method.
Oh you naive child.
In working with it, I found that the code as is could handle associated types in the form `AT` but not `SomeGeneric<AT>`.

The fixes were not hard, but there were several:
1. The marshal engine was using the wrong name for a type (it came from the original type and we were working on a wrapper. This needed yet another chunk of code to make a change in a `TypeSpec` in a very specific way.
2. The TypeMapper could handle identifying and mapping a `NamedTypeSpec` that is an associated type, but not a generic, so I put in code to do that. You should note that in any type of the form `SomeType<SomeOtherType>`, the `SomeType` can **never** be an associated type, so the code is simpler - it's straight forward structural recursion.
3. The OverrideBuilder was asking the wrong question to figure out if a type is generic. It should have been asking if a type is a generic reference.
4. The C# code generator was generating a type of the form `T0` instead of the form `ATAssociatedTypeName`. This took a little while to sort out because I had code to make this change and it looked good. Ultimately, the reason was because past Steve was lazy. There are two ways that Dynamo entities can work: non-lazy or lazy. Most of the entities in dynamo are immutable, so non-lazy makes some sense: You construct the output in the constructor. However, anything that is a generic reference can change later because generic references defer the naming until late because of associated types. The problem is that a bound generic type that contains a generic reference (`SomeType<T>` for example) is done non-lazily, which made it easy to write, but makes any changes in the generic namer don't get reflected in the final output. I changed this.

Surprisingly, all tests pass.