### PR TITLE
fixed parser for variable initialization clause

### DIFF
--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -865,11 +865,17 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 		bool HasSetter (Variable_declaration_tailContext context, bool isLet)
 		{
 			// conditions for having a setter:
-			// getter_setter_keyword_block is null (public var foo: Type)
+			// defaultInitializer and getter_setter_keyword are both null (public var foo: Type)
+			// defaultInitializer is not null (public var foo: Type = initialValue)
 			// getter_setter_keyword_block is non-null and the getter_setter_keyword_block
 			// has a non-null setter_keyword_clause (public var foo:Type { get; set; }, public foo: Type { set }
-			return !isLet && (context.getter_setter_keyword_block () == null ||
-				context.getter_setter_keyword_block ().setter_keyword_clause () != null);
+
+			var defaultInitializer = context.defaultInitializer ();
+			var gettersetter = context.getter_setter_keyword_block ();
+
+			return !isLet && ((defaultInitializer == null && gettersetter == null) ||
+				defaultInitializer != null ||
+				gettersetter?.setter_keyword_clause () != null);
 		}
 
 		public override void EnterExtension_declaration ([NotNull] Extension_declarationContext context)

--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -71,7 +71,8 @@ import_path_identifier : declaration_identifier ;
 variable_declaration: variable_declaration_head variable_declaration_tail (OpComma variable_declaration_tail)* ;
 variable_declaration_head : attributes? declaration_modifiers? var_clause
 	| attributes? declaration_modifiers? let_clause ;
-variable_declaration_tail : variable_name type_annotation getter_setter_keyword_block? ;
+variable_declaration_tail : variable_name type_annotation getter_setter_keyword_block? 
+	| variable_name type_annotation defaultInitializer?;
 variable_name : declaration_identifier ;
 
 var_clause : 'var';

--- a/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
+++ b/tests/tom-swifty-test/XmlReflectionTests/DynamicXmlTests.cs
@@ -1724,5 +1724,23 @@ return a + b
 			var fn = module.TopLevelFunctions.FirstOrDefault (f => f.Name == "sum");
 			Assert.IsNotNull (fn, "no function");
 		}
+
+		[TestCase (ReflectorMode.Parser)]
+		public void InitializedProperty (ReflectorMode mode)
+		{
+			var code = @"
+@frozen
+public struct Foo {
+    public var X:Int = 17
+}
+";
+			var module = ReflectToModules (code, "SomeModule", mode).FirstOrDefault (m => m.Name == "SomeModule");
+			Assert.IsNotNull (module, "no module");
+			var cl = module.Structs.FirstOrDefault (c => c.Name == "Foo");
+			Assert.IsNotNull (cl, "no class");
+
+			var prop = cl.AllProperties ().FirstOrDefault (p => p.Name == "X");
+			Assert.IsNotNull (prop, "no prop");
+		}
 	}
 }


### PR DESCRIPTION
If you declare a `@frozen struct` that has `var` declarations with initialization clauses, the swift compiler will put the initializer into the `.swiftinterface` file.
Changed the `variable_declaration_tail` clause to handle an initializer.
Changed the `HasSetter` predicate
Added a unit test
All tests pass.