### PR TITLE
remove nullable warnings

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSUnaryExpression.cs
+++ b/Dynamo/Dynamo.CSLang/CSUnaryExpression.cs
@@ -12,8 +12,13 @@ namespace Dynamo.CSLang {
 		}
 		protected override void LLWrite (ICodeWriter writer, object o)
 		{
-			writer.Write (string.Format (Operation == CSUnaryOperator.Ref || Operation == CSUnaryOperator.Out ? "{0} " : "{0}", OperatorToString (Operation)), true);
-			Expr.WriteAll (writer);
+			if (IsPostfix (Operation)) {
+				Expr.WriteAll (writer);
+				writer.Write (string.Format (Operation == CSUnaryOperator.Ref || Operation == CSUnaryOperator.Out ? "{0} " : "{0}", OperatorToString (Operation)), true);
+			} else {
+				writer.Write (string.Format (Operation == CSUnaryOperator.Ref || Operation == CSUnaryOperator.Out ? "{0} " : "{0}", OperatorToString (Operation)), true);
+				Expr.WriteAll (writer);
+			}
 		}
 
 		public CSUnaryOperator Operation { get; private set; }
@@ -42,9 +47,18 @@ namespace Dynamo.CSLang {
 				return "*";
 			case CSUnaryOperator.Await:
 				return "await ";
+			case CSUnaryOperator.PostBang:
+				return "!";
+			case CSUnaryOperator.Question:
+				return "?";
 			default:
 				throw new ArgumentOutOfRangeException (nameof(op));
 			}
+		}
+
+		static bool IsPostfix (CSUnaryOperator op)
+		{
+			return op == CSUnaryOperator.PostBang || op == CSUnaryOperator.Question;
 		}
 
 		public static CSUnaryExpression AddressOf (ICSExpression expr)
@@ -80,6 +94,16 @@ namespace Dynamo.CSLang {
 		public static CSUnaryExpression Await (ICSExpression expr)
 		{
 			return new CSUnaryExpression (CSUnaryOperator.Await, expr);
+		}
+
+		public static CSUnaryExpression PostBang (ICSExpression expr)
+		{
+			return new CSUnaryExpression (CSUnaryOperator.PostBang, expr);
+		}
+
+		public static CSUnaryExpression Question (ICSExpression expr)
+		{
+			return new CSUnaryExpression (CSUnaryOperator.Question, expr);
 		}
 	}
 }

