### PR TITLE
fixed issues with closures that throw and have args

### DIFF
--- a/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
+++ b/SwiftRuntimeLibrary/SwiftClosureRepresentation.cs
@@ -80,7 +80,7 @@ namespace SwiftRuntimeLibrary {
 		[UnmanagedCallersOnly]
 		public static void FuncCallbackMaybeThrows (IntPtr retValPtr, IntPtr args, IntPtr refPtr)
 		{
-			FuncCallbackMaybeThrowsImpl (retValPtr, IntPtr.Zero, refPtr);
+			FuncCallbackMaybeThrowsImpl (retValPtr, args, refPtr);
 		}
 
 		static void FuncCallbackMaybeThrowsImpl (IntPtr retValPtr, IntPtr args, IntPtr refPtr)
@@ -114,8 +114,12 @@ namespace SwiftRuntimeLibrary {
 #endif
 			var argumentValues = args != IntPtr.Zero ? StructMarshal.Marshaler.MarshalSwiftTupleMemoryToNet (args, delInfo.Item2) : null;
 #if DEBUG
-			//foreach (var arg in argumentValues) {
-			//	Console.WriteLine ($"arg: {arg} type: {arg.GetType ().Name}");
+			//if (argumentValues is not null) {
+			//	foreach (var arg in argumentValues) {
+			//		Console.WriteLine ($"arg: {arg} type: {arg.GetType ().Name}");
+			//	}
+			//} else {
+			//	Console.WriteLine ("argumentValues is null");
 			//}
 #endif
 

--- a/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
+++ b/SwiftRuntimeLibrary/SwiftMarshal/StructMarshal.cs
@@ -1362,14 +1362,14 @@ namespace SwiftRuntimeLibrary.SwiftMarshal {
 		bool ExceptionReturnContainsSwiftError (IntPtr swiftMeduaTuple, SwiftTupleMap tMap)
 		{
 			//#if DEBUG
-			//			Console.WriteLine("Given pointer " + p.ToString("X8"));
+			//			Console.WriteLine("Given pointer " + swiftMeduaTuple.ToString("X8"));
 			//			Console.WriteLine($"And a tuple map with ${tMap.Offsets.Length} offsets");
 			//			foreach (int i in tMap.Offsets)
 			//			{
 			//				Console.Write($"{i}, ");
 			//			}
 			//			Console.WriteLine();
-			//			Memory.Dump(p, 40);
+			//			Memory.Dump(swiftMeduaTuple, 40);
 			//#endif
 			var boolPtr = swiftMeduaTuple + tMap.Offsets [tMap.Offsets.Length - 1];
 			//#if DEBUG


### PR DESCRIPTION
My own damn fault - forgot an args parameter when I was updating the closure callbacks.
Updated some of the debug output to correct errors.