### PR TITLE
[parser] remove private labels from closure types

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -95,6 +95,18 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 				rewriter.Replace (startToken, endToken, "CoreGraphics.CGFloat");
 			}
 		}
+
+		public override void ExitFunction_type_argument([NotNull] Function_type_argumentContext context)
+		{
+			if (context.argument_label () is Argument_labelContext argContext && argContext.ChildCount == 2) {
+				// function type argument of the form public_label private_label
+				// change to public_label
+				// in a .swiftinterface context, the private label means nothing to us
+				var startToken = argContext.Start;
+				var endToken = argContext.Stop;
+				rewriter.Replace (startToken, endToken, argContext.children [0].GetText ());
+			}
+		}
 	}
 }
 

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -387,7 +387,7 @@ function_type_argument :
 	| argument_label type_annotation
 	;
 
-argument_label : label_identifier ;
+argument_label : label_identifier | label_identifier label_identifier;
 
 type : 
 	array_type # arr_type


### PR DESCRIPTION
Previously, if you had this variable declaration:
```
     public var clos = {(x: Bool) in return x}
```
It would show up in the swift interface file as type `(_: Bool) -> Bool`
The current version of the compiler surfaces it as type `(_ x: Bool) -> Bool`
The parser wouldn't accept a type of `(public_name private_name: type) -> type`, so I adjusted the grammar to do that.
The problem though is that when this type gets surfaced inside we can't handle a closure parameter type with a public and private name, so I desugar it into `(public_name: type) -> type` which is just fine.
