### PR TITLE
add some basic parallelism to improve performance

### DIFF
--- a/SwiftReflector/Inventory/ClassInventory.cs
+++ b/SwiftReflector/Inventory/ClassInventory.cs
@@ -22,12 +22,14 @@ namespace SwiftReflector.Inventory {
 				return;
 			SwiftName className = ToClassName (tld);
 			SwiftClassName formalName = ToFormalClassName (tld);
-			ClassContents contents = null;
-			if (!values.TryGetValue (className, out contents)) {
-				contents = new ClassContents (formalName, sizeofMachinePointer);
-				values.Add (className, contents);
+			lock (valuesLock) {
+				ClassContents contents = null;
+				if (!values.TryGetValue (className, out contents)) {
+					contents = new ClassContents (formalName, sizeofMachinePointer);
+					values.Add (className, contents);
+				}
+				contents.Add (tld, srcStm);
 			}
-			contents.Add (tld, srcStm);
 		}
 
 		public static SwiftClassName ToFormalClassName (TLDefinition tld)

--- a/SwiftReflector/Inventory/FunctionInventory.cs
+++ b/SwiftReflector/Inventory/FunctionInventory.cs
@@ -22,12 +22,14 @@ namespace SwiftReflector.Inventory {
 			if (tlf == null)
 				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 10, $"expected a top-level function but got a {tld.GetType ().Name}");
 
-			OverloadInventory overloads = null;
-			if (!values.TryGetValue (tlf.Name, out overloads)) {
-				overloads = new OverloadInventory (tlf.Name, sizeofMachinePointer);
-				values.Add (tlf.Name, overloads);
+			lock (valuesLock) {
+				OverloadInventory overloads = null;
+				if (!values.TryGetValue (tlf.Name, out overloads)) {
+					overloads = new OverloadInventory (tlf.Name, sizeofMachinePointer);
+					values.Add (tlf.Name, overloads);
+				}
+				overloads.Add (tlf, srcStm);
 			}
-			overloads.Add (tlf, srcStm);
 		}
 
 		public TLFunction ContainsEquivalentFunction (TLFunction func)

--- a/SwiftReflector/Inventory/Inventory.cs
+++ b/SwiftReflector/Inventory/Inventory.cs
@@ -8,6 +8,7 @@ using SwiftReflector.Demangling;
 
 namespace SwiftReflector.Inventory {
 	public abstract class Inventory<T> {
+		protected object valuesLock = new object ();
 		protected Dictionary<SwiftName, T> values = new Dictionary<SwiftName, T> ();
 
 		public IEnumerable<SwiftName> Names { get { return values.Keys; } }
@@ -17,7 +18,9 @@ namespace SwiftReflector.Inventory {
 
 		public bool ContainsName (SwiftName name)
 		{
-			return values.ContainsKey (name);
+			lock (valuesLock) {
+				return values.ContainsKey (name);
+			}
 		}
 		public bool ContainsName (string name)
 		{
@@ -26,7 +29,9 @@ namespace SwiftReflector.Inventory {
 
 		public bool TryGetValue (SwiftName name, out T value)
 		{
-			return values.TryGetValue (name, out value);
+			lock (valuesLock) {
+				return values.TryGetValue (name, out value);
+			}
 		}
 
 		public bool TryGetValue (string name, out T value)

--- a/SwiftReflector/Inventory/OverloadInventory.cs
+++ b/SwiftReflector/Inventory/OverloadInventory.cs
@@ -21,13 +21,15 @@ namespace SwiftReflector.Inventory {
 
 		public override void Add (TLDefinition tld, Stream srcStm)
 		{
-			TLFunction tlf = tld as TLFunction;
-			if (tlf == null)
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 11, $"expected a top-level function but got a {tld.GetType ().Name}");
-			if (Functions.Exists (f => tlf.MangledName == f.MangledName)) {
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 12, $"duplicate function found for {tlf.MangledName}");
-			} else {
-				Functions.Add (tlf);
+			lock (valuesLock) {
+				TLFunction tlf = tld as TLFunction;
+				if (tlf == null)
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 11, $"expected a top-level function but got a {tld.GetType ().Name}");
+				if (Functions.Exists (f => tlf.MangledName == f.MangledName)) {
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 12, $"duplicate function found for {tlf.MangledName}");
+				} else {
+					Functions.Add (tlf);
+				}
 			}
 		}
 

--- a/SwiftReflector/Inventory/PropertyInventory.cs
+++ b/SwiftReflector/Inventory/PropertyInventory.cs
@@ -19,21 +19,23 @@ namespace SwiftReflector.Inventory {
 
 		public override void Add (TLDefinition tld, Stream srcStm)
 		{
-			TLFunction tlf = tld as TLFunction;
-			if (tlf == null)
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 7, $"Expected a TLFunction for a property but got a {tld.GetType ().Name}.");
+			lock (valuesLock) {
+				TLFunction tlf = tld as TLFunction;
+				if (tlf == null)
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 7, $"Expected a TLFunction for a property but got a {tld.GetType ().Name}.");
 
-			SwiftPropertyType prop = tlf.Signature as SwiftPropertyType;
-			if (prop == null)
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 8, $"Expected a function of property type but got a {tlf.Signature.GetType ().Name}.");
+				SwiftPropertyType prop = tlf.Signature as SwiftPropertyType;
+				if (prop == null)
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 8, $"Expected a function of property type but got a {tlf.Signature.GetType ().Name}.");
 
-			PropertyContents contents = null;
-			SwiftName nameToUse = prop.PrivateName ?? prop.Name;
-			if (!values.TryGetValue (nameToUse, out contents)) {
-				contents = new PropertyContents (tlf.Class, nameToUse, sizeofMachinePointer);
-				values.Add (nameToUse, contents);
+				PropertyContents contents = null;
+				SwiftName nameToUse = prop.PrivateName ?? prop.Name;
+				if (!values.TryGetValue (nameToUse, out contents)) {
+					contents = new PropertyContents (tlf.Class, nameToUse, sizeofMachinePointer);
+					values.Add (nameToUse, contents);
+				}
+				contents.Add (tlf, prop);
 			}
-			contents.Add (tlf, prop);
 		}
 
 		public PropertyContents PropertyWithName (SwiftName name)

--- a/SwiftReflector/Inventory/ProtocolInventory.cs
+++ b/SwiftReflector/Inventory/ProtocolInventory.cs
@@ -15,14 +15,16 @@ namespace SwiftReflector.Inventory {
 
 		public override void Add (TLDefinition tld, Stream srcStm)
 		{
-			SwiftName className = ClassInventory.ToClassName (tld);
-			SwiftClassName formalName = ClassInventory.ToFormalClassName (tld);
-			ProtocolContents contents = null;
-			if (!values.TryGetValue (className, out contents)) {
-				contents = new ProtocolContents (formalName, sizeofMachinePointer);
-				values.Add (className, contents);
+			lock (valuesLock) {
+				SwiftName className = ClassInventory.ToClassName (tld);
+				SwiftClassName formalName = ClassInventory.ToFormalClassName (tld);
+				ProtocolContents contents = null;
+				if (!values.TryGetValue (className, out contents)) {
+					contents = new ProtocolContents (formalName, sizeofMachinePointer);
+					values.Add (className, contents);
+				}
+				contents.Add (tld, srcStm);
 			}
-			contents.Add (tld, srcStm);
 		}
 	}
 }

--- a/SwiftReflector/Inventory/VariableInventory.cs
+++ b/SwiftReflector/Inventory/VariableInventory.cs
@@ -16,23 +16,25 @@ namespace SwiftReflector.Inventory {
 		}
 		public override void Add (TLDefinition tld, Stream srcStm)
 		{
-			TLVariable vari = tld as TLVariable;
-			if (vari != null) {
-				VariableContents contents = GoGetIt (vari.Name);
-				if (contents.Variable != null)
-					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 4, $"duplicate variable {vari.Name.Name}.");
-				contents.Variable = vari;
-				return;
-			}
+			lock (valuesLock) {
+				TLVariable vari = tld as TLVariable;
+				if (vari != null) {
+					VariableContents contents = GoGetIt (vari.Name);
+					if (contents.Variable != null)
+						throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 4, $"duplicate variable {vari.Name.Name}.");
+					contents.Variable = vari;
+					return;
+				}
 
-			TLFunction tlf = tld as TLFunction;
-			if (tlf != null) {
-				VariableContents contents = GoGetIt (tlf.Name);
-				contents.Addressors.Add (tlf);
-				return;
-			}
+				TLFunction tlf = tld as TLFunction;
+				if (tlf != null) {
+					VariableContents contents = GoGetIt (tlf.Name);
+					contents.Addressors.Add (tlf);
+					return;
+				}
 
-			throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 5, $"expected a top-level function or top-level variable but got a {tld.GetType ().Name}");
+				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 5, $"expected a top-level function or top-level variable but got a {tld.GetType ().Name}");
+			}
 
 		}
 

