### PR TITLE
Fixed a parsing error in Dyck expressions

### DIFF
--- a/swiftinterfaceparser/SwiftInterface.g4
+++ b/swiftinterfaceparser/SwiftInterface.g4
@@ -297,7 +297,7 @@ dyckSubExpression :
 	| any_other_things_for_dyck_expression;
 
 any_other_things_for_dyck_expression :	
-	( OpDot | OpComma | OpColon | OpSemi | OpAssign | OpAt | OpPound | OpBackTick | OpQuestion | OpUnder)
+	( OpDot | OpComma | OpColon | OpSemi | OpAssign | OpAt | OpPound | OpBackTick | OpQuestion | OpUnder | OpPlus | OpMinus | OpAmp | OpBang | OpTilde | OpGreater | opGreater)
 	| arrow_operator
 	;
 


### PR DESCRIPTION
Added missing operators to the standard list to stop parse errors where there is inline code that uses these.
This fixes issue [793](https://github.com/xamarin/binding-tools-for-swift/issues/793).

As background, a Dyck expression is any expression which consists of arbitrary token that may be surrounded by balanced sets of a bracketing tokens. Inline functions and default values in Swift may have very complicated expressions, but we don't care at all about these, so we can get away with writing these of as a Dyck expression, of which the Swift language is a subset.