### PR TITLE
first swath of naming utility refactoring.

### DIFF
--- a/DylibBinder/SwiftTypeToString.cs
+++ b/DylibBinder/SwiftTypeToString.cs
@@ -19,7 +19,7 @@ namespace DylibBinder {
 
 		public static SLType MapSwiftTypeToSlType (SwiftType swiftType)
 		{
-			var typeMapper = new TypeMapper (TypeDatabasePaths, null);
+			var typeMapper = new TypeMapper (TypeDatabasePaths);
 			var swiftTypeToSLType = new SwiftTypeToSLType (typeMapper, true);
 			var sLImportModules = new SLImportModules ();
 			return swiftTypeToSLType.MapType (sLImportModules, Exceptions.ThrowOnNull (swiftType, nameof (swiftType)));

--- a/SwiftReflector/MethodWrapping.cs
+++ b/SwiftReflector/MethodWrapping.cs
@@ -15,6 +15,7 @@ using SwiftReflector.SwiftXmlReflection;
 using SwiftReflector.TypeMapping;
 using SwiftReflector.Demangling;
 using ObjCRuntime;
+using SwiftReflector.Naming;
 
 namespace SwiftReflector {
 
@@ -80,7 +81,7 @@ namespace SwiftReflector {
 				throw new ArgumentOutOfRangeException (nameof (type));
 			}
 				
-			operatorName = CleanseOperatorName (typeMapper, operatorName);
+			operatorName = CSSafeNaming.SafeOperatorName (operatorName);
 			var classPrefix = moduleNameOrFullClassName.Replace ('.', 'D');
 			return $"{kXamPrefix}{classPrefix}{operatorType}{operatorName}";
 		}
@@ -2441,44 +2442,6 @@ namespace SwiftReflector {
 			errors.Add (ErrorHelper.CreateWarning (code, $"While {doingSomething} {whoAmI} {postMessage}."));
 		}
 
-		static Dictionary<char, string> operatorMap = new Dictionary<char, string> {
-			{ '/', "Slash" },
-			{ '=', "Equals" },
-			{ '+', "Plus" },
-			{ '-', "Minus" },
-			{ '!', "Bang" },
-			{ '*', "Star" },
-			{ '%', "Percent" },
-			{ '<', "LessThan" },
-			{ '>', "GreaterThan" },
-			{ '&', "Ampersand" },
-			{ '|', "Pipe" },
-			{ '^', "Hat" },
-			{ '~', "Tilde" },
-			{ '?', "QuestionMark"},
-			{ '.', "Dot" },
-		};
-
-		static string OperatorCharToSafeString (char c)
-		{
-			string result = null;
-			operatorMap.TryGetValue (c, out result);
-			return result ?? c.ToString ();
-		}
-
-		public string CleanseOperatorName (string s)
-		{
-			return CleanseOperatorName (typeMapper, s);
-		}
-
-		public static string CleanseOperatorName (TypeMapper typeMapper, string s)
-		{
-			var sb = new StringBuilder ();
-			foreach (var c in s) {
-				sb.Append (OperatorCharToSafeString (c));
-			}
-			return typeMapper.SanitizeIdentifier (sb.ToString ());
-		}
 
 		static DelegatedCommaListElemCollection<SLArgument> StripArgumentLabels (DelegatedCommaListElemCollection<SLArgument> args)
 		{

--- a/SwiftReflector/Naming/CSSafeNaming.cs
+++ b/SwiftReflector/Naming/CSSafeNaming.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Dynamo.CSLang;
+using SwiftReflector.TypeMapping;
+
+#nullable enable
+
+namespace SwiftReflector.Naming
+{
+	public class CSSafeNaming {
+
+		static UnicodeCategory [] validStarts = {
+			UnicodeCategory.UppercaseLetter,
+			UnicodeCategory.LowercaseLetter,
+			UnicodeCategory.TitlecaseLetter,
+			UnicodeCategory.ModifierLetter,
+			UnicodeCategory.OtherLetter,
+			UnicodeCategory.LetterNumber
+		};
+
+		static bool ValidIdentifierStart (UnicodeCategory cat)
+		{
+			return validStarts.Contains (cat);
+		}
+
+		static UnicodeCategory [] validContent = {
+			UnicodeCategory.DecimalDigitNumber,
+			UnicodeCategory.ConnectorPunctuation,
+			UnicodeCategory.Format
+		};
+
+		static bool ValidIdentifierContent (UnicodeCategory cat)
+		{
+			return ValidIdentifierStart (cat) || validContent.Contains (cat);
+		}
+
+		static bool IsValidIdentifier (int position, UnicodeCategory cat)
+		{
+			if (position == 0)
+				return ValidIdentifierStart (cat);
+			else
+				return ValidIdentifierContent (cat);
+		}
+
+		static bool IsHighUnicode (string s)
+		{
+			// Steve says: this is arbitrary, but it solves an issue
+			// with mcs and csc not liking certain Ll and Lu class
+			// unicode characters (for now).
+			// Open issue: https://github.com/dotnet/roslyn/issues/27986
+			var encoding = Encoding.UTF32;
+			var bytes = encoding.GetBytes (s);
+			var utf32Value = BitConverter.ToUInt32 (bytes, 0);
+			return utf32Value > 0xffff;
+		}
+
+		public static string SafeIdentifier (string name, ScopedNaming? naming = null)
+		{
+			var sb = new StringBuilder ();
+
+			var characterEnum = StringInfo.GetTextElementEnumerator (name);
+			while (characterEnum.MoveNext ()) {
+				string c = characterEnum.GetTextElement ();
+				int i = characterEnum.ElementIndex;
+
+				var cat = CharUnicodeInfo.GetUnicodeCategory (name, i);
+
+				if (IsValidIdentifier (i, cat) && !IsHighUnicode (c))
+					sb.Append (i == 0 && cat == UnicodeCategory.LowercaseLetter ? c.ToUpper () : c);
+				else
+					sb.Append (UnicodeMapper.MapToUnicodeName (c));
+			}
+
+			if (CSKeywords.IsKeyword (sb.ToString ()))
+				sb.Append ('_');
+			return naming is not null ? naming.GenSym (sb.ToString ()) : sb.ToString ();
+		}
+
+		public static CSIdentifier SafeCSIdentifier (string name, ScopedNaming? naming)
+		{
+			return new CSIdentifier (SafeIdentifier (name, naming));
+		}
+
+		static Dictionary<char, string> operatorMap = new Dictionary<char, string> {
+			{ '/', "Slash" },
+			{ '=', "Equals" },
+			{ '+', "Plus" },
+			{ '-', "Minus" },
+			{ '!', "Bang" },
+			{ '*', "Star" },
+			{ '%', "Percent" },
+			{ '<', "LessThan" },
+			{ '>', "GreaterThan" },
+			{ '&', "Ampersand" },
+			{ '|', "Pipe" },
+			{ '^', "Hat" },
+			{ '~', "Tilde" },
+			{ '?', "QuestionMark"},
+			{ '.', "Dot" },
+		};
+
+		static string OperatorCharToSafeString (char c)
+		{
+			return operatorMap.TryGetValue (c, out var result) ? result : c.ToString ();
+		}
+
+		public static string SafeOperatorName (string s)
+		{
+			var sb = new StringBuilder ();
+			foreach (var c in s) {
+				sb.Append (OperatorCharToSafeString (c));
+			}
+			return SafeIdentifier (sb.ToString ());
+		}
+
+		public static UnicodeMapper UnicodeMapper = UnicodeMapper.Default;
+	}
+}
+

--- a/SwiftReflector/Naming/ScopedNaming.cs
+++ b/SwiftReflector/Naming/ScopedNaming.cs
@@ -11,9 +11,9 @@ namespace SwiftReflector.Naming
 		string autoSymPrefix;
 		Stack<HashSet<string>> names = new Stack<HashSet<string>> ();
 
-		public ScopedNaming (string? autoSymPrefix = null)
+		public ScopedNaming (string autoSymPrefix = "_symbol")
 		{
-			this.autoSymPrefix = string.IsNullOrEmpty (autoSymPrefix) ? "_symbol" : autoSymPrefix;
+			this.autoSymPrefix = autoSymPrefix;
 			names.Push (new HashSet<string> ());
 		}
 

--- a/SwiftReflector/Naming/ScopedNaming.cs
+++ b/SwiftReflector/Naming/ScopedNaming.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Dynamo.CSLang;
+
+#nullable enable
+
+namespace SwiftReflector.Naming
+{
+	public class ScopedNaming
+	{
+		string autoSymPrefix;
+		Stack<HashSet<string>> names = new Stack<HashSet<string>> ();
+
+		public ScopedNaming (string? autoSymPrefix = null)
+		{
+			this.autoSymPrefix = string.IsNullOrEmpty (autoSymPrefix) ? "_symbol" : autoSymPrefix;
+			names.Push (new HashSet<string> ());
+		}
+
+		public void EnterScope ()
+		{
+			names.Push (new HashSet<string> (names.Peek ()));
+		}
+
+		public void ExitScope ()
+		{
+			if (names.Count == 0)
+				throw new Exception ("exited top level scope - that's bad");
+		}
+
+		HashSet<string> Top => names.Peek ();
+
+		bool Contains (string symbol)
+		{
+			return Top.Contains (symbol);
+		}
+
+		public string GenSym (string prefix)
+		{
+			if (string.IsNullOrEmpty (prefix))
+				throw new ArgumentException ("prefix must not be empty", nameof (prefix));
+			lock (names) {
+				if (Contains (prefix)) {
+					var index = 1;
+					while (true) {
+						var candidate = $"{prefix}{index}";
+						if (!Contains (candidate)) {
+							prefix = candidate;
+							break;
+						}
+						index++;
+					}
+				}
+				Top.Add (prefix);
+				return prefix;
+			}
+		}
+
+		public CSIdentifier GenID (string prefix)
+		{
+			return new CSIdentifier (GenSym (prefix));
+		}
+
+		
+		public string GenSym ()
+		{
+			return GenSym (autoSymPrefix);
+		}
+	}
+}
+

--- a/SwiftReflector/SwiftReflector.csproj
+++ b/SwiftReflector/SwiftReflector.csproj
@@ -28,6 +28,12 @@
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Naming\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Naming\" />
+  </ItemGroup>
   <Target Name="BeforeBuild" Inputs="$(MSBuildProjectFullPath)" Outputs="Downloaded\StringUtils.cs">
     <Exec Command="mkdir -p Downloaded" />
     <Exec Command="curl -L https://raw.githubusercontent.com/xamarin/xamarin-macios/ec62a8dd515d1dab8ee88832e33f8cd8e3a8a40d/tools/common/StringUtils.cs &gt; Downloaded/StringUtils.cs" />

--- a/SwiftReflector/TopLevelFunctionCompiler.cs
+++ b/SwiftReflector/TopLevelFunctionCompiler.cs
@@ -14,6 +14,7 @@ using SwiftReflector.Demangling;
 using ObjCRuntime;
 using SwiftRuntimeLibrary.SwiftMarshal;
 using System.Runtime.InteropServices;
+using SwiftReflector.Naming;
 
 namespace SwiftReflector {
 	public class TopLevelFunctionCompiler {
@@ -28,7 +29,7 @@ namespace SwiftReflector {
 		public CSProperty CompileProperty (string propertyName, CSUsingPackages packs, SwiftType swiftPropertyType, bool hasGetter, bool hasSetter,
 						 CSMethodKind methodKind)
 		{
-			propertyName = typeMap.SanitizeIdentifier (propertyName);
+			propertyName = CSSafeNaming.SafeIdentifier (propertyName);
 			NetTypeBundle propertyType = typeMap.MapType (swiftPropertyType, false);
 
 			if (!(swiftPropertyType is SwiftGenericArgReferenceType))
@@ -62,7 +63,7 @@ namespace SwiftReflector {
 			} else {
 				propertyType = typeMap.MapType (getter, swiftPropertyType, false, true);
 			}
-			propertyName = propertyName ?? typeMap.SanitizeIdentifier (getter != null ? getter.PropertyName : setter.PropertyName);
+			propertyName = propertyName ?? CSSafeNaming.SafeIdentifier (getter != null ? getter.PropertyName : setter.PropertyName);
 			bool isSubscript = getter != null ? getter.IsSubscript :
 				setter.IsSubscript;
 
@@ -148,7 +149,7 @@ namespace SwiftReflector {
 			var args = typeMap.MapParameterList (func, func.ParameterLists.Last (), objectsAreIntPtrs, true, null, null, packs);
 			RemapSwiftClosureRepresensation (args);
 			var returnType = returnIsGeneric || returnIsSelf ? null : typeMap.MapType (func, func.ReturnTypeSpec, objectsAreIntPtrs, true);
-			delegateName = delegateName ?? typeMap.SanitizeIdentifier (func.Name);
+			delegateName = delegateName ?? CSSafeNaming.SafeIdentifier (func.Name);
 			var isUnsafe = false;
 
 			args.ForEach (a => AddUsingBlock (packs, a.Type));
@@ -248,7 +249,7 @@ namespace SwiftReflector {
 				returnType = typeMap.MapType (func, func.ReturnTypeSpec, isPinvoke, true);
 			}
 
-			string funcName = functionName ?? typeMap.SanitizeIdentifier (func.Name);
+			string funcName = functionName ?? CSSafeNaming.SafeIdentifier (func.Name);
 
 			if (isPinvoke && !mangledToCSharp.ContainsKey (mangledName))
 				mangledToCSharp.Add (mangledName, funcName);

--- a/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/NewClassCompilerTests.cs
@@ -1115,7 +1115,7 @@ public enum Position {
 				// Now read out the type database XML and verify
 				{
 					List<string> typeDatabasePaths = new List<string> { Path.Combine (libProvider.DirectoryPath, "bindings") };
-					TypeMapper typeMapper = new TypeMapper (typeDatabasePaths, UnicodeMapper.Default);
+					TypeMapper typeMapper = new TypeMapper (typeDatabasePaths);
 					var entity = typeMapper.TypeDatabase.EntityForSwiftName (swiftName);
 					ClassicAssert.AreEqual (ns, entity.SharpNamespace);
 					ClassicAssert.AreEqual (csharpName, entity.SharpTypeName);

--- a/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
+++ b/tests/tom-swifty-test/SwiftReflector/OverrideTests.cs
@@ -46,7 +46,7 @@ namespace SwiftReflector {
 			ClassicAssert.AreEqual (1, classes.Count);
 			ClassDeclaration theClass = classes [0].MakeUnrooted () as ClassDeclaration;
 
-			TypeMapper typeMapper = new TypeMapper (Compiler.kTypeDatabases, UnicodeMapper.Default);
+			TypeMapper typeMapper = new TypeMapper (Compiler.kTypeDatabases);
 			typeMapper.RegisterClass (theClass);
 
 			OverrideBuilder overrider = new OverrideBuilder (typeMapper, theClass, null, new ModuleDeclaration ("OverrideModule"));


### PR DESCRIPTION
Naming of various things in BTfS is spread all over the place. I'm trying to centralize it so it's easier to refactor.

This is step 1 of n - and in this case I've created a new class for creating unique names which also includes the ability to abide by scoping. This code is not used...yet. The general approach for this is to use a stack of hash sets. When you enter a new scope the top-most hashset is used to populate the new scope. Here's the thinking on that: The contents of the hash sets will be relatively small: on the order of 10 items (ie, no fewer than 1 and no more than 100, but typically 6-8). Scopes will typically be exited and entered on function boundaries and I don't anticipate having to create new ones for control structures as these tend to nest very linearly. Checking for existing symbols should be cheaper than it was before and since that is the most common operation, I felt this was better than walking the stack of scopes, but PRs are welcome if you disagree.

The general philosophy here is to use static methods when things are stateless and classes when things require state.

I've also moved `SanitizeIdentifier` and related code from `TypeMapper` and `CleanseOperatorName` from `MethodWrapping` and put them into `CSSafeNaming`.

