### PR TITLE
Remove RunWIthMono and other dead code.

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/ARCTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ARCTests.cs
@@ -60,7 +60,7 @@ namespace SwiftReflector {
 				Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename);
 
 				TestRunning.CopyTestReferencesTo (provider.DirectoryPath);
-				string output = Compiler.RunWithMono (exeOutFilename, provider.DirectoryPath);
+				string output = Compiler.RunWithDotnet (exeOutFilename, provider.DirectoryPath);
 				ClassicAssert.AreEqual ("nothing\n", output);
 			}
 		}
@@ -119,7 +119,7 @@ namespace SwiftReflector {
 
 				TestRunning.CopyTestReferencesTo (provider.DirectoryPath);
 
-				string output = Compiler.RunWithMono (exeOutFilename, provider.DirectoryPath);
+				string output = Compiler.RunWithDotnet (exeOutFilename, provider.DirectoryPath);
 				ClassicAssert.AreEqual ("nothing\n", output);
 			}
 		}

--- a/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
@@ -59,36 +59,6 @@ namespace SwiftReflector {
 			ClassicAssert.IsTrue (Directory.Exists (kSwiftRuntimeMacOutputDirectory));
 			ClassicAssert.IsTrue (File.Exists (Path.Combine (kSwiftRuntimeMacOutputDirectory, kSwiftRuntimeLibraryMac + ".dll")));
 		}
-
-
-		string CompileWithInvokingCode (CSFile cs, CSLine invoker, string nameSpace)
-		{
-			CSNamespace ns = new CSNamespace (nameSpace);
-			CSCodeBlock mainBody = CSCodeBlock.Create (invoker);
-			CSMethod main = new CSMethod (CSVisibility.Public, CSMethodKind.Static, CSSimpleType.Void,
-				new CSIdentifier ("Main"), new CSParameterList (new CSParameter (new CSSimpleType ("string", true), "args")),
-				mainBody);
-			CSClass cl = new CSClass (CSVisibility.Public, "NameNotImportant", new CSMethod [] { main });
-			ns.Block.Add (cl);
-
-			cs.Namespaces.Add (ns);
-
-			using (DisposableTempFile csOut = new DisposableTempFile (null, null, "cs", true)) {
-				CodeWriter.WriteToFile (csOut.Filename, cs);
-
-				using (Stream csExeStm = Compiler.CompileUsing (null, XCodeCompiler.CSharpExe, csOut.Filename,
-				                                                $"-lib:{kSwiftRuntimeMacOutputDirectory} -r:{kSwiftRuntimeLibraryMac}")) {
-					using (DisposableTempFile csExe = new DisposableTempFile (null, null, "exe", true)) {
-						csExeStm.CopyTo (csExe.Stream);
-						csExe.Stream.Close ();
-						string output = Compiler.RunWithMono (csExe.Filename);
-						return output;
-					}
-				}
-			}
-		}
-
-
 	}
 }
 

--- a/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/GenericFunctionTests.cs
@@ -705,7 +705,7 @@ namespace SwiftReflector {
 
 				Exception e = ClassicAssert.Throws<Exception> (() => {
 					TestRunning.CopyTestReferencesTo (provider.DirectoryPath);
-					string output = Compiler.RunWithMono (exeFilename, provider.DirectoryPath, platform: PlatformName.macOS);
+					string output = Compiler.RunWithDotnet (exeFilename, provider.DirectoryPath, platform: PlatformName.macOS);
 					ClassicAssert.AreEqual ("1\n", output);
 				});
 				ClassicAssert.True (e.Message.Contains ("NotSupportedException"));
@@ -1184,7 +1184,7 @@ namespace SwiftReflector {
 
 				Compiler.CSCompile (provider.DirectoryPath, Directory.GetFiles (provider.DirectoryPath, "*.cs"), exeOutFilename);
 				TestRunning.CopyTestReferencesTo (provider.DirectoryPath);
-				return Compiler.RunWithMono (exeOutFilename, provider.DirectoryPath);
+				return Compiler.RunWithDotnet (exeOutFilename, provider.DirectoryPath);
 			}
 		}
 

--- a/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
@@ -171,7 +171,7 @@ namespace dlopentest
 				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
-				string output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
+				string output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
 				ClassicAssert.AreEqual (expected, output);
 				var typeBasedClassName = typeName.Replace ('.', '_');
 
@@ -287,7 +287,7 @@ namespace dlopentest
 				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
-				var output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
+				var output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
 				ClassicAssert.AreEqual (expected, output);
 				var typeBasedClassName = typeName.Replace('.', '_');
 
@@ -376,7 +376,7 @@ namespace dlopentest
 				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}");
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
-				string output = Compiler.RunWithMono (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath);
+				string output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath);
 				ClassicAssert.AreEqual (expected, output);
 			}
 		}


### PR DESCRIPTION
Had 8 or so tests that were running directly with `RunWithMono` - these failed because they were compiled with `dotnet` and that created a type load exception because of the different versions of the code.

Also removed some other dead code.