### PR TITLE
fix macOS references and libraries

### DIFF
--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -193,7 +193,7 @@ namespace tomwiftytest {
 
 			result = ExecAndCollect.Run ("/usr/local/share/dotnet/dotnet", $"add reference {projectReference}", projectDirectory);
 			sb.Append (result);
-			result = ExecAndCollect.Run ("/usr/local/share/dotnet/dotnet", "build", projectDirectory);
+			result = ExecAndCollect.Run ("/usr/local/share/dotnet/dotnet", "build --property:LinkMode=SdkOnly --property:AllowUnsafeBlocks=true", projectDirectory);
 			sb.Append (result);
 			result = sb.ToString ();
 


### PR DESCRIPTION
This PR does 3 small things:
1. adds LinkMode=SdkOnly and AllowUnsafeBlocks=true to the build The first corrects issues at runtime with store kit
2. copies dylibs from the build into the target app in the MonoBundle folder
3. copies XamGlue into the Frameworks folder

This allows 15 new tests to pass