### PR TITLE
handled CGRect issue

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SyntaxDesugaringParser.cs
@@ -6,6 +6,7 @@ using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 using static SwiftInterfaceParser;
+using System.Collections.Generic;
 
 namespace SwiftReflector.SwiftInterfaceReflector {
 	public class SyntaxDesugaringParser : SwiftInterfaceBaseListener {
@@ -83,16 +84,22 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			rewriter.Replace (startToken, endToken, replacementType);
 		}
 
+		static Dictionary<string, string> typeChanges = new Dictionary<string, string> () {
+			{ "Swift.Void", "()" },
+			{ "CoreFoundation.CGAffineTransform", "CoreGraphics.CGAffineTransform" },
+			{ "CoreFoundation.CGColorSapceModel", "CoreGraphics.CGColorSapceModel" },
+			{ "CoreFoundation.CGPoint", "CoreGraphics.CGPoint" },
+			{ "CoreFoundation.CGRect", "CoreGraphics.CGRect" },
+			{ "CoreFoundation.CGSize", "CoreGraphics.CGSize" },
+			{ "CoreFoundation.CGVector", "CoreGraphics.CGVector" },
+		};
+
 		public override void ExitIdentifier_type ([NotNull] Identifier_typeContext context)
 		{
-			if (context.GetText () == "Swift.Void") {
+			if (typeChanges.TryGetValue (context.GetText (), out var substitution)) {
 				var startToken = context.Start;
 				var endToken = context.Stop;
-				rewriter.Replace (startToken, endToken, "()");
-			} else if (context.GetText () == "CoreFoundation.CGFloat") {
-				var startToken = context.Start;
-				var endToken = context.Stop;
-				rewriter.Replace (startToken, endToken, "CoreGraphics.CGFloat");
+				rewriter.Replace (startToken, endToken, substitution);
 			}
 		}
 	}


### PR DESCRIPTION
So it turns out that these structs get aliased to all kinds of things.
The error I was seeing was a type that in the test was `NSRect` and when compiled shows up in the dylib as `_C.CGRect` which is...quite a thing. Past Steve in the demangler, translated this to `CoreGraphics.CGRect`, whereas the `.swiftinterface` file reports it as `CoreFoundation.CGRect` - a type which does not actually exist. (insert mind-blown.gif)
To keep things consistent, I use the desugaring parser to translate that type (and a bunch of others - thanks past Steve) to the correct or at least to a consistent type that the swift compiler accepts.