### PR TITLE
remove poor tests, obsolete definitions

### DIFF
--- a/tests/tom-swifty-test/Compiler.cs
+++ b/tests/tom-swifty-test/Compiler.cs
@@ -44,6 +44,8 @@ namespace tomwiftytest {
 
 		static string kSystemBin = "/usr/bin/";
 		public const string kSystemLib = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/macosx";
+		public static string kSwiftRuntimeOutputDirectory = Path.Combine (TestContext.CurrentContext.TestDirectory, $"../../../../../SwiftRuntimeLibrary/bin/Debug/net{Compiler.kframeWorkVersion}");
+		public const string kSwiftRuntimeLibrary = "SwiftRuntimeLibrary";
 
 		[ThreadStatic]
 		static SwiftCompilerLocation systemCompilerLocation;
@@ -329,22 +331,10 @@ namespace tomwiftytest {
 			}
 			sb.Append (' ');
 			switch (platform) {
-			case PlatformName.macOS:
-				sb.Append ($"-lib:{ConstructorTests.kSwiftRuntimeMacOutputDirectory} ");
-				sb.Append ($"-r:{ConstructorTests.kSwiftRuntimeLibraryMac}.dll ");
-				sb.Append ($"-lib:{ConstructorTests.kXamarinMacDir} ");
-				sb.Append ($"-r:Xamarin.Mac.dll ");
-				break;
-			case PlatformName.iOS:
-				sb.Append ($"-lib:{ConstructorTests.kSwiftRuntimeiOSOutputDirectory} ");
-				sb.Append ($"-r:{ConstructorTests.kSwiftRuntimeLibraryiOS}.dll ");
-				sb.Append ($"-lib:{ConstructorTests.kXamariniOSDir} ");
-				sb.Append ($"-r:Xamarin.iOS.dll ");
-				break;
 			case PlatformName.None:
 				var referenceAssemblyDir = GetReferenceAssemblyLocation ();
-				sb.Append ($"-lib:{ConstructorTests.kSwiftRuntimeOutputDirectory} ");
-				sb.Append ($"-r:{ConstructorTests.kSwiftRuntimeLibrary}.dll ");
+				sb.Append ($"-lib:{kSwiftRuntimeOutputDirectory} ");
+				sb.Append ($"-r:{kSwiftRuntimeLibrary}.dll ");
 				sb.Append ($"-r:{Path.Combine (referenceAssemblyDir, "System.dll")} ");
 				sb.Append ($"-r:{Path.Combine (referenceAssemblyDir, "System.Console.dll")} ");
 				sb.Append ($"-r:{Path.Combine (referenceAssemblyDir, "System.Runtime.dll")} ");
@@ -352,6 +342,9 @@ namespace tomwiftytest {
 				sb.Append ($"-r:{Path.Combine (referenceAssemblyDir, "mscorlib.dll")} ");
 				sb.Append ($"-r:{Path.Combine (referenceAssemblyDir, "System.Text.Encoding.Extensions.dll")} ");
 				break;
+			case PlatformName.macOS:
+			case PlatformName.iOS:
+				throw new NotImplementedException ($"This code path is obsolete for {platform} - how did you get here?");
 			default:
 				throw new NotImplementedException (platform.ToString ());
 			}
@@ -666,12 +659,8 @@ namespace tomwiftytest {
 			env.Add ("DYLD_LIBRARY_PATH", AddOrAppendPathTo (Environment.GetEnvironmentVariables (), "DYLD_LIBRARY_PATH", $"/usr/lib/swift:{kSwiftRuntimeGlueDirectory}"));
 			switch (platform) {
 			case PlatformName.macOS:
-				// This is really a hack, any tests needing to use XM, should create a proper .app using mmp instead.
-				env.Add ("MONO_PATH", AddOrAppendPathTo (Environment.GetEnvironmentVariables (), "MONO_PATH", $"{ConstructorTests.kSwiftRuntimeMacOutputDirectory}"));
-				env ["DYLD_LIBRARY_PATH"] = AddOrAppendPathTo (env, "DYLD_LIBRARY_PATH", "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib");
 				break;
 			case PlatformName.None:
-				env.Add ("MONO_PATH", AddOrAppendPathTo (Environment.GetEnvironmentVariables (), "MONO_PATH", $"{ConstructorTests.kSwiftRuntimeOutputDirectory}"));
 				env ["DYLD_LIBRARY_PATH"] = AddOrAppendPathTo (env, "DYLD_LIBRARY_PATH", ".");
 				if (workingDirectory != null)
 					env ["DYLD_LIBRARY_PATH"] = AddOrAppendPathTo (env, "DYLD_LIBRARY_PATH", workingDirectory);

--- a/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/ConstructorTests.cs
@@ -18,17 +18,6 @@ namespace SwiftReflector {
 	[Parallelizable (ParallelScope.All)]
 	[RunWithLeaks]
 	public class ConstructorTests {
-		public static string kSwiftRuntimeOutputDirectory = Path.Combine (TestContext.CurrentContext.TestDirectory, $"../../../../../SwiftRuntimeLibrary/bin/Debug/net{Compiler.kframeWorkVersion}");
-		public const string kSwiftRuntimeLibrary = "SwiftRuntimeLibrary";
-
-		public static string kSwiftRuntimeMacOutputDirectory = Path.Combine (TestContext.CurrentContext.TestDirectory, $"../../../../../SwiftRuntimeLibrary.Mac/bin/Debug/net{Compiler.kframeWorkVersion}");
-		public static string kSwiftRuntimeiOSOutputDirectory = Path.Combine (TestContext.CurrentContext.TestDirectory, $"../../../../../SwiftRuntimeLibrary.iOS/bin/Debug/net{Compiler.kframeWorkVersion}");
-		public const string kSwiftRuntimeLibraryMac = "SwiftRuntimeLibrary.Mac";
-		public const string kSwiftRuntimeLibraryiOS = "SwiftRuntimeLibrary.iOS";
-
-		public static string kXamarinMacDir = "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac";
-		public static string kXamariniOSDir = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS";
-
 		[Test]
 		public void SimpleConstructor ()
 		{
@@ -42,22 +31,6 @@ namespace SwiftReflector {
 				ClassicAssert.AreEqual ("noname.None", cl.Name.ToFullyQualifiedName ());
 				ClassicAssert.AreEqual (2, cl.Constructors.Values.Count ());
 			}
-		}
-
-
-		[Test]
-		public void SwiftRuntimeLibraryExists ()
-		{
-			ClassicAssert.IsTrue (Directory.Exists (kSwiftRuntimeOutputDirectory));
-			ClassicAssert.IsTrue (File.Exists (Path.Combine (kSwiftRuntimeOutputDirectory, kSwiftRuntimeLibrary + ".dll")));
-		}
-
-
-		[Test]
-		public void SwiftRuntimeLibraryMacExists ()
-		{
-			ClassicAssert.IsTrue (Directory.Exists (kSwiftRuntimeMacOutputDirectory));
-			ClassicAssert.IsTrue (File.Exists (Path.Combine (kSwiftRuntimeMacOutputDirectory, kSwiftRuntimeLibraryMac + ".dll")));
 		}
 	}
 }

--- a/tests/tom-swifty-test/TestRunning.cs
+++ b/tests/tom-swifty-test/TestRunning.cs
@@ -776,7 +776,7 @@ public static class Console {
 			
 		};
 		static string [] testnoneRuntimeAssemblies = {
-			Path.Combine (ConstructorTests.kSwiftRuntimeOutputDirectory, $"{ConstructorTests.kSwiftRuntimeLibrary}.dll"),
+			Path.Combine (Compiler.kSwiftRuntimeOutputDirectory, $"{Compiler.kSwiftRuntimeLibrary}.dll"),
 		};
 
 		public static void CopyTestReferencesTo (string targetDirectory, PlatformName platform = PlatformName.None)


### PR DESCRIPTION
Turns out that these tests are obsolete and the dependent definitions aren't needed.
Removed the tests, removed the definitions.
Moved some definitions out of ConstructorTests into Compiler.cs, where they belonged all along.