--- a/Dynamo/Dynamo.CSLang/CSUnaryExpression.cs
+++ b/Dynamo/Dynamo.CSLang/CSUnaryExpression.cs
@@ -14,9 +14,9 @@ namespace Dynamo.CSLang {
 		{
 			if (IsPostfix (Operation)) {
 				Expr.WriteAll (writer);
-				writer.Write (string.Format (Operation == CSUnaryOperator.Ref || Operation == CSUnaryOperator.Out ? "{0} " : "{0}", OperatorToString (Operation)), true);
+				writer.Write (OperatorToString (Operation), true);
 			} else {
-				writer.Write (string.Format (Operation == CSUnaryOperator.Ref || Operation == CSUnaryOperator.Out ? "{0} " : "{0}", OperatorToString (Operation)), true);
+				writer.Write (OperatorToString (Operation), true);
 				Expr.WriteAll (writer);
 			}
 		}
@@ -36,11 +36,11 @@ namespace Dynamo.CSLang {
 			case CSUnaryOperator.Not:
 				return "!";
 			case CSUnaryOperator.Out:
-				return "out";
+				return "out ";
 			case CSUnaryOperator.Pos:
 				return "+";
 			case CSUnaryOperator.Ref:
-				return "ref";
+				return "ref ";
 			case CSUnaryOperator.AddressOf:
 				return "&";
 			case CSUnaryOperator.Indirection:

--- a/Dynamo/Dynamo.CSLang/Enums.cs
+++ b/Dynamo/Dynamo.CSLang/Enums.cs
@@ -61,6 +61,8 @@ namespace Dynamo.CSLang {
 		AddressOf,
 		Indirection,
 		Await,
+		PostBang,
+		Question,
 	}
 
 	public enum CSAssignmentOperator {

--- a/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
+++ b/SwiftReflector/MarshalEngineCSafeSwiftToCSharp.cs
@@ -135,7 +135,7 @@ namespace SwiftReflector {
 
 				if (entityType == EntityType.DynamicSelf) {
 					var retrieveCallSite = isObjC ? $"Runtime.GetNSObject<{csProxyName}> " : $"SwiftObjectRegistry.Registry.CSObjectForSwiftObject<{csProxyName}> ";
-					callParams.Add (new CSCastExpression(csParm.CSType, new CSFunctionCall (retrieveCallSite, false, csParm.Name).Dot (NewClassCompiler.kInterfaceImpl)));
+					callParams.Add (new CSCastExpression(csParm.CSType, CSUnaryExpression.PostBang (new CSFunctionCall (retrieveCallSite, false, csParm.Name)).Dot (NewClassCompiler.kInterfaceImpl)));
 
 				} else if (entityType == EntityType.Class || (entity != null && entity.IsObjCProtocol)) {
 					var csParmType = csParm.CSType as CSSimpleType;
@@ -279,7 +279,7 @@ namespace SwiftReflector {
 			if (thisIsInterface && !hasAssociatedTypes) {
 				registryCall = $"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (*self)";
 			} else {
-				registryCall = isObjC ? $"Runtime.GetNSObject<{thisTypeName}> (self)" : $"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self)";
+				registryCall = isObjC ? $"Runtime.GetNSObject<{thisTypeName}> (self)!" : $"SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{thisTypeName}> (self)!";
 			}
 
 
@@ -469,8 +469,8 @@ namespace SwiftReflector {
 				csharpCall = new CSInject ($"SwiftObjectRegistry.Registry.InterfaceForExistentialContainer<{thisTypeName}> (*self).{prop.Name.Name}");
 			} else {
 				var call = isObjC ?
-					$"ObjCRuntime.Runtime.GetNSObject<{thisTypeName}> (self).{prop.Name.Name}" :
-					$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject<{thisTypeName}> (self).{prop.Name.Name}";
+					$"ObjCRuntime.Runtime.GetNSObject<{thisTypeName}> (self)!.{prop.Name.Name}" :
+					$"SwiftObjectRegistry.Registry.CSObjectForSwiftObject<{thisTypeName}> (self)!.{prop.Name.Name}";
 
 				csharpCall = new CSInject (call);
 			}

--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -4173,7 +4173,7 @@ namespace SwiftReflector {
 				return new CSFunctionCall ($"ObjCRuntime.Runtime.GetINativeObject<{expectedType.ToString ()}>", false, expr, CSConstant.Val (false));
 			} else {
 				var call = entity.Type.IsObjCOrInheritsObjC (typeMapper) ? "ObjCRuntime.Runtime.GetNSObject<{0}>" : "SwiftObjectRegistry.Registry.CSObjectForSwiftObject <{0}>";
-				return new CSFunctionCall (String.Format (call, expectedType.ToString ()), false, expr);
+				return CSUnaryExpression.PostBang (new CSFunctionCall (String.Format (call, expectedType.ToString ()), false, expr));
 			}
 		}
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -761,7 +761,7 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 			}
 #if !TOM_SWIFTY
 			if (IsNSObject (t)) {
-				var rv = ObjCRuntime.Runtime.GetNSObject (Marshal.ReadIntPtr (swiftSourceMemory));
+				var rv = ObjCRuntime.Runtime.GetNSObject (Marshal.ReadIntPtr (swiftSourceMemory))!;
 				if (owns)
 					rv.DangerousRelease ();
 				return rv;


### PR DESCRIPTION
Added postfix unary operators to dynamo.
Changed all cases of calling `GetNSObject` and `CSObjectForSwiftObject` to have `!` after the call.

Why not inject a null check and exception? Because if these calls return `null` you've got bigger problems on your hands and the runtime will throw and exception for you.