### PR TITLE
removed a bunch of nullable warnings

### DIFF
--- a/Dynamo/Dynamo.CSLang/CSType.cs
+++ b/Dynamo/Dynamo.CSLang/CSType.cs
@@ -88,6 +88,7 @@ namespace Dynamo.CSLang {
 		public CSType [] GenericTypes { get; private set; }
 		public bool IsArray { get; private set; }
 		public bool IsPointer { get; private set; }
+		public bool IsNullable { get; private set; }
 
 		string GenerateName ()
 		{
@@ -156,14 +157,26 @@ namespace Dynamo.CSLang {
 
 		public CSSimpleType Star {
 			get {
-				if (Name.EndsWith ("[]")) {
-					throw new NotImplementedException ("Blindly making an array a pointer doesn't do what you think.");
-				} else {
-					var ptrType = new CSSimpleType (Name + " *", false);
-					ptrType.IsPointer = true;
-					return ptrType;
-				}
+				var ptrType = TypeWithSuffix (" *");
+				ptrType.IsPointer = true;
+				return ptrType;
 			}
+		}
+
+		public CSSimpleType Nullable {
+			get {
+				var nullableType = TypeWithSuffix ("?");
+				nullableType.IsNullable = true;
+				return nullableType;
+			}
+		}
+
+		CSSimpleType TypeWithSuffix (string suffix)
+		{
+			if (IsArray || Name.EndsWith ("[]")) {
+				throw new NotImplementedException ($"Blindly making an array a {suffix} doesn't do what you think.");
+			}
+			return new CSSimpleType (Name + suffix, false);
 		}
 
 		public static CSSimpleType Bool { get { return tBool; } }

--- a/SwiftRuntimeLibrary/BaseProxy.cs
+++ b/SwiftRuntimeLibrary/BaseProxy.cs
@@ -2,17 +2,20 @@
 // Licensed under the MIT License.
 
 using System;
+
+#nullable enable
+
 namespace SwiftRuntimeLibrary {
 	public class BaseProxy {
-		public BaseProxy (Type interfaceType, EveryProtocol everyProtocol)
+		public BaseProxy (Type interfaceType, EveryProtocol? everyProtocol)
 		{
 			InterfaceType = interfaceType;
 			EveryProtocol = everyProtocol;
 		}
 		// be aware that EveryProtocol can be null in the case of the protocol coming from Swift
-		public EveryProtocol EveryProtocol { get; private set; }
+		public EveryProtocol? EveryProtocol { get; private set; }
 		public Type InterfaceType { get; private set; }
 
-		public virtual ISwiftExistentialContainer ProxyExistentialContainer => null;
+		public virtual ISwiftExistentialContainer ProxyExistentialContainer => null!;
 	}
 }


### PR DESCRIPTION
There were several tests that generated warnings about null issues. This sorts them out.

As a bit of background, for every test that generates code (which is most of them), we scan the compiler output and check for warnings and we accept only a small number of warnings. The rest are considered failures. This keeps us honest in terms of the quality of code that we generate. 