### PR TITLE
[parser] remove last bits of any parsing issues

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -31,9 +31,24 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			return rewriter.GetText ();
 		}
 
+		internal static string TypeText (ICharStream input, ParserRuleContext ty)
+		{
+			if (ty is null)
+				return null;
+			var start = ty.Start.StartIndex;
+			var end = ty.Stop.StopIndex;
+			var interval = new Interval (start, end);
+			return input.GetText (interval);
+		}
+
+		string TypeText (ParserRuleContext ty)
+		{
+			return TypeText (charStream, ty);
+		}
+
 		public override void ExitOptional_type ([NotNull] Optional_typeContext context)
 		{
-			var innerType = context.type ().GetText ();
+			var innerType = TypeText (context.type ());
 			var replacementType = $"Swift.Optional<{innerType}>";
 			var startToken = context.Start;
 			var endToken = context.Stop;
@@ -42,7 +57,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void ExitUnwrapped_optional_type ([NotNull] Unwrapped_optional_typeContext context)
 		{
-			var innerType = context.type ().GetText ();
+			var innerType = TypeText (context.type ());
 			var replacementType = $"Swift.Optional<{innerType}>";
 			var startToken = context.Start;
 			var endToken = context.Stop;
@@ -51,7 +66,7 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void ExitArray_type ([NotNull] Array_typeContext context)
 		{
-			var innerType = context.type ().GetText ();
+			var innerType = TypeText (context.type ());
 			var replacementType = $"Swift.Array<{innerType}>";
 			var startToken = context.Start;
 			var endToken = context.Stop;
@@ -60,8 +75,8 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 		public override void ExitDictionary_type ([NotNull] Dictionary_typeContext context)
 		{
-			var keyType = context.children [1].GetText ();
-			var valueType = context.children [3].GetText ();
+			var keyType = TypeText (context.children [1] as ParserRuleContext);
+			var valueType = TypeText (context.children [3] as ParserRuleContext);
 			var replacementType = $"Swift.Dictionary<{keyType},{valueType}>";
 			var startToken = context.Start;
 			var endToken = context.Stop;


### PR DESCRIPTION
There were a few leftover unprotected calls to `GetText` in SwiftInterfaceReflector.
I changed `TypeText` to take a `ParserRuleContext` which is more generalizable
Made an internal static implementation so it can be called from the DesugaringParser
Fixed `GetText` calls in DesugaringParser.


Background
The `GetText` call is good for a single token and a single token only. If a rule represents multiple tokens, we get something like `Token1Token2Token3` instead of `Token1 Token2 Token3`. You'd think that the best approach to this is to interleave spaces with each token, but you don't always know whether a sub piece in the tree is a token or series of tokens that match a larger rule. As such, the antlr way of doing things is to make an interval from the rule and use a library routine to get the text from the original stream. This may be way more text than we actually need (for example `Token1                                          Token2`), but that's for the best. Antlr is a general parser and in some languages that it accepts, the whitespace is significant so replacing it with a single character is not always the right answer. In this case it is. If we care, we could write an extension method on string to collapse all whitespace to a single character if we wanted to.