### PR TITLE
fix rt unmanagedcallers

### DIFF
--- a/SwiftRuntimeLibrary/SwiftComparableProxy.cs
+++ b/SwiftRuntimeLibrary/SwiftComparableProxy.cs
@@ -23,9 +23,9 @@ namespace SwiftRuntimeLibrary {
 
 		struct Comparable_xam_vtable {
 			[MarshalAs (UnmanagedType.FunctionPtr)]
-			public unsafe delegate* unmanaged<IntPtr, IntPtr, bool> opEqualFunc;
+			public unsafe delegate* unmanaged<IntPtr, IntPtr, int> opEqualFunc;
 			[MarshalAs (UnmanagedType.FunctionPtr)]
-			public unsafe delegate* unmanaged<IntPtr, IntPtr, bool> opLessFunc;
+			public unsafe delegate* unmanaged<IntPtr, IntPtr, int> opLessFunc;
 		}
 
 		static Comparable_xam_vtable vtableIComparable;
@@ -34,24 +34,24 @@ namespace SwiftRuntimeLibrary {
 			XamSetVTable ();
 		}
 
-		[UnmanagedCallersOnly]		
-		static bool EqFunc (IntPtr oneptr, IntPtr twoptr)
+		[UnmanagedCallersOnly]
+		static int EqFunc (IntPtr oneptr, IntPtr twoptr)
 		{
 			if (oneptr == twoptr)
-				return true;
+				return 1;
 			var one = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftComparable> (oneptr);
 			var two = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftComparable> (twoptr);
-			return one.OpEquals (two);
+			return one.OpEquals (two) ? 1 : 0;
 		}
 
 		[UnmanagedCallersOnly]
-		static bool LessFunc (IntPtr oneptr, IntPtr twoptr)
+		static int LessFunc (IntPtr oneptr, IntPtr twoptr)
 		{
 			if (oneptr == twoptr)
-				return false;
+				return 0;
 			var one = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftComparable> (oneptr);
 			var two = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftComparable> (twoptr);
-			return one.OpLess (two);
+			return one.OpLess (two) ? 1 : 0;
 		}
 
 		static void XamSetVTable ()

--- a/SwiftRuntimeLibrary/SwiftEquatableProxy.cs
+++ b/SwiftRuntimeLibrary/SwiftEquatableProxy.cs
@@ -22,7 +22,7 @@ namespace SwiftRuntimeLibrary {
 
 		struct Equatable_xam_vtable {
 			public delegate bool Delfunc0 (IntPtr one, IntPtr two);
-			public unsafe delegate *unmanaged<IntPtr, IntPtr, byte> func0;
+			public unsafe delegate *unmanaged<IntPtr, IntPtr, int> func0;
 		}
 
 		static Equatable_xam_vtable vtableIEquatable;
@@ -32,7 +32,7 @@ namespace SwiftRuntimeLibrary {
 		}
 
 		[UnmanagedCallersOnly]
-		static byte EqFunc (IntPtr oneptr, IntPtr twoptr)
+		static int EqFunc (IntPtr oneptr, IntPtr twoptr)
 		{
 			if (oneptr == twoptr)
 				return 1;
@@ -40,7 +40,7 @@ namespace SwiftRuntimeLibrary {
 			var one = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftEquatable> (oneptr);
 			var two = SwiftObjectRegistry.Registry.ProxyForEveryProtocolHandle<ISwiftEquatable> (twoptr);
 
-			return one.OpEquals (two) ? (byte)1 : (byte)0;
+			return one.OpEquals (two) ? 1 : 0;
 		}
 
 		static void XamSetVTable ()


### PR DESCRIPTION
Tests were failing on this because the compiler doesn't catch this error.
Also changed this to int instead of byte to avoid the casting.