### PR TITLE
handle non-standard test library

### DIFF
--- a/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/MetatypeTests.cs
@@ -375,7 +375,7 @@ namespace dlopentest
 
 				Compiler.CSCompile (temp.DirectoryPath, new string [] { csFile }, "TestIt.exe", $"-lib:{Compiler.SystemCompilerLocation.SwiftCompilerLib}");
 				TestRunning.CopyTestReferencesTo (temp.DirectoryPath);
-
+				SwiftRuntimeLibraryTests.SwiftArrayTests.CopyXamGlueFramework (temp.DirectoryPath);
 				string output = Compiler.RunWithDotnet (Path.Combine (temp.DirectoryPath, "TestIt.exe"), temp.DirectoryPath);
 				ClassicAssert.AreEqual (expected, output);
 			}

--- a/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftArrayTests.cs
+++ b/tests/tom-swifty-test/SwiftRuntimeLibraryTests/SwiftArrayTests.cs
@@ -28,9 +28,15 @@ namespace SwiftRuntimeLibraryTests {
 			CopyXamGlueFramework ();
 		}
 
-		static void CopyXamGlueFramework ()
+		public static void CopyXamGlueFramework ()
 		{
 			var localFramework = Path.Combine (Compiler.kTestRoot, "XamGlue.framework");
+			CopyXamGlueFramework (localFramework);
+		}
+
+		public static void CopyXamGlueFramework (string toDir)
+		{
+			var localFramework = Path.Combine (toDir, "XamGlue.framework");
 			if (!Directory.Exists (localFramework)) {
 				Directory.CreateDirectory (localFramework);
 			}


### PR DESCRIPTION
This was a non-standard test in terms of how it was run since it didn't generate any swift code - we're just testing a library.
Refactored the CopyXamGlueFramework code to make that easier.