### PR TITLE
[parser] support for any keyword

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -1654,7 +1654,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			return flagsValue;
 		}
 
-		static string [] ModulesThatWeCanSkip = new string [] {
+		static HashSet<string> ModulesThatWeCanSkip = new HashSet<string> () {
 			"XamGlue",
 			"RegisterAccess",
 			"_StringProcessing",

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -144,6 +144,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		string moduleName;
 		TypeDatabase typeDatabase;
 		IModuleLoader moduleLoader;
+		ICharStream inputStream;
 
 		public SwiftInterfaceReflector (TypeDatabase typeDatabase, IModuleLoader moduleLoader)
 		{
@@ -179,9 +180,9 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 				var desugarer = new SyntaxDesugaringParser (inFile);
 				var desugaredResult = desugarer.Desugar ();
-				var charStream = CharStreams.fromString (desugaredResult);
+				inputStream = CharStreams.fromString (desugaredResult);
 
-				var lexer = new SwiftInterfaceLexer (charStream);
+				var lexer = new SwiftInterfaceLexer (inputStream);
 				var tokenStream = new CommonTokenStream (lexer);
 				var parser = new SwiftInterfaceParser (tokenStream);
 				var walker = new ParseTreeWalker ();
@@ -212,7 +213,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					new XElement ("modulelist", module));
 				var xDocument = new XDocument (new XDeclaration ("1.0", "utf-8", "yes"), tlElement);
 				return xDocument;
-			} catch (ParseException) {
+			} catch (ParseException parseException) {
 				throw;
 			} catch (Exception e) {
 				throw new ParseException ($"Unknown error parsing {inFile}: {e.Message}", e.InnerException);
@@ -328,7 +329,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var alias = EnumTypeAliases (context).FirstOrDefault (ta => ta.typealias_name ().GetText () == kRawValue);
 			if (alias == null)
 				return null;
-			var rawType = alias.typealias_assignment ().type ().GetText ();
+			var rawType = TypeText (alias.typealias_assignment ().type ());
 			return new XAttribute (kRawType, rawType);
 		}
 
@@ -496,7 +497,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		public override void EnterProtocol_associated_type_declaration ([NotNull] Protocol_associated_type_declarationContext context)
 		{
 			var conformingProtocols = GatherConformingProtocols (context.type_inheritance_clause ());
-			var defaultDefn = context.typealias_assignment ()?.type ().GetText ();
+			var defaultDefn = TypeText (context.typealias_assignment ()?.type ());
 			var assocType = new XElement (kAssociatedType,
 				new XAttribute (kName, UnTick (context.typealias_name ().GetText ())));
 			if (defaultDefn != null)
@@ -547,7 +548,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var signature = context.function_signature ();
 
 			var name = UnTick (context.function_name ().GetText ());
-			var returnType = signature.function_result () != null ? signature.function_result ().type ().GetText () : "()";
+			var returnType = signature.function_result () != null ? TypeText (signature.function_result ().type ()) : "()";
 			var accessibility = AccessibilityFromModifiers (head.declaration_modifiers ());
 			var isStatic = IsStaticOrClass (head.declaration_modifiers ());
 			var hasThrows = signature.throws_clause () != null || signature.rethrows_clause () != null;
@@ -719,7 +720,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			// On ExitSubscript_declaration, we remove the IGNORE tag
 
 			var head = context.subscript_head ();
-			var resultType = context.subscript_result ().type ().GetText ();
+			var resultType = TypeText (context.subscript_result ().type ());
 			var accessibility = AccessibilityFromModifiers (head.declaration_modifiers ());
 			var attributes = GatherAttributes (head.attributes ());
 			var isDeprecated = CheckForDeprecated (attributes);
@@ -782,6 +783,16 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			PopIgnore ();
 		}
 
+		string TypeText (TypeContext ty)
+		{
+			if (ty is null)
+				return null;
+			var start = ty.Start.StartIndex;
+			var end = ty.Stop.StopIndex;
+			var interval = new Interval (start, end);
+			return inputStream.GetText (interval);
+		}
+
 		public override void EnterVariable_declaration ([NotNull] Variable_declarationContext context)
 		{
 			var head = context.variable_declaration_head ();
@@ -798,9 +809,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			var isProperty = true;
 
 			foreach (var tail in context.variable_declaration_tail ()) {
-
 				var name = UnTick (tail.variable_name ().GetText ());
-				var resultType = TrimColon (tail.type_annotation ().GetText ());
+				var resultType = TypeText (tail.type_annotation ().type ());
 				var hasThrows = false;
 				var isAsync = HasAsync (tail.getter_setter_keyword_block ()?.getter_keyword_clause ());
 
@@ -920,7 +930,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void EnterOptional_type ([NotNull] Optional_typeContext context)
 		{
-			var innerType = context.type ().GetText ();
 		}
 
 		XElement InfixOperator (Infix_operator_declarationContext context)
@@ -984,7 +993,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 					genericElem.Add (MakeConformanceWhere (name, from));
 				} else {
 					var name = UnTick (requirement.same_type_requirement ().type_identifier ().GetText ());
-					var type = requirement.same_type_requirement ().type ().GetText ();
+					var type = TypeText (requirement.same_type_requirement ().type ());
 					genericElem.Add (MakeEqualityWhere (name, type));
 				}
 			}
@@ -996,7 +1005,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			var name = UnTick (context.typealias_name ().GetText ());
 			var generics = context.generic_parameter_clause ()?.GetText () ?? "";
-			var targetType = context.typealias_assignment ().type ().GetText ();
+			var targetType = TypeText (context.typealias_assignment ().type ());
 			var access = ToAccess (context.access_level_modifier ());
 			var map = new XElement (kTypeAlias, new XAttribute (kName, name + generics),
 				new XAttribute (kAccessibility, access),
@@ -1188,7 +1197,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		{
 			var typeAnnotation = context.type_annotation ();
 			var isInOut = typeAnnotation.inout_clause () != null;
-			var type = typeAnnotation.type ().GetText ();
+			var type = TypeText (typeAnnotation.type ());
 			var privateName = NoUnderscore (UnTick (context.local_parameter_name ()?.GetText ()) ?? "");
 			var replacementPublicName = isSubscript ? "" : privateName;
 			var publicName = NoUnderscore (UnTick (context.external_parameter_name ()?.GetText ()) ?? replacementPublicName);
@@ -1645,6 +1654,13 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			return flagsValue;
 		}
 
+		static string [] ModulesThatWeCanSkip = new string [] {
+			"XamGlue",
+			"RegisterAccess",
+			"_StringProcessing",
+			"_Concurrenct",
+		};
+
 		void LoadReferencedModules ()
 		{
 			var failures = new StringBuilder ();
@@ -1652,9 +1668,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				// XamGlue and RegisterAccess may very well get
 				// used, but we the functions/types exported from these
 				// should never need to be loaded.
-				if (module == "XamGlue")
-					continue;
-				if (module == "RegisterAccess")
+				if (ModulesThatWeCanSkip.Contains (module))
 					continue;
 				if (!moduleLoader.Load (module, typeDatabase)) {
 					if (failures.Length > 0)
@@ -2262,15 +2276,6 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		static bool IsCtorDtor (string name)
 		{
 			return ctorDtorNames.Contains (name);
-		}
-
-		static string TrimColon (string input)
-		{
-			if (!input.Contains (":"))
-				return input;
-			input = input.Trim ();
-			return input.StartsWith (":", StringComparison.Ordinal) ?
-				input.Substring (1) : input;
 		}
 
 		public static string UnTick (string str)

--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -49,6 +49,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 		public List<TypeSpecAttribute> Attributes { get; private set; }
 		public bool HasAttributes { get { return Attributes.Count != 0; } }
 		public bool IsInOut { get; set; }
+		public bool IsAny { get; set; }
 		public virtual bool IsEmptyTuple { get { return false; } }
 		protected abstract string LLToString (bool useFullName);
 		protected virtual string LLFinalStringParts () { return ""; }
@@ -132,6 +133,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 				return false;
 			if (IsInOut != spec.IsInOut)
 				return false;
+			if (IsAny != spec.IsAny)
+				return false;
 			return LLEquals (spec, false);
 		}
 
@@ -144,6 +147,8 @@ namespace SwiftReflector.SwiftXmlReflection {
 			if (!ListEqual (GenericParameters, spec.GenericParameters, true))
 				return false;
 			if (IsInOut != spec.IsInOut)
+				return false;
+			if (IsAny != spec.IsAny)
 				return false;
 			return LLEquals (spec, true);
 		}
@@ -258,6 +263,9 @@ namespace SwiftReflector.SwiftXmlReflection {
 			if (IsInOut)
 				builder.Append ("inout ");
 
+			if (IsAny)
+				builder.Append ("any ");
+
 			if (TypeLabel != null) {
 				builder.Append (TypeLabel).Append (": ");
 			}
@@ -366,6 +374,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				result.Attributes.AddRange (original.Attributes);
 				result.TypeLabel = original.TypeLabel;
 				result.IsInOut = original.IsInOut;
+				result.IsAny = original.IsAny;
 			}
 			return changed;
 		}

--- a/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpecParser.cs
@@ -25,6 +25,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			TypeSpec type = null;
 			List<TypeSpecAttribute> attrs = null;
 			var inout = false;
+			var isAny = false;
 			string typeLabel = null;
 			var throwsClosure = false;
 			var asyncClosure = false;
@@ -41,6 +42,12 @@ namespace SwiftReflector.SwiftXmlReflection {
 			// looks like it's inout
 			if (token.Kind == TypeTokenKind.TypeName && token.Value == "inout") {
 				inout = true;
+				tokenizer.Next ();
+				token = tokenizer.Peek ();
+			}
+
+			if (token.Kind == TypeTokenKind.TypeName && token.Value == "any") {
+				isAny = true;
 				tokenizer.Next ();
 				token = tokenizer.Peek ();
 			}
@@ -130,6 +137,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 			}
 
 			type.IsInOut = inout;
+			type.IsAny = isAny;
 			type.TypeLabel = typeLabel;
 
 			if (type != null && attrs != null) {

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -383,7 +383,7 @@ function_type_argument_list :
 	;
 
 function_type_argument : 
-	attributes? 'inout'? type
+	attributes? inout_clause? type
 	| argument_label type_annotation
 	;
 
@@ -400,12 +400,15 @@ type :
 	| protocol_composition_type # proto_comp_type
 	| type OpDot 'Type' # meta_type
 	| type OpDot 'Protocol' # proto_type
+	| any_clause type # boxed_protocol_type
 	| 'Any' # any_type
 	| 'Self' # self_type
 	| 'Self' OpDot type_identifier # self_long
 	;
 
 type_annotation : OpColon attributes? inout_clause? type ;
+
+any_clause : 'any' ;
 
 inout_clause : 'inout' ;
 

--- a/tests/tom-swifty-test/XmlReflectionTests/GenerativeTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/GenerativeTests.cs
@@ -198,7 +198,21 @@ namespace XmlReflectionTests {
 			Assert.AreEqual (0, spec.Attributes.Count ());
 		}
 
+		[Test]
+		public void HasAnyAttribute ()
+		{
+			var module = ReflectToModules (
+				"public func SomeFunction (a: any Equatable) { }\n", "SomeModule").FirstOrDefault ();
+			Assert.IsNotNull (module, "no module");
+			var func = module.AllTypesAndTopLevelDeclarations.OfType<FunctionDeclaration> ().FirstOrDefault ();
+			Assert.IsNotNull (func, "no function");
+			Assert.AreEqual (1, func.ParameterLists.Count, "wrong number of parameter lists");
+			Assert.AreEqual (1, func.ParameterLists [0].Count, "wong number of parameters");
 
+			var paramItem = func.ParameterLists [0] [0];
+			var spec = paramItem.TypeSpec;
+			Assert.IsTrue (spec.IsAny, "didn't find 'any'");
+		}
 	}
 }
 


### PR DESCRIPTION
Swift added the `any` keyword to the language. It gets used whenever a type is a boxed protocol (aka, existential container) and by default, the swift compiler will generate `any` for any type that would get bound into an existential container. The reasoning behind this, I've read, is that putting in `any` draws attention to this so that when you're using it, you realize that there is a cost to using this type.

What is the cost?
An existential container is a variable sized struct that contains a fixed-sized payload of 3 machine words, followed by a pointer to the type metadata for the value in the payload. This is then followed by 0 or more protocol witness table pointers. What is a witness table? It's a vtable -a table of function pointers that go to methods- that is sits separate from a type.

The cost is in allocating (if needed) the existential container, copying (with reference counting) the value into the payload OR allocating room on the heap for a copy of the value , copying (with reference counting) and then putting the pointer to the value into the payload. So, no, it's not free. I do not, however, see how the use of `any` does anything to draw attention to the cost other than to add syntactic clutter to the language.

```
public func doSomething (a: any SomeProtocol) { }
```
By comparison, you could also write equivalent code that is nearly equivalent to this like so:

```
public func doSomething<T:SomeProtocol> (a: T) { }
```
This uses a different ABI as there is no existential container and the type metadata pointer and protocol witness table(s) get passed in implicit arguments.

In order to do this I:
- added a new case to the `type` grammar in the production rules that with match `any` type.
- fixed an issue in `SwiftInterfaceReflector` that was not getting the text representing a type, but `GetText ()` does not include whitespace that may have existed in the original file and `any` is technically part of the type so I was getting `anyType` instead of `any Type`.
- added a case in `TypeSpecParser` to spot the `any` token and mark it in the `TypeSpec` type, and adjusted all the copy constructors and comparers
- swift now explicitly adds two implicit module imports to every compilation `_StringHandling` and `_Concurrency` which we have be able to load or ignore. I ignore them

Added a unit test.

