### PR TITLE
Fix build/run settings

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
@@ -168,10 +168,10 @@ namespace dlopentest
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
 
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.None);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
-				string output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
+				string output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.None);
 				ClassicAssert.AreEqual (expected, output);
 				var typeBasedClassName = typeName.Replace ('.', '_');
 
@@ -284,10 +284,10 @@ namespace dlopentest
 }}";
 				source += TestRunning.GetManagedConsoleRedirectCode ();
 				File.WriteAllText (csFile, source);
-				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.macOS);
+				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}", PlatformName.None);
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
 
-				var output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.macOS);
+				var output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath, platform: PlatformName.None);
 				ClassicAssert.AreEqual (expected, output);
 				var typeBasedClassName = typeName.Replace('.', '_');
 


### PR DESCRIPTION
This code was generating macOS specific code and in the olden days, this would generate an exe, then do the steps to turn it into a macOS app, but we don't really need the macOS aspect and it works find with the platform set to "None"