### PR TITLE
[types] Don't compare "any" we can't guarantee that we have it.

### DIFF
--- a/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
+++ b/SwiftReflector/SwiftXmlReflection/TypeSpec.cs
@@ -133,8 +133,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				return false;
 			if (IsInOut != spec.IsInOut)
 				return false;
-			if (IsAny != spec.IsAny)
-				return false;
+			// Don't compare IsAny - it's really not important (yet)
 			return LLEquals (spec, false);
 		}
 
@@ -148,8 +147,7 @@ namespace SwiftReflector.SwiftXmlReflection {
 				return false;
 			if (IsInOut != spec.IsInOut)
 				return false;
-			if (IsAny != spec.IsAny)
-				return false;
+			// Don't compare IsAny - it's really not important (yet)
 			return LLEquals (spec, true);
 		}
 


### PR DESCRIPTION
When I stubbed in support for `any` I put in a comparator in `TypeSpec`. This creates a couple issues.
The first is that when I reflect on a module using the .swiftinterface file, I will get `any` tags that I hadn't put in the original code. There's added by the swift compiler as a 'service'. If I'm looking for a wrapper function that I wrote, the original won't have `any`.
Second, when I import functions the .dylib file, there are no `any` tags in the mangled signature.

My choices here are to:
1. Add any tags when I write functions (possible, but tricky to get right in all cases, especially generics or tuples that are nested: `Foo<Bar<Baz<any SomeProtocol>>> and to add any tags to `SwiftType` used from .dylib files (tricky for the same reasons)
2. Make comparisons ignoring `Any` (expedient)

Since I don't see any particular downside to 2, I went with that.