--- a/SwiftReflector/Inventory/WitnessInventory.cs
+++ b/SwiftReflector/Inventory/WitnessInventory.cs
@@ -11,6 +11,7 @@ using ObjCRuntime;
 
 namespace SwiftReflector.Inventory {
 	public class WitnessInventory {
+		object valuesLock = new object ();
 		Dictionary<string, TLFunction> values = new Dictionary<string, TLFunction> ();
 		int sizeofMachinePointer;
 
@@ -21,14 +22,16 @@ namespace SwiftReflector.Inventory {
 
 		public void Add (TLDefinition tld, Stream srcStm)
 		{
-			TLFunction tlf = tld as TLFunction;
-			if (tlf == null)
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 9, $"Expected a TLFunction for a witness table but got a {tld.GetType ().Name}.");
+			lock (valuesLock) {
+				TLFunction tlf = tld as TLFunction;
+				if (tlf == null)
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 9, $"Expected a TLFunction for a witness table but got a {tld.GetType ().Name}.");
 
-			if (values.ContainsKey (tlf.MangledName))
-				throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 10, $"Already received witness table entry for {tlf.MangledName}.");
-			values.Add (tlf.MangledName, tlf);
-			LoadWitnessTable (tlf, srcStm);
+				if (values.ContainsKey (tlf.MangledName))
+					throw ErrorHelper.CreateError (ReflectorError.kInventoryBase + 10, $"Already received witness table entry for {tlf.MangledName}.");
+				values.Add (tlf.MangledName, tlf);
+				LoadWitnessTable (tlf, srcStm);
+			}
 		}
 
 		public IEnumerable<string> MangledNames { get { return values.Keys; } }

