### PR TITLE
fixed boolean marshaling return values

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSArgument.cs
+++ b/Dynamo/Dynamo.CSLang/CSArgument.cs
@@ -22,6 +22,14 @@ namespace Dynamo.CSLang {
 		{
 			Add (new CSArgument (expr));
 		}
+
+		public static CSArgumentList FromExpressions (params ICSExpression [] exprs)
+		{
+			var al = new CSArgumentList ();
+			foreach (var ex in exprs)
+				al.Add (new CSArgument (ex));
+			return al;
+		}
 	}
 }
 

--- a/Dynamo/Dynamo.CSLang/CSAttribute.cs
+++ b/Dynamo/Dynamo.CSLang/CSAttribute.cs
@@ -26,6 +26,11 @@ namespace Dynamo.CSLang {
 		{
 		}
 
+		public CSAttribute (string name, params ICSExpression [] exprs)
+			: this (new CSIdentifier(name), CSArgumentList.FromExpressions (exprs))
+		{
+		}
+
 		// DllImport("msvcrt.dll", EntryPoint="puts")
 		public static CSAttribute DllImport (string dllName, string entryPoint = null)
 		{
@@ -44,6 +49,10 @@ namespace Dynamo.CSLang {
 				args.Add (new CSAssignment ("EntryPoint", CSAssignmentOperator.Assign, CSConstant.Val (entryPoint)));
 			return new CSAttribute (new CSIdentifier ("DllImport"), args, true);
 		}
+
+		static CSAttribute returnMarshalAsI1 = new CSAttribute ("return: MarshalAs", new CSIdentifier ("UnmanagedType.I1"));
+
+		public static CSAttribute ReturnMarshalAsI1 => returnMarshalAsI1;
 
 		public static CSAttribute FieldOffset (int offset)
 		{

--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -256,8 +256,12 @@ namespace SwiftReflector {
 
 			if (isPinvoke) {
 				AddExtraGenericArguments (func, csParams, packs);
-				return CSMethod.InternalPInvoke (csReturnType, funcName, libraryPath,
+				var pinvoke = CSMethod.InternalPInvoke (csReturnType, funcName, libraryPath,
 					mangledName.Substring (1), csParams);
+				if (csReturnType is CSSimpleType simple && simple.Name == "bool") {
+					CSAttribute.ReturnMarshalAsI1.AttachBefore (pinvoke);
+				}
+				return pinvoke;
 			} else {
 				CSMethod retval = null;
 				if (func.IsConstructor) {

--- a/SwiftRuntimeLibrary/SwiftCore.cs
+++ b/SwiftRuntimeLibrary/SwiftCore.cs
@@ -27,6 +27,7 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		[DllImport (SwiftCoreConstants.LibSwiftCore)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool swift_isDeallocating (IntPtr p);
 
 		public static bool IsDeallocating (IntPtr p)
@@ -284,6 +285,7 @@ namespace SwiftRuntimeLibrary {
 
 
 		[DllImport (SwiftCoreConstants.LibSwiftCore)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		static extern bool swift_dynamicCast (IntPtr dest, IntPtr src, SwiftMetatype srcType, SwiftMetatype targetType, nint flags);
 
 		unsafe static bool DynamicCast (ref object dest, object src, Type srcType, Type destType, DynamicCastFlags flags)
@@ -383,6 +385,7 @@ namespace SwiftRuntimeLibrary {
 
 #if __IOS__ || __MACOS__ || __WATCHOS__ || __TVOS__
 		[DllImport (kXamGlue, EntryPoint = XamGlueConstants.SwiftCore_GetEnumMetadata)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool GetEnumMetadataByName (byte [] stringData, out SwiftMetatype swiftMetatype);
 #else
 		// the underlying pinvoke only exists on a specific platform, for no platform default to failure.

--- a/SwiftRuntimeLibrary/SwiftDictionary.cs
+++ b/SwiftRuntimeLibrary/SwiftDictionary.cs
@@ -307,8 +307,8 @@ namespace SwiftRuntimeLibrary {
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.SwiftDictionary_DictValues)]
 		public static extern IntPtr DictValues (IntPtr retVal, IntPtr dict, SwiftMetatype keyType, SwiftMetatype valType,
 														   IntPtr protoWitness);
-
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.SwiftDictionary_DictContainsKey)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool DictContainsKey (IntPtr dict, IntPtr keyPtr, SwiftMetatype keyType, SwiftMetatype valType,
 													  IntPtr protoWitness);
 
@@ -317,6 +317,7 @@ namespace SwiftRuntimeLibrary {
 					    IntPtr protoWitness);
 
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.SwiftDictionary_DictRemove)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool DictRemove (IntPtr dictPtr, IntPtr keyPtr, SwiftMetatype keyType, SwiftMetatype valType,
 							     IntPtr protoWitness);
 

--- a/SwiftRuntimeLibrary/SwiftEquatableProxy.cs
+++ b/SwiftRuntimeLibrary/SwiftEquatableProxy.cs
@@ -22,7 +22,7 @@ namespace SwiftRuntimeLibrary {
 
 		struct Equatable_xam_vtable {
 			public delegate bool Delfunc0 (IntPtr one, IntPtr two);
-			public unsafe delegate *unmanaged<IntPtr, IntPtr, bool> func0;
+			public unsafe delegate *unmanaged<IntPtr, IntPtr, byte> func0;
 		}
 
 		static Equatable_xam_vtable vtableIEquatable;
@@ -32,15 +32,15 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		[UnmanagedCallersOnly]
-		static bool EqFunc (IntPtr oneptr, IntPtr twoptr)
+		static byte EqFunc (IntPtr oneptr, IntPtr twoptr)
 		{
 			if (oneptr == twoptr)
-				return true;
+				return 1;
 
 			var one = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftEquatable> (oneptr);
 			var two = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftEquatable> (twoptr);
 
-			return one.OpEquals (two);
+			return one.OpEquals (two) ? (byte)1 : (byte)0;
 		}
 
 		static void XamSetVTable ()

--- a/SwiftRuntimeLibrary/SwiftOptional.cs
+++ b/SwiftRuntimeLibrary/SwiftOptional.cs
@@ -124,6 +124,7 @@ namespace SwiftRuntimeLibrary {
 		internal static extern SwiftMetatype PIMetadataAccessor_SwiftOptional (SwiftMetadataRequest request, SwiftMetatype mt);
 
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.NativeMethodsForSwiftOptional_HasValue)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool HasValue (IntPtr val, SwiftMetatype mt);
 
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.NativeMethodsForSwiftOptional_Case)]

--- a/SwiftRuntimeLibrary/SwiftSet.cs
+++ b/SwiftRuntimeLibrary/SwiftSet.cs
@@ -134,6 +134,7 @@ namespace SwiftRuntimeLibrary {
 		public static extern nint SetGetCount (IntPtr self, SwiftMetatype t, IntPtr protoWitness);
 
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.SwiftSet_SetIsEmpty)]
+		[return: MarshalAs (UnmanagedType.I1)]
 		public static extern bool SetIsEmpty (IntPtr self, SwiftMetatype t, IntPtr protoWitness);
 
 		[DllImport (SwiftCore.kXamGlue, EntryPoint = XamGlueConstants.SwiftSet_SetGetCapacity)]


### PR DESCRIPTION
This fixes about 20 tests for funcs that return boolean values.
In swift land, booleans are return only in the bottom bit and apparently .NET 7 doesn't handle things quite the same way as Xamarin did. Oops.

I fixed this by changing the statically bound methods that return bool to have `[return: MarshalAs (UnmanagedType.I1)]` and added code to the pinvoke generator which will attach that attribute to the pinvokes that return bool. In the process, I added a convenience factory method to `CSAttribute` which makes it easier to generate an attribute as a one-liner.