### PR TITLE
fix SDK name issue

### DIFF
--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -96,7 +96,7 @@ namespace tomwiftytest {
 		{
 			if (sdkPath == null)
 				sdkPath = ExecAndCollect.Run ("/usr/bin/xcrun", "--show-sdk-path --sdk macosx");
-			return sdkPath;
+			return sdkPath.Trim ();
 		}
 
 		static string BuildArgs (XCodeCompiler compiler, string compilerName, string outfile, string pathToCode, string extraOptions)


### PR DESCRIPTION
The sdkPath coming back from Xcode has a newline in it now for some reason.
Add in a Trim and it's sorted out.
Fixes 27 tests.