--- a/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
+++ b/SwiftReflector/SwiftInterfaceReflector/SwiftInterfaceReflector.cs
@@ -14,6 +14,8 @@ using System.Text;
 using Dynamo;
 using SwiftReflector.TypeMapping;
 using SwiftReflector.SwiftXmlReflection;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace SwiftReflector.SwiftInterfaceReflector {
 	public class SwiftInterfaceReflector : SwiftInterfaceBaseListener {
@@ -152,6 +154,19 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 			this.moduleLoader = Exceptions.ThrowOnNull (moduleLoader, nameof (moduleLoader));
 		}
 
+		public async Task ReflectAsync (string inFile, Stream outStm)
+		{
+			Exceptions.ThrowOnNull (inFile, nameof (inFile));
+			Exceptions.ThrowOnNull (outStm, nameof (outStm));
+
+
+			await Task.Run (() => {
+				var xDocument = Reflect (inFile);
+				xDocument.Save (outStm);
+				currentElement.Clear ();
+			});
+		}
+
 		public void Reflect (string inFile, Stream outStm)
 		{
 			Exceptions.ThrowOnNull (inFile, nameof (inFile));
@@ -161,6 +176,13 @@ namespace SwiftReflector.SwiftInterfaceReflector {
 
 			xDocument.Save (outStm);
 			currentElement.Clear ();
+		}
+
+		public async Task<XDocument> ReflectAsync (string inFile)
+		{
+			return await Task.Run (() => {
+				return Reflect (inFile);
+			});
 		}
 
 		public XDocument Reflect (string inFile)


### PR DESCRIPTION
First cut on making aspects of BTfS parallelizable.

ErrorHandling and the *Inventory stack needed to be made thread-safe.

I made reflection and demangling async and changed how they're being invoked to run them in parallel.
Across the entire suit of unit tests, this improves performance by about 7%.

I'm fairly certain that I can make the C# code generation parallel as well - but I'll do that in a separate PR.
