### PR TITLE
Add handle into vtables

### DIFF
--- a/SwiftReflector/NewClassCompiler.cs
+++ b/SwiftReflector/NewClassCompiler.cs
@@ -2053,9 +2053,20 @@ namespace SwiftReflector {
 					                                                                   virtFunctions, virtFunctions [i], vtableEntryIndex, vtableName, vtable, vtableAssignments, use, swiftLibraryPath);
 				}
 			}
+			AddVTHandleIfNeeded (use, vtable, vtableAssignments, vtableName);
 			ImplementVTableInitializer (proxyClass, picl, usedPinvokeNames, protocolDecl, vtableAssignments, wrapper, vtableType, vtableName, swiftLibraryPath);
 
 			return vtable.Fields.Count > 0;
+		}
+
+		void AddVTHandleIfNeeded (CSUsingPackages use, CSStruct vtable, List<CSLine> vtableAssignments, string vtName)
+		{
+			if (vtable.Fields.Count > 0) {
+				use.AddIfNotPresent (typeof (GCHandle));
+				var gcType = new CSSimpleType (typeof (GCHandle));
+				var decl = new CSFieldDeclaration (gcType, OverrideBuilder.kVtableHandleName, value: null, CSVisibility.Public);
+				vtable.Fields.Insert (0, new CSLine (decl));
+			}
 		}
 
 		void CollectAllProtocolMethods (List<FunctionDeclaration> functions, ProtocolDeclaration decl)
@@ -2114,6 +2125,7 @@ namespace SwiftReflector {
 			if (vtable.Fields.Count > 0) {
 				cl.InnerClasses.Add (vtable);
 			}
+			AddVTHandleIfNeeded (use, vtable, vtableAssignments, vtableName);
 			ImplementVTableInitializer (cl, picl, usedPinvokeNames, classDecl, vtableAssignments, wrapper, vtableType, vtableName, swiftLibraryPath);
 			return virtFuncs.Count;
 		}

--- a/SwiftReflector/OverrideBuilder.cs
+++ b/SwiftReflector/OverrideBuilder.cs
@@ -14,6 +14,7 @@ using ObjCRuntime;
 
 namespace SwiftReflector {
 	public class OverrideBuilder {
+		public const string kVtableHandleName = "csVTHandle";
 		TypeMapper typeMapper;
 		string vtableTypeName;
 		string vtableName = null;
@@ -1483,7 +1484,16 @@ namespace SwiftReflector {
 					}
 				}
 			}
+			if (cl.Fields.Count > 0) {
+				cl.Fields.Insert (0, VtableHandleDeclaration ());
+			}
 			return cl;
+		}
+
+		SLLine VtableHandleDeclaration ()
+		{
+			var fieldLine = SLDeclaration.VarLine (kVtableHandleName, new SLOptionalType (SLSimpleType.OpaquePointer), SLConstant.Nil, Visibility.Public);
+			return fieldLine;
 		}
 
 		SLLine ToFieldDeclaration (FunctionDeclaration func, int index, List<string> fieldIdentifiers)


### PR DESCRIPTION
Step 1 of sanitizing every usage of `[UnmanagedCallersOnly]` for generics is to add a handle to every vtable.

This does exactly that.